### PR TITLE
PromiEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepare": "yarn run snyk-protect"
   },
   "dependencies": {
+    "eventemitter3": "^4.0.4",
     "react-native-webview": "^8.1.2",
     "snyk": "^1.319.1",
     "whatwg-url": "^8.0.0"
@@ -63,7 +64,6 @@
     "sinon": "7.1.1",
     "ts-loader": "~6.2.1",
     "ts-node": "~8.5.2",
-    "typed-emitter": "^1.0.0",
     "typescript": "~3.8.3",
     "webpack": "~4.41.2",
     "webpack-chain": "~6.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "sinon": "7.1.1",
     "ts-loader": "~6.2.1",
     "ts-node": "~8.5.2",
+    "typed-emitter": "^1.0.0",
     "typescript": "~3.8.3",
     "webpack": "~4.41.2",
     "webpack-chain": "~6.2.0",

--- a/src/core/payload-transport.ts
+++ b/src/core/payload-transport.ts
@@ -40,7 +40,7 @@ function standardizeResponse(
   requestPayload: JsonRpcRequestPayload | JsonRpcRequestPayload[],
   event: MagicMessageEvent,
 ): StandardizedResponse {
-  const { id } = event.data.response;
+  const id = event.data.response?.id ?? undefined;
   const requestPayloadResolved = getRequestPayloadFromBatch(requestPayload, id);
 
   if (id && requestPayloadResolved) {

--- a/src/core/payload-transport.ts
+++ b/src/core/payload-transport.ts
@@ -25,7 +25,7 @@ interface StandardizedResponse {
  */
 function getRequestPayloadFromBatch(
   requestPayload: JsonRpcRequestPayload | JsonRpcRequestPayload[],
-  id?: string | number,
+  id?: string | number | null,
 ): JsonRpcRequestPayload | undefined {
   return id && Array.isArray(requestPayload)
     ? requestPayload.find(p => p.id === id)
@@ -40,7 +40,7 @@ function standardizeResponse(
   requestPayload: JsonRpcRequestPayload | JsonRpcRequestPayload[],
   event: MagicMessageEvent,
 ): StandardizedResponse {
-  const id = event.data.response?.id ?? undefined;
+  const { id } = event.data.response;
   const requestPayloadResolved = getRequestPayloadFromBatch(requestPayload, id);
 
   if (id && requestPayloadResolved) {

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -2,6 +2,12 @@ import { BaseModule } from '../base-module';
 import { MagicPayloadMethod, LoginWithMagicLinkConfiguration } from '../../types';
 import { createJsonRpcRequestPayload } from '../../core/json-rpc';
 
+type LoginWithMagicLinkEvents = {
+  'email-sent': () => void;
+  'email-not-deliverable': () => void;
+  retry: () => void;
+};
+
 export class AuthModule extends BaseModule {
   /**
    * Initiate the "magic link" login flow for a user. If the flow is successful,
@@ -11,6 +17,6 @@ export class AuthModule extends BaseModule {
   public loginWithMagicLink(configuration: LoginWithMagicLinkConfiguration) {
     const { email, showUI = true } = configuration;
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithMagicLink, [{ email, showUI }]);
-    return this.request<string | null>(requestPayload);
+    return this.request<string | null, LoginWithMagicLinkEvents>(requestPayload);
   }
 }

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -8,7 +8,7 @@ export class AuthModule extends BaseModule {
    * this method will return a Decentralized ID token (with a default lifespan
    * of 15 minutes).
    */
-  public async loginWithMagicLink(configuration: LoginWithMagicLinkConfiguration) {
+  public loginWithMagicLink(configuration: LoginWithMagicLinkConfiguration) {
     const { email, showUI = true } = configuration;
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithMagicLink, [{ email, showUI }]);
     return this.request<string | null>(requestPayload);

--- a/src/modules/base-module.ts
+++ b/src/modules/base-module.ts
@@ -5,12 +5,10 @@ import { ViewController } from '../types/core/view-types';
 import { SDKBase } from '../core/sdk';
 import { standardizeJsonRpcRequestPayload } from '../core/json-rpc';
 import { createPromiEvent } from '../util/promise-tools';
-import { TypedEmitter, EventsDefinition } from '../util/events';
+import { EventsDefinition } from '../util/events';
 
-export class BaseModule<ModuleEvents extends EventsDefinition = void> extends TypedEmitter<ModuleEvents> {
-  constructor(protected readonly sdk: SDKBase) {
-    super();
-  }
+export class BaseModule {
+  constructor(protected readonly sdk: SDKBase) {}
 
   protected get transport(): PayloadTransport {
     return (this.sdk as any).transport;

--- a/src/modules/base-module.ts
+++ b/src/modules/base-module.ts
@@ -4,10 +4,13 @@ import { PayloadTransport } from '../core/payload-transport';
 import { ViewController } from '../types/core/view-types';
 import { SDKBase } from '../core/sdk';
 import { standardizeJsonRpcRequestPayload } from '../core/json-rpc';
-import { createPromiEvent, EventsDefinition } from '../util/promise-tools';
+import { createPromiEvent } from '../util/promise-tools';
+import { TypedEmitter, EventsDefinition } from '../util/events';
 
-export class BaseModule {
-  constructor(protected readonly sdk: SDKBase) {}
+export class BaseModule<ModuleEvents extends EventsDefinition = void> extends TypedEmitter<ModuleEvents> {
+  constructor(protected readonly sdk: SDKBase) {
+    super();
+  }
 
   protected get transport(): PayloadTransport {
     return (this.sdk as any).transport;
@@ -17,7 +20,7 @@ export class BaseModule {
     return (this.sdk as any).overlay;
   }
 
-  protected request<ResultType = any, Events extends EventsDefinition = {}>(payload: JsonRpcRequestPayload) {
+  protected request<ResultType = any, Events extends EventsDefinition = void>(payload: Partial<JsonRpcRequestPayload>) {
     const responsePromise = this.transport.post<ResultType>(
       this.overlay,
       MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST,

--- a/src/modules/base-module.ts
+++ b/src/modules/base-module.ts
@@ -4,6 +4,7 @@ import { PayloadTransport } from '../core/payload-transport';
 import { ViewController } from '../types/core/view-types';
 import { SDKBase } from '../core/sdk';
 import { standardizeJsonRpcRequestPayload } from '../core/json-rpc';
+import { createPromiEvent, EventsDefinition } from '../util/promise-tools';
 
 export class BaseModule {
   constructor(protected readonly sdk: SDKBase) {}
@@ -16,15 +17,19 @@ export class BaseModule {
     return (this.sdk as any).overlay;
   }
 
-  protected async request<ResultType = any>(payload: JsonRpcRequestPayload) {
-    const response = await this.transport.post<ResultType>(
+  protected request<ResultType = any, Events extends EventsDefinition = {}>(payload: JsonRpcRequestPayload) {
+    const responsePromise = this.transport.post<ResultType>(
       this.overlay,
       MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST,
       standardizeJsonRpcRequestPayload(payload),
     );
 
-    if (response.hasError) throw new MagicRPCError(response.payload.error);
-    else if (response.hasResult) return response.payload.result as ResultType;
-    else throw createMalformedResponseError();
+    return createPromiEvent<ResultType, Events>((resolve, reject) => {
+      responsePromise.then(res => {
+        if (res.hasError) reject(new MagicRPCError(res.payload.error));
+        else if (res.hasResult) resolve(res.payload.result as ResultType);
+        else throw createMalformedResponseError();
+      });
+    });
   }
 }

--- a/src/modules/rpc-provider/index.ts
+++ b/src/modules/rpc-provider/index.ts
@@ -14,7 +14,7 @@ import {
   createSynchronousWeb3MethodWarning,
 } from '../../core/sdk-exceptions';
 import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload, JsonRpcResponse } from '../../core/json-rpc';
-import { PromiEvent, EventsDefinition } from '../../util/promise-tools';
+import { PromiEvent } from '../../util/promise-tools';
 
 /** */
 export class RPCProviderModule extends BaseModule {
@@ -71,14 +71,14 @@ export class RPCProviderModule extends BaseModule {
   }
 
   /* eslint-disable prettier/prettier */
-  public send<ResultType = any, Events extends EventsDefinition = {}>(method: string, params?: any[]): PromiEvent<ResultType, Events>;
-  public send(payload: JsonRpcRequestPayload | JsonRpcRequestPayload[], onRequestComplete: JsonRpcRequestCallback): void;
-  public send<ResultType>(payload: JsonRpcRequestPayload, none: void): JsonRpcResponsePayload<ResultType>;
-  /* eslint-enable prettier/prettier */
-  public send<ResultType = any, Events extends EventsDefinition = {}>(
+   public send<ResultType = any>(method: string, params?: any[]): PromiEvent<ResultType>;
+   public send(payload: JsonRpcRequestPayload | JsonRpcRequestPayload[], onRequestComplete: JsonRpcRequestCallback): void;
+   public send<ResultType>(payload: JsonRpcRequestPayload, none: void): JsonRpcResponsePayload<ResultType>;
+   /* eslint-enable prettier/prettier */
+  public send<ResultType = any>(
     payloadOrMethod: string | JsonRpcRequestPayload | JsonRpcRequestPayload[],
     onRequestCompleteOrParams: JsonRpcRequestCallback | any[] | void,
-  ): PromiEvent<ResultType, Events> | JsonRpcResponsePayload<ResultType> | void {
+  ): PromiEvent<ResultType> | JsonRpcResponsePayload<ResultType> | void {
     // Case #1
     // Web3 >= 1.0.0-beta.38 calls `send` with method and parameters.
     if (typeof payloadOrMethod === 'string') {
@@ -87,7 +87,7 @@ export class RPCProviderModule extends BaseModule {
         Array.isArray(onRequestCompleteOrParams) ? onRequestCompleteOrParams : [],
       );
 
-      return this.request(payload);
+      return this.request(payload) as any;
     }
 
     // Case #2

--- a/src/modules/rpc-provider/index.ts
+++ b/src/modules/rpc-provider/index.ts
@@ -14,6 +14,7 @@ import {
   createSynchronousWeb3MethodWarning,
 } from '../../core/sdk-exceptions';
 import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload, JsonRpcResponse } from '../../core/json-rpc';
+import { PromiEvent, EventsDefinition } from '../../util/promise-tools';
 
 /** */
 export class RPCProviderModule extends BaseModule {
@@ -70,14 +71,14 @@ export class RPCProviderModule extends BaseModule {
   }
 
   /* eslint-disable prettier/prettier */
-  public send<ResultType>(method: string, params?: any[]): Promise<ResultType>;
+  public send<ResultType = any, Events extends EventsDefinition = {}>(method: string, params?: any[]): PromiEvent<ResultType, Events>;
   public send(payload: JsonRpcRequestPayload | JsonRpcRequestPayload[], onRequestComplete: JsonRpcRequestCallback): void;
   public send<ResultType>(payload: JsonRpcRequestPayload, none: void): JsonRpcResponsePayload<ResultType>;
   /* eslint-enable prettier/prettier */
-  public send<ResultType = any>(
+  public send<ResultType = any, Events extends EventsDefinition = {}>(
     payloadOrMethod: string | JsonRpcRequestPayload | JsonRpcRequestPayload[],
     onRequestCompleteOrParams: JsonRpcRequestCallback | any[] | void,
-  ): Promise<ResultType> | JsonRpcResponsePayload<ResultType> | void {
+  ): PromiEvent<ResultType, Events> | JsonRpcResponsePayload<ResultType> | void {
     // Case #1
     // Web3 >= 1.0.0-beta.38 calls `send` with method and parameters.
     if (typeof payloadOrMethod === 'string') {

--- a/src/modules/rpc-provider/index.ts
+++ b/src/modules/rpc-provider/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable consistent-return */
+/* eslint-disable consistent-return, prefer-spread */
 
 import { BaseModule } from '../base-module';
 import {
@@ -15,9 +15,12 @@ import {
 } from '../../core/sdk-exceptions';
 import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload, JsonRpcResponse } from '../../core/json-rpc';
 import { PromiEvent } from '../../util/promise-tools';
+import { TypedEmitter, createTypedEmitter } from '../../util/events';
+
+const { createBoundEmitterMethod, createChainingEmitterMethod } = createTypedEmitter();
 
 /** */
-export class RPCProviderModule extends BaseModule {
+export class RPCProviderModule extends BaseModule implements TypedEmitter {
   // Implements EIP 1193:
   // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md
 
@@ -111,4 +114,17 @@ export class RPCProviderModule extends BaseModule {
     const requestPayload = createJsonRpcRequestPayload('eth_accounts');
     return this.request<string[]>(requestPayload);
   }
+
+  public on = createChainingEmitterMethod('on', this);
+  public once = createChainingEmitterMethod('once', this);
+  public addListener = createChainingEmitterMethod('addListener', this);
+
+  public off = createChainingEmitterMethod('off', this);
+  public removeListener = createChainingEmitterMethod('removeListener', this);
+  public removeAllListeners = createChainingEmitterMethod('removeAllListeners', this);
+
+  public emit = createBoundEmitterMethod('emit');
+  public eventNames = createBoundEmitterMethod('eventNames');
+  public listeners = createBoundEmitterMethod('listeners');
+  public listenerCount = createBoundEmitterMethod('listenerCount');
 }

--- a/src/modules/user/index.ts
+++ b/src/modules/user/index.ts
@@ -8,6 +8,14 @@ import {
 } from '../../types';
 import { createJsonRpcRequestPayload } from '../../core/json-rpc';
 
+type UpdateEmailEvents = {
+  'email-sent': () => void;
+  'email-not-deliverable': () => void;
+  'old-email-confirmed': () => void;
+  'new-email-confirmed': () => void;
+  retry: () => void;
+};
+
 export class UserModule extends BaseModule {
   /** */
   public getIdToken(configuration?: GetIdTokenConfiguration) {
@@ -31,7 +39,7 @@ export class UserModule extends BaseModule {
   public updateEmail(configuration: UpdateEmailConfiguration) {
     const { email, showUI = true } = configuration;
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.UpdateEmail, [{ email, showUI }]);
-    return this.request<string | null>(requestPayload);
+    return this.request<string | null, UpdateEmailEvents>(requestPayload);
   }
 
   /** */

--- a/src/modules/user/index.ts
+++ b/src/modules/user/index.ts
@@ -28,7 +28,7 @@ export class UserModule extends BaseModule {
   }
 
   /** */
-  public async updateEmail(configuration: UpdateEmailConfiguration) {
+  public updateEmail(configuration: UpdateEmailConfiguration) {
     const { email, showUI = true } = configuration;
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.UpdateEmail, [{ email, showUI }]);
     return this.request<string | null>(requestPayload);

--- a/src/types/core/message-types.ts
+++ b/src/types/core/message-types.ts
@@ -5,6 +5,7 @@ export enum MagicIncomingWindowMessage {
   MAGIC_OVERLAY_READY = 'MAGIC_OVERLAY_READY',
   MAGIC_SHOW_OVERLAY = 'MAGIC_SHOW_OVERLAY',
   MAGIC_HIDE_OVERLAY = 'MAGIC_HIDE_OVERLAY',
+  MAGIC_HANDLE_EVENT = 'MAGIC_HANDLE_EVENT',
 }
 
 export enum MagicOutgoingWindowMessage {

--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -9,3 +9,37 @@ export type EventsDefinition = { [K in string | symbol]: (...args: any[]) => voi
 export class TypedEmitter<Events extends EventsDefinition = void> extends EventEmitter<
   Events extends void ? string | symbol : Events
 > {}
+
+type ChainingMethods = 'on' | 'once' | 'addListener' | 'off' | 'removeListener' | 'removeAllListeners';
+type NonChainingMethods = 'emit' | 'eventNames' | 'listeners' | 'listenerCount';
+
+type ReplaceReturnType<T extends (...a: any) => any, TNewReturn> = (...a: Parameters<T>) => TNewReturn;
+
+/**
+ *
+ */
+export function createTypedEmitter<Events extends EventsDefinition = void>() {
+  const emitter = new TypedEmitter<Events>();
+
+  const createChainingEmitterMethod = <T1 extends ChainingMethods, T2>(
+    method: T1,
+    source: T2,
+  ): ReplaceReturnType<TypedEmitter[T1], T2> => {
+    return (...args: any[]) => {
+      (emitter as any)[method].apply(emitter, args);
+      return source;
+    };
+  };
+
+  const createBoundEmitterMethod = <T extends NonChainingMethods>(method: T): TypedEmitter[T] => {
+    return (...args: any[]) => {
+      return (emitter as any)[method].apply(emitter, args);
+    };
+  };
+
+  return {
+    emitter,
+    createChainingEmitterMethod,
+    createBoundEmitterMethod,
+  };
+}

--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -1,0 +1,11 @@
+import EventEmitter from 'eventemitter3';
+
+export type EventsDefinition = { [K in string | symbol]: (...args: any[]) => void } | void;
+
+/**
+ * An extension of `EventEmitter` (provided by `eventemitter3`) with an adjusted
+ * type interface that supports the unique structure of Magic SDK modules.
+ */
+export class TypedEmitter<Events extends EventsDefinition = void> extends EventEmitter<
+  Events extends void ? string | symbol : Events
+> {}

--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -16,7 +16,8 @@ type NonChainingMethods = 'emit' | 'eventNames' | 'listeners' | 'listenerCount';
 type ReplaceReturnType<T extends (...a: any) => any, TNewReturn> = (...a: Parameters<T>) => TNewReturn;
 
 /**
- *
+ * Creates a `TypedEmitter` instance and returns helper functions for easily
+ * mixing `TypedEmitter` methods into other objects.
  */
 export function createTypedEmitter<Events extends EventsDefinition = void>() {
   const emitter = new TypedEmitter<Events>();

--- a/src/util/promise-tools.ts
+++ b/src/util/promise-tools.ts
@@ -1,23 +1,78 @@
-import { EventEmitter } from 'events';
-import TypedEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import { MagicSDKError, MagicRPCError } from '../core/sdk-exceptions';
 
 export type EventsDefinition<EventName extends string = string> = {
   [P in EventName]: (...args: any[]) => void;
 };
 
-export type PromiEvent<TResult, TEvents extends EventsDefinition> = Promise<TResult> & TypedEmitter<TEvents>;
+type Arguments<T> = [T] extends [(...args: infer U) => any] ? U : [T] extends [void] ? [] : [T];
 
+/**
+ * Adapted from `typed-emitter`, made to work with `eventemitter3`.
+ *
+ * @see https://github.com/andywer/typed-emitter
+ */
+interface TypedEmitter<Events extends EventsDefinition> {
+  addListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+  on<E extends keyof Events>(event: E, listener: Events[E]): this;
+  once<E extends keyof Events>(event: E, listener: Events[E]): this;
+
+  off<E extends keyof Events>(event: E, listener: Events[E]): this;
+  removeAllListeners<E extends keyof Events>(event?: E): this;
+  removeListener<E extends keyof Events>(event: E, listener: Events[E]): this;
+
+  emit<E extends keyof Events>(event: E, ...args: Arguments<Events[E]>): boolean;
+  eventNames(): (keyof Events | string | symbol)[];
+  listeners<E extends keyof Events>(event: E): Function[];
+  listenerCount<E extends keyof Events>(event: E): number;
+}
+
+/**
+ * An exact replication of the `Promise` interface with an updated return type
+ * for each chaining method.
+ */
+interface EventedPromiseChain<T, TEvents extends EventsDefinition> extends Promise<T> {
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
+  ): PromiEvent<TResult1 | TResult2, TEvents>;
+
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null,
+  ): PromiEvent<T | TResult, TEvents>;
+
+  finally(onfinally?: (() => void) | undefined | null): PromiEvent<T, TEvents>;
+}
+
+/**
+ * A `Promise` and `EventEmitter` all in one!
+ */
+export type PromiEvent<TResult, TEvents extends EventsDefinition> = EventedPromiseChain<TResult, TEvents> &
+  TypedEmitter<TEvents>;
+
+/**
+ * Default events attached to every `PromiEvent`.
+ */
 type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (err: MagicSDKError | MagicRPCError) => void;
   settled: () => void;
 };
 
+/**
+ * A `Promise` executor with the option of being asynchronous.
+ */
 type AsyncPromiseExecutor<TResult> = (
   resolve: (value?: TResult | PromiseLike<TResult>) => void,
   reject: (reason?: any) => void,
 ) => void | Promise<void>;
+
+/**
+ * Clone a `Promise` object by calling `promise.then()`
+ */
+function clonePromise<T extends Promise<any>>(promise: T): T {
+  return promise.then() as T;
+}
 
 /**
  * Create a native JavaScript `Promise` overloaded with strongly-typed methods
@@ -28,21 +83,57 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = {}>
 ): PromiEvent<TResult, TEvents & DefaultEvents<TResult>> {
   const promise = createAutoCatchingPromise(executor);
   const eventEmitter = new EventEmitter() as TypedEmitter<TEvents & DefaultEvents<TResult>>;
-  const promiEvent = Object.assign(promise, eventEmitter);
 
-  promiEvent.then(result => {
-    promiEvent.emit('done', result);
-    if (!promiEvent.finally) promiEvent.emit('settled');
+  const promiEvent = () => {
+    return Object.assign(clonePromise(promise), {
+      then: createChainingPromiseMethod('then'),
+      catch: createChainingPromiseMethod('catch'),
+      finally: createChainingPromiseMethod('finally'),
+
+      addListener: createChainingEmitterMethod('addListener'),
+      on: createChainingEmitterMethod('on'),
+      once: createChainingEmitterMethod('once'),
+
+      off: createChainingEmitterMethod('off'),
+      removeAllListeners: createChainingEmitterMethod('removeAllListeners'),
+      removeListener: createChainingEmitterMethod('removeListener'),
+
+      emit: createBoundEmitterMethod('emit'),
+      eventNames: createBoundEmitterMethod('eventNames'),
+      listeners: createBoundEmitterMethod('listeners'),
+      listenerCount: createBoundEmitterMethod('listenerCount'),
+    });
+  };
+
+  const createChainingPromiseMethod = (method: keyof typeof promise) => (...args: any[]) => {
+    (promise as any)[method].apply(promise, args);
+    return promiEvent();
+  };
+
+  const createChainingEmitterMethod = (method: keyof typeof eventEmitter) => (...args: any[]) => {
+    (eventEmitter as any)[method].apply(eventEmitter, args);
+    return promiEvent();
+  };
+
+  const createBoundEmitterMethod = (method: keyof typeof eventEmitter) => (...args: any[]) => {
+    return (eventEmitter as any)[method].apply(eventEmitter, args);
+  };
+
+  const result = promiEvent();
+
+  result.then(resolved => {
+    result.emit('done', resolved);
+    if (!promise.finally) result.emit('settled');
   });
 
-  promiEvent.catch(err => {
-    promiEvent.emit('error', err);
-    if (!promiEvent.finally) promiEvent.emit('settled');
+  result.catch(err => {
+    result.emit('error', err);
+    if (!promise.finally) result.emit('settled');
   });
 
-  if (promiEvent.finally) promiEvent.finally(() => promiEvent.emit('settled'));
+  if ((promise as any).finally) result.finally(() => result.emit('settled'));
 
-  return promiEvent;
+  return result as any;
 }
 
 /**

--- a/src/util/promise-tools.ts
+++ b/src/util/promise-tools.ts
@@ -41,6 +41,15 @@ type AsyncPromiseExecutor<TResult> = (
   reject: (reason?: any) => void,
 ) => void | Promise<void>;
 
+const promiEventBrand = Symbol('isPromiEvent');
+
+/**
+ * Returns `true` if the given `value` is a `PromiEvent`.
+ */
+export function isPromiEvent(value: any): value is PromiEvent<any> {
+  return !!value[promiEventBrand];
+}
+
 /**
  * Create a native JavaScript `Promise` overloaded with strongly-typed methods
  * from `EventEmitter`.
@@ -77,6 +86,8 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = voi
    */
   const promiEvent = (source: any) => {
     return Object.assign(source, {
+      [promiEventBrand]: true,
+
       [thenSymbol]: source[thenSymbol] || source.then,
       [catchSymbol]: source[catchSymbol] || source.catch,
       [finallySymbol]: source[finallySymbol] || source.finally,

--- a/src/util/promise-tools.ts
+++ b/src/util/promise-tools.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'events';
+import TypedEmitter from 'typed-emitter';
+import { MagicSDKError, MagicRPCError } from '../core/sdk-exceptions';
+
+export type EventsDefinition<EventName extends string = string> = {
+  [P in EventName]: (...args: any[]) => void;
+};
+
+export type PromiEvent<TResult, TEvents extends EventsDefinition> = Promise<TResult> & TypedEmitter<TEvents>;
+
+type DefaultEvents<TResult> = {
+  done: (result: TResult) => void;
+  error: (err: MagicSDKError | MagicRPCError) => void;
+  settled: () => void;
+};
+
+type AsyncPromiseExecutor<TResult> = (
+  resolve: (value?: TResult | PromiseLike<TResult>) => void,
+  reject: (reason?: any) => void,
+) => void | Promise<void>;
+
+/**
+ * Create a native JavaScript `Promise` overloaded with strongly-typed methods
+ * from `EventEmitter`.
+ */
+export function createPromiEvent<TResult, TEvents extends EventsDefinition = {}>(
+  executor: AsyncPromiseExecutor<TResult>,
+): PromiEvent<TResult, TEvents & DefaultEvents<TResult>> {
+  const promise = createAutoCatchingPromise(executor);
+  const eventEmitter = new EventEmitter() as TypedEmitter<TEvents & DefaultEvents<TResult>>;
+  const promiEvent = Object.assign(promise, eventEmitter);
+
+  promiEvent.then(result => {
+    promiEvent.emit('done', result);
+    if (!promiEvent.finally) promiEvent.emit('settled');
+  });
+
+  promiEvent.catch(err => {
+    promiEvent.emit('error', err);
+    if (!promiEvent.finally) promiEvent.emit('settled');
+  });
+
+  if (promiEvent.finally) promiEvent.finally(() => promiEvent.emit('settled'));
+
+  return promiEvent;
+}
+
+/**
+ * Creates a `Promise` with an **async executor** that automatically catches
+ * errors occurring within the executor. Nesting promises in this way is usually
+ * deemed an _anti-pattern_, but it's useful and clean when promisifying the
+ * event-based code that's inherent to JSON RPC.
+ *
+ * So, here we solve the issue of nested promises by ensuring that no errors
+ * mistakenly go unhandled!
+ */
+export function createAutoCatchingPromise<TResult>(executor: AsyncPromiseExecutor<TResult>) {
+  return new Promise<TResult>((resolve, reject) => {
+    const result = executor(resolve, reject);
+    Promise.resolve(result).catch(reject);
+  });
+}

--- a/src/util/promise-tools.ts
+++ b/src/util/promise-tools.ts
@@ -99,13 +99,13 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = voi
       catch: createChainingPromiseMethod(catchSymbol, source),
       finally: createChainingPromiseMethod(finallySymbol, source),
 
-      addListener: createChainingEmitterMethod('addListener', source),
       on: createChainingEmitterMethod('on', source),
       once: createChainingEmitterMethod('once', source),
+      addListener: createChainingEmitterMethod('addListener', source),
 
       off: createChainingEmitterMethod('off', source),
-      removeAllListeners: createChainingEmitterMethod('removeAllListeners', source),
       removeListener: createChainingEmitterMethod('removeListener', source),
+      removeAllListeners: createChainingEmitterMethod('removeAllListeners', source),
 
       emit: createBoundEmitterMethod('emit'),
       eventNames: createBoundEmitterMethod('eventNames'),

--- a/src/util/promise-tools.ts
+++ b/src/util/promise-tools.ts
@@ -1,54 +1,15 @@
-import EventEmitter from 'eventemitter3';
+import { TypedEmitter, EventsDefinition } from './events';
 import { MagicSDKError, MagicRPCError } from '../core/sdk-exceptions';
-
-export type EventsDefinition<EventName extends string = string> = {
-  [P in EventName]: (...args: any[]) => void;
-};
-
-type Arguments<T> = [T] extends [(...args: infer U) => any] ? U : [T] extends [void] ? [] : [T];
-
-/**
- * Adapted from `typed-emitter`, made to work with `eventemitter3`.
- *
- * @see https://github.com/andywer/typed-emitter
- */
-interface TypedEmitter<Events extends EventsDefinition> {
-  addListener<E extends keyof Events>(event: E, listener: Events[E]): this;
-  on<E extends keyof Events>(event: E, listener: Events[E]): this;
-  once<E extends keyof Events>(event: E, listener: Events[E]): this;
-
-  off<E extends keyof Events>(event: E, listener: Events[E]): this;
-  removeAllListeners<E extends keyof Events>(event?: E): this;
-  removeListener<E extends keyof Events>(event: E, listener: Events[E]): this;
-
-  emit<E extends keyof Events>(event: E, ...args: Arguments<Events[E]>): boolean;
-  eventNames(): (keyof Events | string | symbol)[];
-  listeners<E extends keyof Events>(event: E): Function[];
-  listenerCount<E extends keyof Events>(event: E): number;
-}
-
-/**
- * An exact replication of the `Promise` interface with an updated return type
- * for each chaining method.
- */
-interface EventedPromiseChain<T, TEvents extends EventsDefinition> extends Promise<T> {
-  then<TResult1 = T, TResult2 = never>(
-    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
-    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
-  ): PromiEvent<TResult1 | TResult2, TEvents>;
-
-  catch<TResult = never>(
-    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null,
-  ): PromiEvent<T | TResult, TEvents>;
-
-  finally(onfinally?: (() => void) | undefined | null): PromiEvent<T, TEvents>;
-}
 
 /**
  * A `Promise` and `EventEmitter` all in one!
  */
-export type PromiEvent<TResult, TEvents extends EventsDefinition> = EventedPromiseChain<TResult, TEvents> &
-  TypedEmitter<TEvents>;
+export type PromiEvent<TResult, TEvents extends EventsDefinition = void> = Promise<TResult> &
+  {
+    [P in keyof TypedEmitter]: TypedEmitter<
+      TEvents extends void ? DefaultEvents<TResult> : TEvents & DefaultEvents<TResult>
+    >[P];
+  };
 
 /**
  * Default events attached to every `PromiEvent`.
@@ -60,7 +21,7 @@ type DefaultEvents<TResult> = {
 };
 
 /**
- * A `Promise` executor with the option of being asynchronous.
+ * A `Promise` executor with can be optionally asynchronous.
  */
 type AsyncPromiseExecutor<TResult> = (
   resolve: (value?: TResult | PromiseLike<TResult>) => void,
@@ -68,72 +29,55 @@ type AsyncPromiseExecutor<TResult> = (
 ) => void | Promise<void>;
 
 /**
- * Clone a `Promise` object by calling `promise.then()`
- */
-function clonePromise<T extends Promise<any>>(promise: T): T {
-  return promise.then() as T;
-}
-
-/**
  * Create a native JavaScript `Promise` overloaded with strongly-typed methods
  * from `EventEmitter`.
  */
-export function createPromiEvent<TResult, TEvents extends EventsDefinition = {}>(
+export function createPromiEvent<TResult, TEvents extends EventsDefinition = void>(
   executor: AsyncPromiseExecutor<TResult>,
-): PromiEvent<TResult, TEvents & DefaultEvents<TResult>> {
+): PromiEvent<TResult, TEvents extends void ? DefaultEvents<TResult> : TEvents & DefaultEvents<TResult>> {
   const promise = createAutoCatchingPromise(executor);
-  const eventEmitter = new EventEmitter() as TypedEmitter<TEvents & DefaultEvents<TResult>>;
-
-  const promiEvent = () => {
-    return Object.assign(clonePromise(promise), {
-      then: createChainingPromiseMethod('then'),
-      catch: createChainingPromiseMethod('catch'),
-      finally: createChainingPromiseMethod('finally'),
-
-      addListener: createChainingEmitterMethod('addListener'),
-      on: createChainingEmitterMethod('on'),
-      once: createChainingEmitterMethod('once'),
-
-      off: createChainingEmitterMethod('off'),
-      removeAllListeners: createChainingEmitterMethod('removeAllListeners'),
-      removeListener: createChainingEmitterMethod('removeListener'),
-
-      emit: createBoundEmitterMethod('emit'),
-      eventNames: createBoundEmitterMethod('eventNames'),
-      listeners: createBoundEmitterMethod('listeners'),
-      listenerCount: createBoundEmitterMethod('listenerCount'),
-    });
-  };
-
-  const createChainingPromiseMethod = (method: keyof typeof promise) => (...args: any[]) => {
-    (promise as any)[method].apply(promise, args);
-    return promiEvent();
-  };
-
-  const createChainingEmitterMethod = (method: keyof typeof eventEmitter) => (...args: any[]) => {
-    (eventEmitter as any)[method].apply(eventEmitter, args);
-    return promiEvent();
-  };
+  const eventEmitter = new TypedEmitter<TEvents & DefaultEvents<TResult>>();
+  let isUsingPromise = true;
 
   const createBoundEmitterMethod = (method: keyof typeof eventEmitter) => (...args: any[]) => {
     return (eventEmitter as any)[method].apply(eventEmitter, args);
   };
 
-  const result = promiEvent();
+  const createChainingEmitterMethod = (method: keyof typeof eventEmitter) => (...args: any[]) => {
+    isUsingPromise = false;
+    return createBoundEmitterMethod(method)(...args);
+  };
 
-  result.then(resolved => {
-    result.emit('done', resolved);
-    if (!promise.finally) result.emit('settled');
+  const source = promise.then(
+    resolved => {
+      promiEvent.emit('done', resolved);
+      promiEvent.emit('settled');
+      return resolved;
+    },
+
+    err => {
+      promiEvent.emit('error', err);
+      promiEvent.emit('settled');
+      if (isUsingPromise) throw err;
+    },
+  );
+
+  const promiEvent = Object.assign(source, {
+    addListener: createChainingEmitterMethod('addListener'),
+    on: createChainingEmitterMethod('on'),
+    once: createChainingEmitterMethod('once'),
+
+    off: createChainingEmitterMethod('off'),
+    removeAllListeners: createChainingEmitterMethod('removeAllListeners'),
+    removeListener: createChainingEmitterMethod('removeListener'),
+
+    emit: createBoundEmitterMethod('emit'),
+    eventNames: createBoundEmitterMethod('eventNames'),
+    listeners: createBoundEmitterMethod('listeners'),
+    listenerCount: createBoundEmitterMethod('listenerCount'),
   });
 
-  result.catch(err => {
-    result.emit('error', err);
-    if (!promise.finally) result.emit('settled');
-  });
-
-  if ((promise as any).finally) result.finally(() => result.emit('settled'));
-
-  return result as any;
+  return promiEvent as any;
 }
 
 /**

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -8,4 +8,5 @@ export const MSG_TYPES = (encodedQueryParams = ENCODED_QUERY_PARAMS) => ({
   MAGIC_SHOW_OVERLAY: `MAGIC_SHOW_OVERLAY-${encodedQueryParams}`,
   MAGIC_HIDE_OVERLAY: `MAGIC_HIDE_OVERLAY-${encodedQueryParams}`,
   MAGIC_HANDLE_REQUEST: `MAGIC_HANDLE_REQUEST-${encodedQueryParams}`,
+  MAGIC_HANDLE_EVENT: `MAGIC_HANDLE_EVENT-${encodedQueryParams}`,
 });

--- a/test/spec/modules/base-module/request.spec.ts
+++ b/test/spec/modules/base-module/request.spec.ts
@@ -6,10 +6,12 @@ import { BaseModule } from '../../../../src/modules/base-module';
 import { createPayloadTransport, createMagicSDK } from '../../../factories';
 import { JsonRpcRequestPayload } from '../../../../src/types';
 import { MagicRPCError, MagicSDKError } from '../../../../src/core/sdk-exceptions';
+import { isPromiEvent } from '../../../../src/util/promise-tools';
+import { MSG_TYPES } from '../../../constants';
 
 function createBaseModule() {
   const sdk = createMagicSDK();
-  const payloadTransport = createPayloadTransport();
+  const payloadTransport = createPayloadTransport('');
   const postStub = sinon.stub();
   (payloadTransport as any).post = postStub;
   Object.defineProperty(sdk, 'transport', {
@@ -39,7 +41,7 @@ test.serial('Resolves with a successful response', async t => {
 
   const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
 
-  postStub.returns(response);
+  postStub.returns(Promise.resolve(response));
 
   const result = await baseModule.request(requestPayload);
 
@@ -51,7 +53,7 @@ test.serial('Rejects with a `MagicRPCError` upon request failed', async t => {
 
   const response = new JsonRpcResponse(requestPayload).applyError({ code: -32603, message: 'hello world' });
 
-  postStub.returns(response);
+  postStub.returns(Promise.resolve(response));
 
   const err: MagicRPCError = await t.throwsAsync(baseModule.request(requestPayload));
   t.true(err instanceof MagicRPCError);
@@ -64,10 +66,145 @@ test.serial('Rejects with `MALFORMED_RESPONSE` error if response cannot be parse
 
   const response = new JsonRpcResponse(requestPayload);
 
-  postStub.returns(response);
+  postStub.returns(Promise.resolve(response));
 
   const err: MagicSDKError = await t.throwsAsync(baseModule.request(requestPayload));
   t.true(err instanceof MagicSDKError);
   t.is(err.code, 'MALFORMED_RESPONSE');
   t.is(err.message, 'Magic SDK Error: [MALFORMED_RESPONSE] Response from the Magic iframe is malformed.');
+});
+
+test.serial('Return value is a `PromiEvent`', async t => {
+  const { baseModule, postStub } = createBaseModule();
+
+  const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
+
+  postStub.returns(Promise.resolve(response));
+
+  const result = baseModule.request(requestPayload);
+
+  t.true(isPromiEvent(result));
+});
+
+test.serial.cb('Emits events received from the `PayloadTransport`', t => {
+  const { baseModule, postStub } = createBaseModule();
+
+  const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
+
+  postStub.returns(
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve(response);
+      }, 1000);
+    }),
+  );
+
+  baseModule.request(requestPayload).on('hello', result => {
+    t.is(result, 'world');
+    t.end();
+  });
+
+  window.postMessage(
+    {
+      msgType: MSG_TYPES().MAGIC_HANDLE_EVENT,
+      response: { id: requestPayload.id, result: { event: 'hello', params: ['world'] } },
+    },
+    '*',
+  );
+});
+
+test.serial('Receive no further events after the response from `PayloadTransport` resolves', async t => {
+  t.plan(1);
+
+  const { baseModule, postStub } = createBaseModule();
+
+  const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
+
+  postStub.returns(
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve(response);
+      }, 1000);
+    }),
+  );
+
+  const request = baseModule
+    .request(requestPayload)
+    .on('hello', result => {
+      t.is(result, 'world');
+    })
+    .on('hello2', () => {
+      t.fail();
+    });
+
+  window.postMessage(
+    {
+      msgType: MSG_TYPES().MAGIC_HANDLE_EVENT,
+      response: { id: requestPayload.id, result: { event: 'hello', params: ['world'] } },
+    },
+    '*',
+  );
+
+  await request;
+
+  window.postMessage(
+    {
+      msgType: MSG_TYPES().MAGIC_HANDLE_EVENT,
+      response: { id: requestPayload.id, result: { event: 'hello2' } },
+    },
+    '*',
+  );
+});
+
+test.serial.cb('Falls back to empty array if `params` is missing from event', t => {
+  const { baseModule, postStub } = createBaseModule();
+
+  const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
+
+  postStub.returns(
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve(response);
+      }, 1000);
+    }),
+  );
+
+  baseModule.request(requestPayload).on('hello', (...args) => {
+    t.deepEqual(args, []);
+    t.end();
+  });
+
+  window.postMessage(
+    {
+      msgType: MSG_TYPES().MAGIC_HANDLE_EVENT,
+      response: { id: requestPayload.id, result: { event: 'hello' } },
+    },
+    '*',
+  );
+});
+
+test.serial.cb('Ignores events with malformed response', t => {
+  const { baseModule, postStub } = createBaseModule();
+
+  const response = new JsonRpcResponse(requestPayload).applyResult('hello world');
+
+  postStub.returns(
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve(response);
+      }, 1000);
+    }),
+  );
+
+  baseModule.request(requestPayload).on('hello', () => {
+    t.fail();
+  });
+
+  window.postMessage(
+    {
+      msgType: MSG_TYPES().MAGIC_HANDLE_EVENT,
+      response: { id: requestPayload.id, result: undefined },
+    },
+    '*',
+  );
 });

--- a/test/spec/modules/base-module/request.spec.ts
+++ b/test/spec/modules/base-module/request.spec.ts
@@ -196,9 +196,14 @@ test.serial.cb('Ignores events with malformed response', t => {
     }),
   );
 
-  baseModule.request(requestPayload).on('hello', () => {
-    t.fail();
-  });
+  baseModule
+    .request(requestPayload)
+    .on('hello', () => {
+      t.fail();
+    })
+    .then(() => {
+      t.end();
+    });
 
   window.postMessage(
     {

--- a/test/spec/util/events/createTypedEmitter.spec.ts
+++ b/test/spec/util/events/createTypedEmitter.spec.ts
@@ -1,0 +1,47 @@
+import browserEnv from '@ikscodes/browser-env';
+import sinon from 'sinon';
+import test from 'ava';
+import { TypedEmitter, createTypedEmitter } from '../../../../src/util/events';
+
+test.beforeEach(t => {
+  browserEnv.restore();
+});
+
+test('Returns an object containing a `TypedEmitter` instance & two helper functions', t => {
+  const { emitter, createBoundEmitterMethod, createChainingEmitterMethod } = createTypedEmitter();
+
+  t.true(emitter instanceof TypedEmitter);
+  t.is(typeof createBoundEmitterMethod, 'function');
+  t.is(typeof createChainingEmitterMethod, 'function');
+});
+
+test('`createBoundEmitterMethod` helper creates a function that calls the underlying `TypedEmitter` method', t => {
+  const { emitter, createBoundEmitterMethod } = createTypedEmitter();
+
+  const emitStub = sinon.stub().returns('foobar');
+  emitter.emit = emitStub;
+
+  const testObj = {
+    foo: createBoundEmitterMethod('emit'),
+  };
+
+  const result = testObj.foo('hello world');
+
+  t.true(emitStub.calledWith('hello world'));
+  t.is(result, 'foobar' as any);
+});
+
+test('`createChainingEmitterMethod` helper creates a function that calls the underlying `TypedEmitter` method', t => {
+  const { emitter, createChainingEmitterMethod } = createTypedEmitter();
+
+  const onStub = sinon.stub().returns('foobar');
+  emitter.on = onStub;
+
+  const testObj: any = {};
+  testObj.foo = createChainingEmitterMethod('on', testObj);
+
+  const result = testObj.foo('hello world');
+
+  t.true(onStub.calledWith('hello world'));
+  t.is(result, testObj);
+});

--- a/test/spec/util/events/typed-emitter/constructor.spec.ts
+++ b/test/spec/util/events/typed-emitter/constructor.spec.ts
@@ -1,0 +1,15 @@
+import browserEnv from '@ikscodes/browser-env';
+import test from 'ava';
+import EventEmitter from 'eventemitter3';
+import { TypedEmitter } from '../../../../../src/util/events';
+
+test.beforeEach(t => {
+  browserEnv.restore();
+});
+
+test('Initialize `TypedEmitter`', t => {
+  const emitter = new TypedEmitter();
+
+  t.true(emitter instanceof TypedEmitter);
+  t.true(emitter instanceof EventEmitter);
+});

--- a/test/spec/util/promise-tools/createAutoCatchingPromise.spec.ts
+++ b/test/spec/util/promise-tools/createAutoCatchingPromise.spec.ts
@@ -1,0 +1,43 @@
+import browserEnv from '@ikscodes/browser-env';
+import test from 'ava';
+import { createAutoCatchingPromise } from '../../../../src/util/promise-tools';
+
+test.beforeEach(t => {
+  browserEnv.restore();
+});
+
+test('Creates a native `Promise`', t => {
+  const p = createAutoCatchingPromise(resolve => resolve());
+
+  t.true(p instanceof Promise);
+});
+
+test.cb('Resolves the `Promise`', t => {
+  createAutoCatchingPromise(resolve => resolve()).then(() => {
+    t.end();
+  });
+});
+
+test.cb('Rejects the `Promise`', t => {
+  createAutoCatchingPromise((resolve, reject) => reject()).catch(() => {
+    t.end();
+  });
+});
+
+test.cb('Rejects the `Promise` if an async executor is given and throws', t => {
+  createAutoCatchingPromise(async () => {
+    throw new Error('Oops');
+  }).catch(err => {
+    t.is(err.message, 'Oops');
+    t.end();
+  });
+});
+
+test.cb('Rejects the `Promise` if a sync executor is given and throws', t => {
+  createAutoCatchingPromise(() => {
+    throw new Error('Oops');
+  }).catch(err => {
+    t.is(err.message, 'Oops');
+    t.end();
+  });
+});

--- a/test/spec/util/promise-tools/createPromiEvent.spec.ts
+++ b/test/spec/util/promise-tools/createPromiEvent.spec.ts
@@ -1,0 +1,95 @@
+import browserEnv from '@ikscodes/browser-env';
+import sinon from 'sinon';
+import test from 'ava';
+import { createPromiEvent } from '../../../../src/util/promise-tools';
+import { TypedEmitter } from '../../../../src/util/events';
+
+const chainingEmitterMethods = ['on', 'once', 'addListener', 'off', 'removeListener', 'removeAllListeners'];
+const nonChainingEmitterMethods = ['emit', 'eventNames', 'listeners', 'listenerCount'];
+const typedEmitterMethods = [...chainingEmitterMethods, ...nonChainingEmitterMethods];
+const promiseMethods = ['then', 'catch', 'finally'];
+
+test.beforeEach(t => {
+  browserEnv.restore();
+});
+
+test('Creates a native `Promise`', t => {
+  const p = createPromiEvent(resolve => resolve());
+
+  t.true(p instanceof Promise);
+});
+
+test('Attaches `TypedEmitter` methods to the initial value', t => {
+  const p = createPromiEvent(resolve => resolve());
+
+  typedEmitterMethods.forEach(method => {
+    t.true(typeof p[method] === 'function');
+  });
+});
+
+test('Attaches `TypedEmitter` methods to `Promise.then` result', t => {
+  const p = createPromiEvent(resolve => resolve()).then();
+
+  typedEmitterMethods.forEach(method => {
+    t.true(typeof p[method] === 'function');
+  });
+});
+
+test('Attaches `TypedEmitter` methods to `Promise.catch` result', t => {
+  const p = createPromiEvent(resolve => resolve()).catch();
+
+  typedEmitterMethods.forEach(method => {
+    t.true(typeof p[method] === 'function');
+  });
+});
+
+test('Attaches `TypedEmitter` methods to `Promise.finally` result', t => {
+  const p = createPromiEvent(resolve => resolve()).catch();
+
+  typedEmitterMethods.forEach(method => {
+    t.true(typeof p[method] === 'function');
+  });
+});
+
+test('Attaches `Promise` methods to `TypedEmitter` results', t => {
+  chainingEmitterMethods.forEach(emitterMethod => {
+    const emitterStub = sinon.stub(TypedEmitter.prototype, emitterMethod as any);
+    const p = createPromiEvent(resolve => resolve())[emitterMethod]();
+
+    promiseMethods.forEach(promiseMethod => {
+      t.true(typeof p[promiseMethod] === 'function');
+    });
+
+    emitterStub.restore();
+  });
+});
+
+test.cb('Emits "done" event upon Promise resolution', t => {
+  createPromiEvent(resolve => resolve('hello')).on('done', result => {
+    t.is(result, 'hello');
+    t.end();
+  });
+});
+
+test.cb('Emits "settled" event upon Promise resolution', t => {
+  createPromiEvent(resolve => resolve()).on('settled', () => {
+    t.end();
+  });
+});
+
+test.cb('Emits "error" event upon Promise reject', t => {
+  createPromiEvent((resolve, reject) => reject('goodbye'))
+    .on('error', err => {
+      t.is(err, 'goodbye' as any);
+      t.end();
+    })
+    .catch(() => {});
+});
+
+test.cb('Emits "settled" event upon Promise reject', t => {
+  createPromiEvent((resolve, reject) => reject())
+    .on('settled', () => {
+      t.end();
+    })
+    .catch(() => {});
+});

--- a/test/spec/util/promise-tools/isPromiEvent.spec.ts
+++ b/test/spec/util/promise-tools/isPromiEvent.spec.ts
@@ -1,0 +1,19 @@
+import browserEnv from '@ikscodes/browser-env';
+import test from 'ava';
+import { createPromiEvent, isPromiEvent } from '../../../../src/util/promise-tools';
+
+test.beforeEach(t => {
+  browserEnv.restore();
+});
+
+test('Returns `true` for valid `PromiEvent` object', t => {
+  const p = createPromiEvent(resolve => resolve());
+
+  t.true(isPromiEvent(p));
+});
+
+test('Returns `false` for invalid `PromiEvent` object', t => {
+  const p = {};
+
+  t.false(isPromiEvent(p));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,6 +4333,11 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+eventemitter3@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
+  integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -10576,11 +10581,6 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-typed-emitter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-1.0.0.tgz#e21a0151539fc6f61e1f59b0d3655f6879b59eb5"
-  integrity sha512-bZS13Bz8kgF1kxJ370V7QMwzpqlrVJ4cu9bsBWRqDL2kzKLcx0vCDPkZ0NgJ31HZ4tXFSOxChXii6YLG6Rqz4A==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10577,6 +10577,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+typed-emitter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-1.0.0.tgz#e21a0151539fc6f61e1f59b0d3655f6879b59eb5"
+  integrity sha512-bZS13Bz8kgF1kxJ370V7QMwzpqlrVJ4cu9bsBWRqDL2kzKLcx0vCDPkZ0NgJ31HZ4tXFSOxChXii6YLG6Rqz4A==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"


### PR DESCRIPTION
### 📦 Pull Request

Overloads the promises returned by SDK methods with event emitter methods. This will enable a number of use-cases as described in #93. The events are not yet set up from the iframe side, so we should wait to merge this until that is complete.

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- #93 

### 🚨 Test instructions

`yarn test`

### ⚠️ Update `CHANGELOG.md`

- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
