### PR TITLE
Externalize provider and types deps for web entry point

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "microbundle watch src/index.ts --define $ENV --target web --format modern,es,cjs",
     "build": "yarn run build:npm && yarn run build:cdn",
-    "build:npm": "microbundle build src/index.ts --define $ENV --target web --format modern,es,cjs",
+    "build:npm": "microbundle build src/index.ts --define $ENV --target web --format modern,es,cjs --external @magic-sdk/provider,@magic-sdk/types",
     "build:cdn": "microbundle build src/index.cdn.ts --define $ENV --tsconfig tsconfig.cdn.json --output dist/magic.js --target web --name Magic --format umd --sourcemap false --external none",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
### 📦 Pull Request

We are examining an issue related to Magic SDK extensions related to the usage of `@magic-sdk/provider` and `@magic-sdk/types` as bundled deps instead of external deps.

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

We'll be testing this as a `canary` version first
