### PR TITLE
Add explicit `targetOrigin` parameter to `postMessage` calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "bootstrap": "yarn install && lerna link",
     "wsrun": "wsrun --bin $INIT_CWD/scripts/runner.sh -p $PKG",
-    "dev": "yarn clean && tsc -b -w $(yarn --silent paths)",
+    "dev": "yarn clean && $INIT_CWD/scripts/dev.sh",
     "build": "yarn clean && $INIT_CWD/scripts/build.sh",
     "clean": "$INIT_CWD/scripts/clean.sh",
     "lint": "$INIT_CWD/scripts/lint.sh",

--- a/packages/provider/tsconfig.module.json
+++ b/packages/provider/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.settings.json",
 
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es6",
     "rootDir": "./src",
     "outDir": "./dist/module"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -27,7 +27,6 @@
     "@magic-sdk/types": "^1.3.1",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
-    "regenerator-runtime": "0.13.5",
     "whatwg-url": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -6,8 +6,6 @@
   no-underscore-dangle
  */
 
-import 'regenerator-runtime/runtime';
-
 import { createSDK } from '@magic-sdk/provider';
 import * as processPolyfill from 'process';
 import localForage from 'localforage';

--- a/packages/react-native/src/react-native-webview-controller.tsx
+++ b/packages/react-native/src/react-native-webview-controller.tsx
@@ -135,7 +135,7 @@ export class ReactNativeWebViewController extends ViewController<ReactNativeTran
 
   public async postMessage(data: any) {
     if (this.webView && (this.webView as any).postMessage) {
-      (this.webView as any).postMessage(JSON.stringify(data), '*');
+      (this.webView as any).postMessage(JSON.stringify(data), this.endpoint);
     } else {
       throw createModalNotReadyError();
     }

--- a/packages/react-native/test/spec/react-native-webview-controller/postMessage.spec.ts
+++ b/packages/react-native/test/spec/react-native-webview-controller/postMessage.spec.ts
@@ -11,14 +11,14 @@ test.beforeEach((t) => {
 });
 
 test('Calls webView.postMessage with the expected arguments', async (t) => {
-  const overlay = createReactNativeWebViewController();
+  const overlay = createReactNativeWebViewController('http://example.com');
 
   const postMessageStub = sinon.stub();
   (overlay as any).webView = { postMessage: postMessageStub };
 
   await overlay.postMessage({ thisIsData: 'hello world' });
 
-  t.deepEqual(postMessageStub.args[0], [JSON.stringify({ thisIsData: 'hello world' }), '*']);
+  t.deepEqual(postMessageStub.args[0], [JSON.stringify({ thisIsData: 'hello world' }), 'http://example.com']);
 });
 
 test('Throws MODAL_NOT_READY error if webView is nil', async (t) => {

--- a/packages/react-native/tsconfig.module.json
+++ b/packages/react-native/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.settings.json",
 
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es6",
     "rootDir": ".",
     "outDir": "./dist/module"
   },

--- a/packages/types/tsconfig.module.json
+++ b/packages/types/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.settings.json",
 
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es6",
     "rootDir": "./src",
     "outDir": "./dist/module"
   },

--- a/packages/web/src/iframe-controller.ts
+++ b/packages/web/src/iframe-controller.ts
@@ -90,7 +90,7 @@ export class IframeController extends ViewController {
   public async postMessage(data: any) {
     const iframe = await this.iframe;
     if (iframe && iframe.contentWindow) {
-      iframe.contentWindow.postMessage(data, '*');
+      iframe.contentWindow.postMessage(data, this.endpoint);
     } else {
       throw createModalNotReadyError();
     }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 
-import 'regenerator-runtime/runtime';
-
 import { SDKBase, createSDK } from '@magic-sdk/provider';
 import localForage from 'localforage';
 import * as memoryDriver from 'localforage-driver-memory';

--- a/packages/web/test/spec/iframe-controller/postMessage.spec.ts
+++ b/packages/web/test/spec/iframe-controller/postMessage.spec.ts
@@ -10,14 +10,14 @@ test.beforeEach((t) => {
 });
 
 test('Calls iframe.contentWindow.postMessage with the expected arguments', async (t) => {
-  const overlay = createIframeController();
+  const overlay = createIframeController('http://example.com');
 
   const postMessageStub = sinon.stub();
   (overlay as any).iframe = { contentWindow: { postMessage: postMessageStub } };
 
   await overlay.postMessage({ thisIsData: 'hello world' });
 
-  t.deepEqual(postMessageStub.args[0], [{ thisIsData: 'hello world' }, '*']);
+  t.deepEqual(postMessageStub.args[0], [{ thisIsData: 'hello world' }, 'http://example.com']);
 });
 
 test('Throws MODAL_NOT_READY error if iframe.contentWindow is nil', async (t) => {

--- a/packages/web/tsconfig.cdn.json
+++ b/packages/web/tsconfig.cdn.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.settings.json",
 
   "compilerOptions": {
-    "module": "esnext",
+    "module": "esnext", // Microbundle will output ES5
     "declaration": false,
     "sourceMap": false,
     "composite": false,

--- a/packages/web/tsconfig.module.json
+++ b/packages/web/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.settings.json",
 
   "compilerOptions": {
-    "module": "esnext",
+    "module": "es6",
     "rootDir": ".",
     "outDir": "./dist/module"
   },

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,13 @@ echo "+-------------------------------------------------------------------------
 echo "  Building CommonJS files..."
 echo
 
-tsc -b $(yarn --silent paths)
+paths=$(echo -e $(yarn --silent paths tsconfig.json))
+
+echo "Compiling TypeScripts for the following projects:"
+node -pe "'$paths'.split(' ').reduce((prev, next) => prev + '\n - ' + next, '')"
+echo
+
+tsc -b $paths
 echo "TypeScripts compiled."
 
 echo
@@ -13,14 +19,20 @@ echo "+-------------------------------------------------------------------------
 echo "  Building ES module files..."
 echo
 
-tsc -b $(yarn --silent paths tsconfig.module.json)
+paths=$(echo -e $(yarn --silent paths tsconfig.module.json))
+
+echo "Compiling TypeScripts for the following projects:"
+node -pe "'$paths'.split(' ').reduce((prev, next) => prev + '\n - ' + next, '')"
+echo
+
+tsc -b $paths
 echo "TypeScripts compiled."
 
 echo
 echo "+------------------------------------------------------------------------------+"
 echo "  Building CDN bundles..."
-echo "  (You can safely ignore \`The 'this' keyword is equivalent to 'undefined'\`"
-echo "   warnings"
+echo
+echo "You can safely ignore \`The 'this' keyword is equivalent to 'undefined'\` warnings"
 echo
 
 yarn wsrun --serial $INIT_CWD/scripts/build:cdn.sh

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo
+echo "+------------------------------------------------------------------------------+"
+echo "  Building CommonJS files for development..."
+echo
+
+paths=$(echo -e $(yarn --silent paths tsconfig.json))
+
+echo "Compiling TypeScripts for the following projects:"
+node -pe "'$paths'.split(' ').reduce((prev, next) => prev + '\n - ' + next, '')"
+echo
+
+sleep 3
+
+tsc -b -w $paths

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -3,7 +3,7 @@
     "lib": ["es2018", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es5",
     "strict": true,
     "jsx": "react",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### 📦 Pull Request

This add an explicit `targetOrigin` parameter to `postMessage` calls (before, we used `"*"`).

### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?

### ⚠️ Update `CHANGELOG.md`

- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
