### PR TITLE
Add 'files' array back to package JSON

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
+  "files": ["dist/*"],
   "target": "web",
   "main": "dist/commonjs/index.js",
   "module": "dist/module/index.js",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/provider",
-  "version": "2.5.3",
+  "version": "2.5.4-alpha.0",
   "description": "Core business logic for Magic SDK packages.",
   "author": "Fortmatic <team@fortmatic.com> (https://fortmatic.com/)",
   "license": "MIT",
@@ -9,7 +9,9 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
-  "files": ["dist/*"],
+  "files": [
+    "dist/*"
+  ],
   "target": "web",
   "main": "dist/commonjs/index.js",
   "module": "dist/module/index.js",
@@ -18,7 +20,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "@magic-sdk/types": "^1.4.3",
+    "@magic-sdk/types": "^1.4.4-alpha.0",
     "eventemitter3": "^4.0.4"
   },
   "peerDependencies": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
+  "files": ["dist/*"],
   "target": "node",
   "main": "dist/commonjs/src/index.js",
   "module": "dist/module/src/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/react-native",
-  "version": "2.4.3",
+  "version": "2.4.4-alpha.0",
   "description": "Passwordless authentication for React Native.",
   "author": "Fortmatic <team@fortmatic.com> (https://fortmatic.com/)",
   "license": "MIT",
@@ -9,7 +9,9 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
-  "files": ["dist/*"],
+  "files": [
+    "dist/*"
+  ],
   "target": "node",
   "main": "dist/commonjs/src/index.js",
   "module": "dist/module/src/index.js",
@@ -21,8 +23,8 @@
     "@aveq-research/localforage-asyncstorage-driver": "^1.0.2",
     "@babel/core": "^7.9.6",
     "@babel/runtime": "^7.9.6",
-    "@magic-sdk/provider": "^2.5.3",
-    "@magic-sdk/types": "^1.4.3",
+    "@magic-sdk/provider": "^2.5.4-alpha.0",
+    "@magic-sdk/types": "^1.4.4-alpha.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
     "whatwg-url": "^8.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/types",
-  "version": "1.4.3",
+  "version": "1.4.4-alpha.0",
   "description": "Core typings for Magic SDK packages.",
   "author": "Fortmatic <team@fortmatic.com> (https://fortmatic.com/)",
   "license": "MIT",
@@ -9,7 +9,9 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
-  "files": ["dist/*"],
+  "files": [
+    "dist/*"
+  ],
   "target": "web",
   "main": "dist/commonjs/index.js",
   "module": "dist/module/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
+  "files": ["dist/*"],
   "target": "web",
   "main": "dist/commonjs/index.js",
   "module": "dist/module/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
+  "files": ["dist/*"],
   "umdGlobal": "Magic",
   "target": "web",
   "main": "dist/commonjs/src/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-sdk",
-  "version": "2.4.3",
+  "version": "2.4.4-alpha.0",
   "description": "Passwordless authentication for the web.",
   "author": "Fortmatic <team@fortmatic.com> (https://fortmatic.com/)",
   "license": "MIT",
@@ -9,7 +9,9 @@
     "url": "https://github.com/fortmatic/magic-js"
   },
   "homepage": "https://magic.link",
-  "files": ["dist/*"],
+  "files": [
+    "dist/*"
+  ],
   "umdGlobal": "Magic",
   "target": "web",
   "main": "dist/commonjs/src/index.js",
@@ -22,8 +24,8 @@
   "dependencies": {
     "@babel/core": "^7.9.6",
     "@babel/runtime": "^7.9.6",
-    "@magic-sdk/provider": "^2.5.3",
-    "@magic-sdk/types": "^1.4.3",
+    "@magic-sdk/provider": "^2.5.4-alpha.0",
+    "@magic-sdk/types": "^1.4.4-alpha.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
     "regenerator-runtime": "0.13.5"


### PR DESCRIPTION
### 📦 Pull Request

A mistake in the `files` array of Package JSON files in the repo lead to a bad deploy. It was fixed in a brute-force way by removing the `files` array completely. This PR replaces that field (in a working condition).
