### PR TITLE
[W.I.P.] Add `redirectURI` parameter to `loginWithMagicLink`; Implement `loginWithCredential`

### DIFF
--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 - ...
 
+## `2.7.0-alpha.0` - 09/08/2020
+
+#### Added
+
+- New, optional `redirectURI` parameter for the `loginWithMagicLink` method
+- New `loginWithCredential` method for completing a magic link login with redirect: `await magic.auth.loginWithCredential()`
+
 ## `2.6.0` - 08/24/2020
 
 #### Added

--- a/packages/provider/src/modules/auth/index.ts
+++ b/packages/provider/src/modules/auth/index.ts
@@ -38,21 +38,18 @@ export class AuthModule extends BaseModule {
    * If no argument is provided, a credential is automatically parsed from
    * `window.location.search`.
    */
-  public loginWithCredential(credential?: string) {
-    let queryString: string | undefined;
+  public loginWithCredential(credentialOrQueryString?: string) {
+    let credentialResolved = credentialOrQueryString ?? '';
 
-    if (!credential && SDKEnvironment.target === 'web') {
-      queryString = window.location.search;
+    if (!credentialOrQueryString && SDKEnvironment.target === 'web') {
+      credentialResolved = window.location.search;
 
       // Remove the query from the redirect callback as a precaution.
       const urlWithoutQuery = window.location.origin + window.location.pathname;
       window.history.replaceState(null, '', urlWithoutQuery);
     }
 
-    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithCredential, [
-      credential,
-      queryString,
-    ]);
+    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithCredential, [credentialResolved]);
 
     return this.request<string | null>(requestPayload);
   }

--- a/packages/provider/src/modules/auth/index.ts
+++ b/packages/provider/src/modules/auth/index.ts
@@ -33,7 +33,9 @@ export class AuthModule extends BaseModule {
   /**
    * Log a user in with a special one-time-use credential token. This is
    * currently used during magic link flows with a configured redirect to
-   * hydrate the user session at the end of the flow.
+   * hydrate the user session at the end of the flow. If the flow is successful,
+   * this method will return a Decentralized ID token (with a default lifespan
+   * of 15 minutes).
    *
    * If no argument is provided, a credential is automatically parsed from
    * `window.location.search`.

--- a/packages/provider/src/modules/auth/index.ts
+++ b/packages/provider/src/modules/auth/index.ts
@@ -39,25 +39,21 @@ export class AuthModule extends BaseModule {
    * `window.location.search`.
    */
   public loginWithCredential(credential?: string) {
-    let credentialResolved = credential ?? '';
+    let queryString: string | undefined;
 
     if (!credential && SDKEnvironment.target === 'web') {
-      const queryString = window.location.search;
+      queryString = window.location.search;
 
       // Remove the query from the redirect callback as a precaution.
       const urlWithoutQuery = window.location.origin + window.location.pathname;
       window.history.replaceState(null, '', urlWithoutQuery);
-
-      // Parse the URL query string for a `magic_credential` value.
-      credentialResolved =
-        queryString
-          .substr(1)
-          .split('&')
-          .map((part) => [part.substring(0, part.indexOf('=')), part.substring(part.indexOf('=')).substr(1)])
-          .find(([key]) => key === 'magic_credential')?.[1] ?? '';
     }
 
-    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithCredential, [credentialResolved]);
+    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.LoginWithCredential, [
+      credential,
+      queryString,
+    ]);
+
     return this.request<string | null>(requestPayload);
   }
 

--- a/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
+++ b/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
@@ -1,0 +1,95 @@
+/* eslint-disable global-require, @typescript-eslint/no-var-requires */
+
+import browserEnv from '@ikscodes/browser-env';
+import test from 'ava';
+import sinon from 'sinon';
+import { getPayloadIdStub, mockSDKEnvironmentConstant } from '../../../mocks';
+import { BaseModule } from '../../../../src/modules/base-module';
+import { createMagicSDK } from '../../../factories';
+
+test.beforeEach((t) => {
+  browserEnv.restore();
+  (BaseModule as any).prototype.request = sinon.stub();
+  mockSDKEnvironmentConstant('target', 'web');
+});
+
+test.serial('Generates JSON RPC request payload with the given parameter as the credential', async (t) => {
+  const magic = createMagicSDK();
+
+  const idStub = getPayloadIdStub();
+  idStub.returns(222);
+
+  await magic.auth.loginWithCredential('helloworld');
+
+  const requestPayload = (magic.user as any).request.args[0][0];
+  t.is(requestPayload.jsonrpc, '2.0');
+  t.is(requestPayload.id, 222);
+  t.is(requestPayload.method, 'magic_auth_login_with_credential');
+  t.deepEqual(requestPayload.params, ['helloworld']);
+});
+
+test.serial('If no parameter is given & platform target is "web", parse query string for credential', async (t) => {
+  const magic = createMagicSDK();
+
+  const idStub = getPayloadIdStub();
+  idStub.returns(777);
+
+  browserEnv.stub('window.history.replaceState', () => {});
+
+  browserEnv.stub('window.location', {
+    search: '?magic_credential=asdf',
+    origin: 'http://example.com',
+    pathname: '/hello/world',
+  });
+
+  await magic.auth.loginWithCredential();
+
+  const requestPayload = (magic.user as any).request.args[0][0];
+  t.is(requestPayload.jsonrpc, '2.0');
+  t.is(requestPayload.id, 777);
+  t.is(requestPayload.method, 'magic_auth_login_with_credential');
+  t.deepEqual(requestPayload.params, ['asdf']);
+});
+
+test.serial(
+  'If no parameter is given & platform target is "web", fall back to empty string if no credential is found',
+  async (t) => {
+    const magic = createMagicSDK();
+
+    const idStub = getPayloadIdStub();
+    idStub.returns(777);
+
+    browserEnv.stub('window.history.replaceState', () => {});
+
+    browserEnv.stub('window.location', {
+      search: '?noop=asdf',
+      origin: 'http://example.com',
+      pathname: '/hello/world',
+    });
+
+    await magic.auth.loginWithCredential();
+
+    const requestPayload = (magic.user as any).request.args[0][0];
+    t.is(requestPayload.jsonrpc, '2.0');
+    t.is(requestPayload.id, 777);
+    t.is(requestPayload.method, 'magic_auth_login_with_credential');
+    t.deepEqual(requestPayload.params, ['']);
+  },
+);
+
+test.serial('If no parameter is given & platform target is NOT "web", credential is empty string', async (t) => {
+  const magic = createMagicSDK();
+
+  const idStub = getPayloadIdStub();
+  idStub.returns(777);
+
+  mockSDKEnvironmentConstant('target', 'react-native');
+
+  await magic.auth.loginWithCredential();
+
+  const requestPayload = (magic.user as any).request.args[0][0];
+  t.is(requestPayload.jsonrpc, '2.0');
+  t.is(requestPayload.id, 777);
+  t.is(requestPayload.method, 'magic_auth_login_with_credential');
+  t.deepEqual(requestPayload.params, ['']);
+});

--- a/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
+++ b/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
@@ -25,7 +25,7 @@ test.serial('Generates JSON RPC request payload with the given parameter as the 
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 222);
   t.is(requestPayload.method, 'magic_auth_login_with_credential');
-  t.deepEqual(requestPayload.params, ['helloworld', undefined]);
+  t.deepEqual(requestPayload.params, ['helloworld']);
 });
 
 test.serial(
@@ -50,7 +50,7 @@ test.serial(
     t.is(requestPayload.jsonrpc, '2.0');
     t.is(requestPayload.id, 777);
     t.is(requestPayload.method, 'magic_auth_login_with_credential');
-    t.deepEqual(requestPayload.params, [undefined, '?magic_credential=asdf']);
+    t.deepEqual(requestPayload.params, ['?magic_credential=asdf']);
   },
 );
 
@@ -68,5 +68,5 @@ test.serial('If no parameter is given & platform target is NOT "web", credential
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 777);
   t.is(requestPayload.method, 'magic_auth_login_with_credential');
-  t.deepEqual(requestPayload.params, ['', undefined]);
+  t.deepEqual(requestPayload.params, ['']);
 });

--- a/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
+++ b/packages/provider/test/spec/modules/auth/loginWithCredential.spec.ts
@@ -25,34 +25,11 @@ test.serial('Generates JSON RPC request payload with the given parameter as the 
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 222);
   t.is(requestPayload.method, 'magic_auth_login_with_credential');
-  t.deepEqual(requestPayload.params, ['helloworld']);
-});
-
-test.serial('If no parameter is given & platform target is "web", parse query string for credential', async (t) => {
-  const magic = createMagicSDK();
-
-  const idStub = getPayloadIdStub();
-  idStub.returns(777);
-
-  browserEnv.stub('window.history.replaceState', () => {});
-
-  browserEnv.stub('window.location', {
-    search: '?magic_credential=asdf',
-    origin: 'http://example.com',
-    pathname: '/hello/world',
-  });
-
-  await magic.auth.loginWithCredential();
-
-  const requestPayload = (magic.user as any).request.args[0][0];
-  t.is(requestPayload.jsonrpc, '2.0');
-  t.is(requestPayload.id, 777);
-  t.is(requestPayload.method, 'magic_auth_login_with_credential');
-  t.deepEqual(requestPayload.params, ['asdf']);
+  t.deepEqual(requestPayload.params, ['helloworld', undefined]);
 });
 
 test.serial(
-  'If no parameter is given & platform target is "web", fall back to empty string if no credential is found',
+  'If no parameter is given & platform target is "web", URL search string is included in the payload params',
   async (t) => {
     const magic = createMagicSDK();
 
@@ -62,7 +39,7 @@ test.serial(
     browserEnv.stub('window.history.replaceState', () => {});
 
     browserEnv.stub('window.location', {
-      search: '?noop=asdf',
+      search: '?magic_credential=asdf',
       origin: 'http://example.com',
       pathname: '/hello/world',
     });
@@ -73,7 +50,7 @@ test.serial(
     t.is(requestPayload.jsonrpc, '2.0');
     t.is(requestPayload.id, 777);
     t.is(requestPayload.method, 'magic_auth_login_with_credential');
-    t.deepEqual(requestPayload.params, ['']);
+    t.deepEqual(requestPayload.params, [undefined, '?magic_credential=asdf']);
   },
 );
 
@@ -91,5 +68,5 @@ test.serial('If no parameter is given & platform target is NOT "web", credential
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 777);
   t.is(requestPayload.method, 'magic_auth_login_with_credential');
-  t.deepEqual(requestPayload.params, ['']);
+  t.deepEqual(requestPayload.params, ['', undefined]);
 });

--- a/packages/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
+++ b/packages/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
@@ -24,7 +24,7 @@ test.serial('Generates JSON RPC request payload with `email` parameter', async (
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 222);
   t.is(requestPayload.method, 'magic_auth_login_with_magic_link');
-  t.deepEqual(requestPayload.params, [{ email: 'test', showUI: true }]);
+  t.deepEqual(requestPayload.params, [{ email: 'test', showUI: true, redirectURI: undefined }]);
 });
 
 test.serial('Generates JSON RPC request payload with `showUI` parameter', async (t) => {
@@ -39,5 +39,20 @@ test.serial('Generates JSON RPC request payload with `showUI` parameter', async 
   t.is(requestPayload.jsonrpc, '2.0');
   t.is(requestPayload.id, 777);
   t.is(requestPayload.method, 'magic_auth_login_with_magic_link');
-  t.deepEqual(requestPayload.params, [{ email: 'test', showUI: false }]);
+  t.deepEqual(requestPayload.params, [{ email: 'test', showUI: false, redirectURI: undefined }]);
+});
+
+test.serial('Generates JSON RPC request payload with `redirectURI` parameter', async (t) => {
+  const magic = createMagicSDK();
+
+  const idStub = getPayloadIdStub();
+  idStub.returns(999);
+
+  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, redirectURI: 'helloworld' });
+
+  const requestPayload = (magic.user as any).request.args[0][0];
+  t.is(requestPayload.jsonrpc, '2.0');
+  t.is(requestPayload.id, 999);
+  t.is(requestPayload.method, 'magic_auth_login_with_magic_link');
+  t.deepEqual(requestPayload.params, [{ email: 'test', showUI: true, redirectURI: 'helloworld' }]);
 });

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 - ...
 
+## `2.7.0-alpha.0` - 09/08/2020
+
+#### Added
+
+- New, optional `redirectURI` parameter for the `loginWithMagicLink` method
+- New `loginWithCredential` method for completing a magic link login with redirect: `await magic.auth.loginWithCredential()`
+
 ## `2.6.0` - 08/24/2020
 
 #### Added

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 - ...
 
+## `1.5.0-alpha.0` - 09/08/2020
+
+#### Added
+
+- New, optional `redirectURI` parameter for the `loginWithMagicLink` method
+- New `loginWithCredential` method for completing a magic link login with redirect: `await magic.auth.loginWithCredential()`
+
 ## `1.4.8` - 08/20/2020
 
 #### Added

--- a/packages/types/src/core/json-rpc-types.ts
+++ b/packages/types/src/core/json-rpc-types.ts
@@ -41,6 +41,7 @@ export interface JsonRpcResponsePayload<ResultType = any> {
  */
 export enum MagicPayloadMethod {
   LoginWithMagicLink = 'magic_auth_login_with_magic_link',
+  LoginWithCredential = 'magic_auth_login_with_credential',
   GetIdToken = 'magic_auth_get_id_token',
   GenerateIdToken = 'magic_auth_generate_id_token',
   GetMetadata = 'magic_auth_get_metadata',

--- a/packages/types/src/modules/auth-types.ts
+++ b/packages/types/src/modules/auth-types.ts
@@ -10,6 +10,14 @@ export interface LoginWithMagicLinkConfiguration {
    * authentication.
    */
   showUI?: boolean;
+
+  /**
+   * You can optionally provide a redirect URI that will be followed at the end
+   * of the magic link flow. Don't forget to invoke
+   * `magic.auth.loginWithCredential()` to complete the login from the route you
+   * configure here.
+   */
+  redirectURI?: string;
 }
 
 export interface RegisterWithWebAuthnConfiguration {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 - ...
 
+## `2.6.0-alpha.0` - 09/08/2020
+
+#### Added
+
+- New, optional `redirectURI` parameter for the `loginWithMagicLink` method
+- New `loginWithCredential` method for completing a magic link login with redirect: `await magic.auth.loginWithCredential()`
+
 ## `2.5.0` - 08/24/2020
 
 #### Added

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,12 +6,16 @@
 # Increase memory limit for Node
 export NODE_OPTIONS=--max_old_space_size=4096
 
+RAW_INPUT=$1
+
 runTests() {
+  # Parse a glob of input test files (relative to the package directory).
+  input=$(echo $($INIT_CWD/scripts/glob.ts $RAW_INPUT))
 
   export TS_NODE_PROJECT="./test/tsconfig.json"
 
   # Run tests, with coverage.
-  npx nyc --reporter=lcov --reporter=text-summary  ava -T 120000 || exit 1
+  npx nyc --reporter=lcov --reporter=text-summary  ava -T 120000 $input || exit 1
 }
 
 echoNoTests() {


### PR DESCRIPTION
### 📦 Pull Request

This PR adds two features to support redirect URIs in the core magic link flow:

1. Adds `redirectURI` parameter to `loginWithMagicLink`
2. Adds `loginWithCredential` method to support the redirect "callback"

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
