### PR TITLE
Add framework for extension compatibility checks

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -21,13 +21,15 @@
   },
   "dependencies": {
     "@magic-sdk/types": "^1.5.0",
-    "eventemitter3": "^4.0.4"
+    "eventemitter3": "^4.0.4",
+    "semver": "^7.3.2"
   },
   "peerDependencies": {
     "localforage": "^1.7.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.6",
+    "@types/semver": "^7.3.4",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5"
   },

--- a/packages/provider/src/core/sdk-environment.ts
+++ b/packages/provider/src/core/sdk-environment.ts
@@ -29,3 +29,8 @@ export function createSDK<SDK extends SDKBase>(
   Object.assign(SDKEnvironment, environment);
   return SDKBaseCtor as any;
 }
+
+export const envNameToNpmName = {
+  'magic-sdk': 'magic-sdk' as const,
+  'magic-sdk-rn': '@magic-sdk/react-native' as const,
+};

--- a/packages/provider/src/core/sdk-exceptions.ts
+++ b/packages/provider/src/core/sdk-exceptions.ts
@@ -142,7 +142,7 @@ export function createIncompatibleExtensionsError(extensions: Extension<string>[
     }
   });
 
-  return new MagicSDKError(SDKErrorCode.IncompatibleExtensionsError, msg);
+  return new MagicSDKError(SDKErrorCode.IncompatibleExtensions, msg);
 }
 
 export function createInvalidArgumentError(options: {

--- a/packages/provider/src/core/sdk-exceptions.ts
+++ b/packages/provider/src/core/sdk-exceptions.ts
@@ -131,16 +131,21 @@ export function createIncompatibleExtensionsError(extensions: Extension<string>[
   const npmName = envNameToNpmName[SDKEnvironment.sdkName];
   let msg = `Some extensions are incompatible with \`${npmName}@${SDKEnvironment.version}\`:`;
 
-  extensions.forEach((ext) => {
-    const compat = ext.compat![npmName];
+  extensions
+    .filter((ext) => typeof ext.compat !== 'undefined' && ext.compat !== null)
+    .forEach((ext) => {
+      const compat = ext.compat![npmName];
 
-    /* istanbul ignore else */
-    if (typeof compat === 'string') {
-      msg += `\n  - Extension \`${ext.name}\` supports version(s) \`${compat}\``;
-    } else if (!compat) {
-      msg += `\n  - Extension \`${ext.name}\` does not support ${SDKEnvironment.target} environments.`;
-    }
-  });
+      /* istanbul ignore else */
+      if (typeof compat === 'string') {
+        msg += `\n  - Extension \`${ext.name}\` supports version(s) \`${compat}\``;
+      } else if (!compat) {
+        msg += `\n  - Extension \`${ext.name}\` does not support ${SDKEnvironment.target} environments.`;
+      }
+
+      // Else case is irrelevant here here
+      // (we filter out extensions with missing `compat` field)
+    });
 
   return new MagicSDKError(SDKErrorCode.IncompatibleExtensions, msg);
 }

--- a/packages/provider/src/modules/base-extension.ts
+++ b/packages/provider/src/modules/base-extension.ts
@@ -12,6 +12,13 @@ import {
   isPromiEvent,
 } from '../util';
 
+interface BaseExtension<TName extends string> extends BaseModule {
+  compat?: {
+    'magic-sdk': boolean | string;
+    '@magic-sdk/react-native': boolean | string;
+  };
+}
+
 abstract class BaseExtension<TName extends string> extends BaseModule {
   public abstract readonly name: TName;
 
@@ -34,7 +41,7 @@ abstract class BaseExtension<TName extends string> extends BaseModule {
 
     const sdkAccessFields = ['request', 'transport', 'overlay', 'sdk'];
 
-    // Dissallow SDK access before initialization.
+    // Disallow SDK access before initialization.
     return new Proxy(this, {
       get: (target, prop, receiver) => {
         if (sdkAccessFields.includes(prop as string) && !this.isInitialized) {
@@ -122,7 +129,7 @@ export abstract class Extension<TName extends string> extends BaseExtension<TNam
  * These fields are exposed on the `Extension` type, but should be hidden from
  * the public interface.
  */
-type HiddenExtensionFields = 'name' | 'init' | 'config';
+type HiddenExtensionFields = 'name' | 'init' | 'config' | 'compat';
 
 /**
  * Gets the type contained in an array type.

--- a/packages/provider/test/mocks.ts
+++ b/packages/provider/test/mocks.ts
@@ -16,8 +16,17 @@ export function getPayloadIdStub() {
   return stub;
 }
 
+const originalSDKEnvironment: any = {};
+
 export function mockSDKEnvironmentConstant(key: keyof typeof SDKEnvironment, value: any) {
+  if (!originalSDKEnvironment[key]) originalSDKEnvironment[key] = SDKEnvironment[key];
   (SDKEnvironment as any)[key] = value;
+}
+
+export function restoreSDKEnvironmentConstants() {
+  Object.keys(originalSDKEnvironment).forEach((key) => {
+    (SDKEnvironment as any)[key] = originalSDKEnvironment[key];
+  });
 }
 
 export function transformNewAssertionForServerStub() {

--- a/packages/provider/test/spec/core/sdk-exceptions/error-factories.spec.ts
+++ b/packages/provider/test/spec/core/sdk-exceptions/error-factories.spec.ts
@@ -11,7 +11,10 @@ import {
   createExtensionNotInitializedError,
   createWebAuthnNotSupportError,
   createWebAuthCreateCredentialError,
+  createIncompatibleExtensionsError,
 } from '../../../../src/core/sdk-exceptions';
+import { Extension } from '../../../../src/modules/base-extension';
+import { mockSDKEnvironmentConstant, restoreSDKEnvironmentConstants } from '../../../mocks';
 
 function errorAssertions<T extends ExecutionContext<any>>(
   t: T,
@@ -27,6 +30,7 @@ function errorAssertions<T extends ExecutionContext<any>>(
 
 test.beforeEach((t) => {
   browserEnv.restore();
+  restoreSDKEnvironmentConstants();
 });
 
 test('Creates a `MISSING_API_KEY` error', async (t) => {
@@ -133,5 +137,86 @@ test('Creates an `EXTENSION_NOT_INITIALIZED` error', async (t) => {
     error,
     'EXTENSION_NOT_INITIALIZED',
     'Extensions must be initialized with a Magic SDK instance before `Extension.foo` can be accessed. Do not invoke `Extension.foo` inside an extension constructor.',
+  );
+});
+
+class NoopExtSupportingWeb extends Extension<'noop'> {
+  name = 'noop' as const;
+  compat = {
+    'magic-sdk': '>1.0.0',
+    '@magic-sdk/react-native': false,
+  };
+  helloWorld() {}
+}
+
+class NoopExtSupportingReactNative extends Extension<'noop'> {
+  name = 'noop' as const;
+  compat = {
+    'magic-sdk': false,
+    '@magic-sdk/react-native': '>1.0.0',
+  };
+  helloWorld() {}
+}
+
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web version', async (t) => {
+  mockSDKEnvironmentConstant('target', 'web');
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk');
+  mockSDKEnvironmentConstant('version', '0.0.0');
+
+  const error = createIncompatibleExtensionsError([new NoopExtSupportingWeb(), new NoopExtSupportingWeb()]);
+
+  errorAssertions(
+    t,
+    error,
+    'INCOMPATIBLE_EXTENSIONS',
+    'Some extensions are incompatible with `magic-sdk@0.0.0`:\n  - Extension `noop` supports version(s) `>1.0.0`\n  - Extension `noop` supports version(s) `>1.0.0`',
+  );
+});
+
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native version', async (t) => {
+  mockSDKEnvironmentConstant('target', 'react-native');
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('version', '0.0.0');
+
+  const error = createIncompatibleExtensionsError([
+    new NoopExtSupportingReactNative(),
+    new NoopExtSupportingReactNative(),
+  ]);
+
+  errorAssertions(
+    t,
+    error,
+    'INCOMPATIBLE_EXTENSIONS',
+    'Some extensions are incompatible with `@magic-sdk/react-native@0.0.0`:\n  - Extension `noop` supports version(s) `>1.0.0`\n  - Extension `noop` supports version(s) `>1.0.0`',
+  );
+});
+
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web environments', async (t) => {
+  mockSDKEnvironmentConstant('target', 'web');
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk');
+  mockSDKEnvironmentConstant('version', '0.0.0');
+
+  const error = createIncompatibleExtensionsError([new NoopExtSupportingReactNative()]);
+
+  errorAssertions(
+    t,
+    error,
+    'INCOMPATIBLE_EXTENSIONS',
+    'Some extensions are incompatible with `magic-sdk@0.0.0`:\n  - Extension `noop` does not support web environments.',
+  );
+});
+
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native environments', async (t) => {
+  mockSDKEnvironmentConstant('target', 'react-native');
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('version', '0.0.0');
+
+  const error = createIncompatibleExtensionsError([new NoopExtSupportingWeb()]);
+
+  errorAssertions(
+    t,
+    error,
+    'INCOMPATIBLE_EXTENSIONS',
+    'Some extensions are incompatible with `@magic-sdk/react-native@0.0.0`:\n  - Extension `noop` does not support react-native environments.',
   );
 });

--- a/packages/provider/test/spec/core/sdk-exceptions/error-factories.spec.ts
+++ b/packages/provider/test/spec/core/sdk-exceptions/error-factories.spec.ts
@@ -158,7 +158,7 @@ class NoopExtSupportingReactNative extends Extension<'noop'> {
   helloWorld() {}
 }
 
-test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web version', async (t) => {
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web (version-related)', async (t) => {
   mockSDKEnvironmentConstant('target', 'web');
   mockSDKEnvironmentConstant('sdkName', 'magic-sdk');
   mockSDKEnvironmentConstant('version', '0.0.0');
@@ -173,7 +173,7 @@ test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web version', async 
   );
 });
 
-test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native version', async (t) => {
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native (version-related)', async (t) => {
   mockSDKEnvironmentConstant('target', 'react-native');
   mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
   mockSDKEnvironmentConstant('version', '0.0.0');
@@ -191,7 +191,7 @@ test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native version
   );
 });
 
-test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web environments', async (t) => {
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web (environment-related)', async (t) => {
   mockSDKEnvironmentConstant('target', 'web');
   mockSDKEnvironmentConstant('sdkName', 'magic-sdk');
   mockSDKEnvironmentConstant('version', '0.0.0');
@@ -206,7 +206,7 @@ test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for web environments', a
   );
 });
 
-test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native environments', async (t) => {
+test.serial('Creates an `INCOMPATIBLE_EXTENSIONS` error for React Native (environment-related)', async (t) => {
   mockSDKEnvironmentConstant('target', 'react-native');
   mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
   mockSDKEnvironmentConstant('version', '0.0.0');

--- a/packages/provider/test/spec/core/sdk/constructor.spec.ts
+++ b/packages/provider/test/spec/core/sdk/constructor.spec.ts
@@ -5,11 +5,7 @@ import test, { ExecutionContext } from 'ava';
 import sinon from 'sinon';
 import { MAGIC_RELAYER_FULL_URL, TEST_API_KEY } from '../../../constants';
 import { TestMagicSDK } from '../../../factories';
-import {
-  mockSDKEnvironmentConstant,
-  restoreSDKEnvironmentConstant,
-  restoreSDKEnvironmentConstants,
-} from '../../../mocks';
+import { mockSDKEnvironmentConstant, restoreSDKEnvironmentConstants } from '../../../mocks';
 import {
   createReactNativeEndpointConfigurationWarning,
   createIncompatibleExtensionsError,

--- a/packages/provider/test/spec/core/sdk/constructor.spec.ts
+++ b/packages/provider/test/spec/core/sdk/constructor.spec.ts
@@ -5,8 +5,16 @@ import test, { ExecutionContext } from 'ava';
 import sinon from 'sinon';
 import { MAGIC_RELAYER_FULL_URL, TEST_API_KEY } from '../../../constants';
 import { TestMagicSDK } from '../../../factories';
-import { mockSDKEnvironmentConstant } from '../../../mocks';
-import { createReactNativeEndpointConfigurationWarning } from '../../../../src/core/sdk-exceptions';
+import {
+  mockSDKEnvironmentConstant,
+  restoreSDKEnvironmentConstant,
+  restoreSDKEnvironmentConstants,
+} from '../../../mocks';
+import {
+  createReactNativeEndpointConfigurationWarning,
+  createIncompatibleExtensionsError,
+  MagicSDKError,
+} from '../../../../src/core/sdk-exceptions';
 import { AuthModule } from '../../../../src/modules/auth';
 import { UserModule } from '../../../../src/modules/user';
 import { RPCProviderModule } from '../../../../src/modules/rpc-provider';
@@ -14,6 +22,7 @@ import { Extension } from '../../../../src/modules/base-extension';
 
 test.beforeEach((t) => {
   browserEnv.restore();
+  restoreSDKEnvironmentConstants();
 });
 
 function assertEncodedQueryParams(t: ExecutionContext, encodedQueryParams: string, expectedParams: any = {}) {
@@ -121,6 +130,24 @@ class NoopExtWithEmptyConfig extends Extension.Internal<'noop'> {
   helloWorld() {}
 }
 
+class NoopExtSupportingWeb extends Extension<'noop'> {
+  name = 'noop' as const;
+  compat = {
+    'magic-sdk': '>1.0.0',
+    '@magic-sdk/react-native': false,
+  };
+  helloWorld() {}
+}
+
+class NoopExtSupportingReactNative extends Extension<'noop'> {
+  name = 'noop' as const;
+  compat = {
+    'magic-sdk': false,
+    '@magic-sdk/react-native': '>1.0.0',
+  };
+  helloWorld() {}
+}
+
 test.serial('Initialize `MagicSDK` with config-less extensions via array', (t) => {
   const magic = new TestMagicSDK(TEST_API_KEY, { extensions: [new NoopExtNoConfig()] });
 
@@ -170,6 +197,95 @@ test.serial('Initialize `MagicSDK` with config-ful extensions via dictionary (em
   assertEncodedQueryParams(t, magic.encodedQueryParams);
 
   t.true(magic.foobar instanceof NoopExtWithEmptyConfig);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible web extension (platform) via array', (t) => {
+  const ext = new NoopExtSupportingReactNative();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: [ext] }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible web extension (platform) via dictionary', (t) => {
+  const ext = new NoopExtSupportingReactNative();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: { foobar: ext } }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible React Native extension (platform) via array', (t) => {
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('target', 'react-native');
+
+  const ext = new NoopExtSupportingWeb();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: [ext] }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible React Native extension (platform) via dictionary', (t) => {
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('target', 'react-native');
+
+  const ext = new NoopExtSupportingWeb();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: { foobar: ext } }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible web extension (version) via array', (t) => {
+  mockSDKEnvironmentConstant('version', '0.1.0');
+
+  const ext = new NoopExtSupportingWeb();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: [ext] }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible web extension (version) via dictionary', (t) => {
+  mockSDKEnvironmentConstant('version', '0.1.0');
+
+  const ext = new NoopExtSupportingWeb();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: { foobar: ext } }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible React Native extension (version) via array', (t) => {
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('target', 'react-native');
+  mockSDKEnvironmentConstant('version', '0.1.0');
+
+  const ext = new NoopExtSupportingReactNative();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: [ext] }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
+});
+
+test.serial('Initialize `MagicSDK` with incompatible React Native extension (version) via dictionary', (t) => {
+  mockSDKEnvironmentConstant('sdkName', 'magic-sdk-rn');
+  mockSDKEnvironmentConstant('target', 'react-native');
+  mockSDKEnvironmentConstant('version', '0.1.0');
+  const ext = new NoopExtSupportingReactNative();
+  const expectedError = createIncompatibleExtensionsError([ext]);
+  const error: MagicSDKError = t.throws(() => new TestMagicSDK(TEST_API_KEY, { extensions: { foobar: ext } }));
+
+  t.is(error.code, expectedError.code);
+  t.is(error.message, expectedError.message);
 });
 
 test.serial(

--- a/packages/types/src/core/exception-types.ts
+++ b/packages/types/src/core/exception-types.ts
@@ -5,7 +5,7 @@ export enum SDKErrorCode {
   InvalidArgument = 'INVALID_ARGUMENT',
   ExtensionNotInitialized = 'EXTENSION_NOT_INITIALIZED',
   WebAuthnNotSupported = 'WEBAUTHN_NOT_SUPPORTED',
-  IncompatibleExtensionsError = 'INCOMPATIBLE_EXTENSIONS',
+  IncompatibleExtensions = 'INCOMPATIBLE_EXTENSIONS',
   WebAuthnCreateCredentialError = 'WEBAUTHN_CREATE_CREDENTIAL_ERROR',
 }
 

--- a/packages/types/src/core/exception-types.ts
+++ b/packages/types/src/core/exception-types.ts
@@ -5,6 +5,7 @@ export enum SDKErrorCode {
   InvalidArgument = 'INVALID_ARGUMENT',
   ExtensionNotInitialized = 'EXTENSION_NOT_INITIALIZED',
   WebAuthnNotSupported = 'WEBAUTHN_NOT_SUPPORTED',
+  IncompatibleExtensionsError = 'INCOMPATIBLE_EXTENSIONS',
   WebAuthnCreateCredentialError = 'WEBAUTHN_CREATE_CREDENTIAL_ERROR',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,6 +2710,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
+"@types/semver@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
+  integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
+
 "@types/sinon@~7.5.0":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.2.tgz#5e2f1d120f07b9cda07e5dedd4f3bf8888fccdb9"


### PR DESCRIPTION
### 📦 Pull Request

Adds a small framework to check Magic SDK extension compatibility at runtime.

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- Fixes #122 

### 🚨 Test instructions

`yarn test`

### ⚠️ Update `CHANGELOG.md`

- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
