### PR TITLE
Add 'importHelpers: true' to base tsconfig.json

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -18,7 +18,8 @@
   "types": "dist/commonjs/index.d.ts",
   "peerDependencies": {
     "@magic-sdk/provider": "^3.0.1",
-    "@magic-sdk/types": "^2.0.1"
+    "@magic-sdk/types": "^2.0.1",
+    "tslib": "^2.0.3"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@magic-sdk/types": "^3.0.0",
     "eventemitter3": "^4.0.4",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "tslib": "^2.0.3"
   },
   "peerDependencies": {
     "localforage": "^1.7.4"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,7 +29,8 @@
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",
     "process": "~0.11.10",
-    "whatwg-url": "~8.1.0"
+    "whatwg-url": "~8.1.0",
+    "tslib": "^2.0.3"
   },
   "devDependencies": {
     "react": "^16.13.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,5 +16,8 @@
   "main": "dist/commonjs/index.js",
   "module": "dist/module/index.js",
   "types": "dist/commonjs/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.0.3"
+  },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,8 @@
     "@magic-sdk/types": "^3.0.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
-    "regenerator-runtime": "0.13.5"
+    "regenerator-runtime": "0.13.5",
+    "tslib": "^2.0.3"
   },
   "ava": {
     "require": [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,10 +4,11 @@ echo
 boxen --border-color cyan --dim-border --padding 1 "Building TypeScripts..."
 echo
 
+echo "🤔 Determining TypeScript projects to build..."
 tsconfig_paths=$(echo -e $(yarn --silent paths tsconfig.json tsconfig.module.json))
 
-echo "Compiling TypeScripts for the following projects:"
-node -pe "'$tsconfig_paths'.split(' ').reduce((prev, next) => prev + '\n  - ' + next, '')"
+echo "  Compiling TypeScripts for the following projects:"
+node -pe "'$tsconfig_paths'.split(' ').reduce((prev, next) => prev + '\n    - ' + next, '')"
 echo
 
 tsc -b $tsconfig_paths
@@ -17,9 +18,6 @@ echo "TypeScripts compiled."
 
 echo
 boxen --border-color cyan --dim-border --padding 1 "Building CDN bundles..."
-echo
-
-echo "You can safely ignore \`The 'this' keyword is equivalent to 'undefined'\` warnings"
 echo
 
 yarn wsrun --serial $INIT_CWD/scripts/wsrun/build:cdn.sh

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,13 +4,15 @@ echo
 boxen --border-color cyan --dim-border --padding 1 "Building for development..."
 echo
 
+echo "🤔 Determining TypeScript projects to build..."
 pkg_paths=$(echo -e $(yarn --silent paths))
 tsconfig_paths=$(echo -e $(yarn --silent paths tsconfig.json tsconfig.module.json))
 
-echo "Compiling TypeScripts for the following projects:"
-node -pe "'$tsconfig_paths'.split(' ').reduce((prev, next) => prev + '\n  - ' + next, '')"
+
+echo "  Compiling TypeScripts for the following projects:"
+node -pe "'$tsconfig_paths'.split(' ').reduce((prev, next) => prev + '\n    - ' + next, '')"
 echo
 
-sleep 3
+sleep 5
 
 tsc-watch --onSuccess "$INIT_CWD/scripts/inject-env.ts $pkg_paths" -b -w $tsconfig_paths

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -18,5 +18,6 @@
     "declaration": true,
     "skipLibCheck": true,
     "composite": true,
+    "importHelpers": true,
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13909,6 +13909,11 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
+tslib@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"


### PR DESCRIPTION
### 📦 Pull Request

Adds `importHelpers: true` to our `tsconfig.json` settings to slightly reduce bundle size and suppress `'this' is undefined` warnings from `microbundle`.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
