### PR TITLE
Remove ES6 Proxy references

### DIFF
--- a/packages/provider/src/modules/base-extension.ts
+++ b/packages/provider/src/modules/base-extension.ts
@@ -33,22 +33,23 @@ abstract class BaseExtension<TName extends string> extends BaseModule {
   constructor() {
     super(undefined as any);
 
-    const sdkAccessFields = ['request', 'transport', 'overlay', 'sdk'];
-
     // Disallow SDK access before initialization.
-    return new Proxy(this, {
-      get: (target, prop, receiver) => {
-        if (sdkAccessFields.includes(prop as string) && !this.isInitialized) {
-          throw createExtensionNotInitializedError(prop as string);
-        }
-
-        return Reflect.get(target, prop, receiver);
-      },
+    ['request', 'transport', 'overlay', 'sdk'].forEach((prop) => {
+      Object.defineProperty(this, prop, {
+        get: () => {
+          if (!this.isInitialized) {
+            throw createExtensionNotInitializedError(prop);
+          } else {
+            return super[prop as keyof BaseModule];
+          }
+        },
+      });
     });
   }
 
   /**
    * Registers a Magic SDK instance with this Extension.
+   *
    * @internal
    */
   public init(sdk: SDKBase) {

--- a/packages/provider/src/modules/base-extension.ts
+++ b/packages/provider/src/modules/base-extension.ts
@@ -92,11 +92,15 @@ abstract class BaseExtension<TName extends string> extends BaseModule {
     // Replace original property descriptors
     // for SDK access fields post-initialization.
     sdkAccessFields.forEach((prop) => {
-      const { descriptor, isPrototypeField } = this.__sdk_access_field_descriptors__.get(prop)!;
-      if (!isPrototypeField) {
-        Object.defineProperty(this, prop, descriptor);
-      } else {
-        delete this[prop as keyof this];
+      /* istanbul ignore else */
+      if (this.__sdk_access_field_descriptors__.has(prop)) {
+        const { descriptor, isPrototypeField } = this.__sdk_access_field_descriptors__.get(prop)!;
+
+        if (isPrototypeField) {
+          delete this[prop as keyof this];
+        } else {
+          Object.defineProperty(this, prop, descriptor);
+        }
       }
     });
 

--- a/packages/provider/src/modules/base-extension.ts
+++ b/packages/provider/src/modules/base-extension.ts
@@ -97,6 +97,8 @@ abstract class BaseExtension<TName extends string> extends BaseModule {
         const { descriptor, isPrototypeField } = this.__sdk_access_field_descriptors__.get(prop)!;
 
         if (isPrototypeField) {
+          // For prototype fields, we just need the `delete` operator so that
+          // the instance will fallback to the prototype chain itself.
           delete this[prop as keyof this];
         } else {
           Object.defineProperty(this, prop, descriptor);

--- a/packages/provider/src/modules/base-module.ts
+++ b/packages/provider/src/modules/base-module.ts
@@ -8,7 +8,7 @@ import { ViewController } from '../core/view-controller';
 import { EventsDefinition } from '../util/events';
 
 export class BaseModule {
-  constructor(protected readonly sdk: SDKBase) {}
+  constructor(protected sdk: SDKBase) {}
 
   /**
    * The `PayloadTransport` for the SDK instance registered to this module.


### PR DESCRIPTION
### 📦 Pull Request

Our usage of ES6 Proxy was breaking support for legacy browsers like IE11. This is a small refactor to remove references to `Proxy`.

### 🚨 Test instructions

`yarn test`, as usual!

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
