### PR TITLE
register "inactive recipient" rpc error code

### DIFF
--- a/packages/types/src/core/exception-types.ts
+++ b/packages/types/src/core/exception-types.ts
@@ -30,6 +30,7 @@ export enum RPCErrorCode {
   UserAlreadyLoggedIn = -10003,
   UpdateEmailFailed = -10004,
   UserRequestEditEmail = -10005,
+  InactiveRecipient = -10010,
 }
 
 export type ErrorCode = SDKErrorCode | RPCErrorCode;


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- https://app.clubhouse.io/magic-labs/story/33482/surface-email-hard-bounce-as-a-user-error-case

### 🚨 Test instructions

Trigger email to a hard bounced email and the sdk should throw error immediately

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
