### PR TITLE
Coerce version with `next` to be recognizable

### DIFF
--- a/packages/@magic-sdk/provider/test/factories.ts
+++ b/packages/@magic-sdk/provider/test/factories.ts
@@ -3,8 +3,7 @@
 import * as memoryDriver from 'localforage-driver-memory';
 import localForage from 'localforage';
 import { MAGIC_RELAYER_FULL_URL, ENCODED_QUERY_PARAMS, TEST_API_KEY } from './constants';
-import { PayloadTransport } from '../src/core/payload-transport';
-import { ViewController } from '../src/core/view-controller';
+import { PayloadTransport, ViewController } from '../src';
 import type { SDKEnvironment } from '../src/core/sdk-environment';
 
 export class TestViewController extends ViewController {


### PR DESCRIPTION
### 📦 Pull Request

When sdk version is `next` or alpha branch version, the compat check will throws an error as it doesn't recognize these versions

### ✅ Fixed Issues

[ch44048]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
