### PR TITLE
Import regeneratorRuntime in Magic JS (non-CDN version)

### DIFF
--- a/packages/@magic-sdk/commons/package.json
+++ b/packages/@magic-sdk/commons/package.json
@@ -17,6 +17,7 @@
   "target": "web",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "exports": "./dist/modern/index.js",
   "types": "./dist/types/index.d.ts",
   "devDependencies": {
     "@magic-sdk/provider": "^6.0.1",

--- a/packages/@magic-sdk/provider/package.json
+++ b/packages/@magic-sdk/provider/package.json
@@ -17,10 +17,10 @@
   "target": "web",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "exports": "./dist/modern/index.js",
   "types": "./dist/types/index.d.ts",
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.9.6",
-    "@babel/plugin-transform-runtime": "^7.9.6",
     "@peculiar/webcrypto": "^1.1.7",
     "eventemitter3": "^4.0.4",
     "localforage": "^1.7.4",

--- a/packages/@magic-sdk/react-native/package.json
+++ b/packages/@magic-sdk/react-native/package.json
@@ -20,8 +20,6 @@
   "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aveq-research/localforage-asyncstorage-driver": "^3.0.1",
-    "@babel/core": "~7.10.4",
-    "@babel/runtime": "~7.10.4",
     "@magic-sdk/commons": "^2.0.1",
     "@magic-sdk/provider": "^6.0.1",
     "@magic-sdk/types": "^5.0.0",
@@ -38,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
+    "@babel/runtime": "~7.10.4",
     "metro-react-native-babel-preset": "^0.66.2",
     "react": "^16.13.1",
     "react-native": "^0.62.2",

--- a/packages/@magic-sdk/types/package.json
+++ b/packages/@magic-sdk/types/package.json
@@ -17,6 +17,7 @@
   "target": "web",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "exports": "./dist/modern/index.js",
   "types": "./dist/types/index.d.ts",
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/magic-sdk/src/index.ts
+++ b/packages/magic-sdk/src/index.ts
@@ -1,5 +1,7 @@
 /* istanbul ignore file */
 
+import 'regenerator-runtime/runtime';
+
 import { SDKBase, createSDK } from '@magic-sdk/provider';
 import localForage from 'localforage';
 import * as memoryDriver from 'localforage-driver-memory';
@@ -13,7 +15,7 @@ export const Magic = createSDK(SDKBase, {
   version: process.env.WEB_VERSION!,
   defaultEndpoint: 'https://auth.magic.link/',
   ViewController: IframeController,
-  configureStorage: /* istanbul ignore next */ async () => {
+  configureStorage: async () => {
     const lf = localForage.createInstance({
       name: 'MagicAuthLocalStorageDB',
       storeName: 'MagicAuthLocalStorage',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,7 +2207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.0.0, @babel/plugin-transform-runtime@npm:^7.9.6":
+"@babel/plugin-transform-runtime@npm:^7.0.0":
   version: 7.10.4
   resolution: "@babel/plugin-transform-runtime@npm:7.10.4"
   dependencies:
@@ -4118,11 +4118,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/commons@^2.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^2.0.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^6.0.0
+    "@magic-sdk/provider": ^6.0.1
     "@magic-sdk/types": ^5.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
@@ -4130,12 +4130,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^6.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^6.0.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@babel/plugin-transform-runtime": ^7.9.6
     "@magic-sdk/types": ^5.0.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
@@ -4156,8 +4155,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^2.0.0
-    "@magic-sdk/provider": ^6.0.0
+    "@magic-sdk/commons": ^2.0.1
+    "@magic-sdk/provider": ^6.0.1
     "@magic-sdk/types": ^5.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -13747,8 +13746,8 @@ fsevents@^1.2.7:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^2.0.0
-    "@magic-sdk/provider": ^6.0.0
+    "@magic-sdk/commons": ^2.0.1
+    "@magic-sdk/provider": ^6.0.1
     "@magic-sdk/types": ^5.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
Fixes an issue where `regneratorRuntime` may be undefined when importing in modern browsers.