### PR TITLE
Change 'externals' and 'global' condition in magic-sdk > CDN build

### DIFF
--- a/packages/magic-sdk/package.json
+++ b/packages/magic-sdk/package.json
@@ -42,4 +42,5 @@
     "localforage-driver-memory": "^1.0.5"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
+
 }

--- a/scripts/bin/wsrun/build-package.ts
+++ b/scripts/bin/wsrun/build-package.ts
@@ -57,14 +57,20 @@ async function modern() {
 async function cdn() {
   const pkgJson = require(`${process.cwd()}/package.json`);
 
+  const isMagicSDK = process.cwd().endsWith('packages/magic-sdk');
+
+  // For CDN targets outside of `magic-sdk` itself,
+  // we assume `magic-sdk` & `@magic-sdk/commons` are external/global.
+  const externals = isMagicSDK ? ['none'] : ['magic-sdk', '@magic-sdk/commons'];
+  const globals = isMagicSDK ? undefined : { 'magic-sdk': 'Magic', '@magic-sdk/commons': 'Magic' };
+
   await build({
     format: 'iife',
     target: pkgJson.target,
     output: pkgJson.jsdelivr,
     name: pkgJson.cdnGlobalName,
-    // For CDN targets, we assume `magic-sdk`, `@magic-sdk/commons` are external/global.
-    externals: ['magic-sdk', '@magic-sdk/commons'],
-    globals: { 'magic-sdk': 'Magic', '@magic-sdk/commons': 'Magic' },
+    externals,
+    globals,
     sourcemap: false,
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4118,14 +4118,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-ext/oauth@^0.9.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^0.9.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/types": ^5.0.3
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^6.0.5
+    magic-sdk: ^6.0.6
   languageName: unknown
   linkType: soft
 
@@ -4133,8 +4133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-oauth@workspace:packages/@magic-ext/react-native-oauth"
   dependencies:
-    "@magic-sdk/react-native": ^6.0.5
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/react-native": ^6.0.6
+    "@magic-sdk/types": ^5.0.3
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     expo-web-browser: ^8.3.1
@@ -4145,16 +4145,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^2.0.5
+    "@magic-sdk/commons": ^2.0.6
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^2.0.5, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^2.0.6, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^6.0.5
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/provider": ^6.0.6
+    "@magic-sdk/types": ^5.0.3
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -4168,17 +4168,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^0.9.0
-    magic-sdk: ^6.0.5
+    "@magic-ext/oauth": ^0.9.1
+    magic-sdk: ^6.0.6
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^6.0.5, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^6.0.6, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/types": ^5.0.3
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -4190,7 +4190,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native@^6.0.5, @magic-sdk/react-native@workspace:packages/@magic-sdk/react-native":
+"@magic-sdk/react-native@^6.0.6, @magic-sdk/react-native@workspace:packages/@magic-sdk/react-native":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native@workspace:packages/@magic-sdk/react-native"
   dependencies:
@@ -4198,9 +4198,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^2.0.5
-    "@magic-sdk/provider": ^6.0.5
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/commons": ^2.0.6
+    "@magic-sdk/provider": ^6.0.6
+    "@magic-sdk/types": ^5.0.3
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -4221,7 +4221,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^5.0.2, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^5.0.3, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -13895,16 +13895,16 @@ fsevents@^1.2.7:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^6.0.5, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^6.0.6, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^2.0.5
-    "@magic-sdk/provider": ^6.0.5
-    "@magic-sdk/types": ^5.0.2
+    "@magic-sdk/commons": ^2.0.6
+    "@magic-sdk/provider": ^6.0.6
+    "@magic-sdk/types": ^5.0.3
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
Fixes an issue where `OAuthExtension` was incompatible with Magic SDK via CDN.