### PR TITLE
Fix bug with `d.generateKey is undefined` build bug

### DIFF
--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -56,7 +56,7 @@ export async function createJwt() {
   const data = strToUint8(`${jws.protected}.${jws.claims}`);
   const sigType = { name: ALGO_NAME, hash: { name: 'SHA-256' } };
 
-  const sig = uint8ToUrlBase64(new Uint8Array(await crypto.subtle.sign(sigType, privateJwk, data)));
+  const sig = uint8ToUrlBase64(new Uint8Array(await subtle.sign(sigType, privateJwk, data)));
   return `${jws.protected}.${jws.claims}.${sig}`;
 }
 


### PR DESCRIPTION
### 📦 Pull Request

CDN bundles were affected by a mysterious `d.generateKey is undefined` bug. This would not break the user experience, but did prevent our session persistence mechanism from working correctly. Turns out the issue is related to a Babel plugin hoisting bug related to `async/await`.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
