### PR TITLE
Revert to `.js` extension for ES module builds targeting webpack/CRA

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -14,7 +14,7 @@
   "target": "web",
   "cdnGlobalName": "MagicOAuthExtension",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
   "exports": {

--- a/packages/@magic-ext/react-native-oauth/package.json
+++ b/packages/@magic-ext/react-native-oauth/package.json
@@ -13,7 +13,7 @@
   ],
   "target": "node",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/modern/index.mjs",

--- a/packages/@magic-ext/webauthn/package.json
+++ b/packages/@magic-ext/webauthn/package.json
@@ -14,7 +14,7 @@
   "target": "web",
   "cdnGlobalName": "MagicWebAuthnExtension",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
   "react-native": "./dist/react-native/index.native.js",

--- a/packages/@magic-sdk/commons/package.json
+++ b/packages/@magic-sdk/commons/package.json
@@ -14,7 +14,7 @@
   ],
   "target": "web",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/modern/index.mjs",

--- a/packages/@magic-sdk/provider/package.json
+++ b/packages/@magic-sdk/provider/package.json
@@ -14,7 +14,7 @@
   ],
   "target": "web",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/modern/index.mjs",

--- a/packages/@magic-sdk/react-native/package.json
+++ b/packages/@magic-sdk/react-native/package.json
@@ -14,7 +14,7 @@
   ],
   "target": "node",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
     "@aveq-research/localforage-asyncstorage-driver": "^3.0.1",

--- a/packages/@magic-sdk/types/package.json
+++ b/packages/@magic-sdk/types/package.json
@@ -14,7 +14,7 @@
   ],
   "target": "web",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/modern/index.mjs",

--- a/packages/magic-sdk/package.json
+++ b/packages/magic-sdk/package.json
@@ -15,7 +15,7 @@
   "target": "web",
   "cdnGlobalName": "Magic",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/magic.js",
   "exports": {

--- a/scripts/bin/scaffold/template/hybrid/package.json
+++ b/scripts/bin/scaffold/template/hybrid/package.json
@@ -12,7 +12,7 @@
   "target": "web",
   "cdnGlobalName": "<%= cdnGlobalName %>",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
   "react-native": "./dist/react-native/index.native.js",

--- a/scripts/bin/scaffold/template/react-native/package.json
+++ b/scripts/bin/scaffold/template/react-native/package.json
@@ -11,7 +11,7 @@
   "files": ["dist"],
   "target": "node",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/modern/index.mjs",

--- a/scripts/bin/scaffold/template/web/package.json
+++ b/scripts/bin/scaffold/template/web/package.json
@@ -12,7 +12,7 @@
   "target": "web",
   "cdnGlobalName": "<%= cdnGlobalName %>",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.mjs",
+  "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4118,14 +4118,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-ext/oauth@^0.10.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^0.10.3, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/types": ^5.1.3
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^6.1.2
+    magic-sdk: ^6.1.3
   languageName: unknown
   linkType: soft
 
@@ -4133,8 +4133,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-oauth@workspace:packages/@magic-ext/react-native-oauth"
   dependencies:
-    "@magic-sdk/react-native": ^6.1.2
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/react-native": ^6.1.3
+    "@magic-sdk/types": ^5.1.3
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     expo-web-browser: ^8.3.1
@@ -4145,16 +4145,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^2.1.2
+    "@magic-sdk/commons": ^2.1.3
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^2.1.2, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^2.1.3, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^6.1.2
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/provider": ^6.1.3
+    "@magic-sdk/types": ^5.1.3
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -4168,17 +4168,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^0.10.2
-    magic-sdk: ^6.1.2
+    "@magic-ext/oauth": ^0.10.3
+    magic-sdk: ^6.1.3
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^6.1.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^6.1.3, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/types": ^5.1.3
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -4190,7 +4190,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native@^6.1.2, @magic-sdk/react-native@workspace:packages/@magic-sdk/react-native":
+"@magic-sdk/react-native@^6.1.3, @magic-sdk/react-native@workspace:packages/@magic-sdk/react-native":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native@workspace:packages/@magic-sdk/react-native"
   dependencies:
@@ -4198,9 +4198,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^2.1.2
-    "@magic-sdk/provider": ^6.1.2
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/commons": ^2.1.3
+    "@magic-sdk/provider": ^6.1.3
+    "@magic-sdk/types": ^5.1.3
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -4221,7 +4221,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^5.1.2, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^5.1.3, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -13895,16 +13895,16 @@ fsevents@^1.2.7:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^6.1.2, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^6.1.3, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^2.1.2
-    "@magic-sdk/provider": ^6.1.2
-    "@magic-sdk/types": ^5.1.2
+    "@magic-sdk/commons": ^2.1.3
+    "@magic-sdk/provider": ^6.1.3
+    "@magic-sdk/types": ^5.1.3
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

By addressing #229 via #230, we accidentally broke older versions of Webpack compatibility and specifically `create-react-app`, which does not support `.mjs` by default. To fix this, we revert to `.js` for the index file specified by `package.json#module`.
