### PR TITLE
Add support for `data-locale` parameter in `@magic-sdk/pnp`

### DIFF
--- a/packages/@magic-sdk/pnp/src/context/callback.ts
+++ b/packages/@magic-sdk/pnp/src/context/callback.ts
@@ -5,11 +5,11 @@ import { dispatchReadyEvent } from '../utils/events';
 export async function callback(): Promise<void> {
   // In this context, `loginURI` and `redirectURI` are the same.
   // We simply need a location to redirect to upon callback failure.
-  const { src, apiKey, loginURI, redirectURI = window.location.origin } = getScriptData();
+  const { src, apiKey, locale, loginURI, redirectURI = window.location.origin } = getScriptData();
 
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
-  const magic = createMagicInstance(apiKey, src.origin);
+  const magic = createMagicInstance(apiKey, src.origin, locale);
 
   function clearURLQuery() {
     const urlWithoutQuery = window.location.origin + window.location.pathname;

--- a/packages/@magic-sdk/pnp/src/context/login.ts
+++ b/packages/@magic-sdk/pnp/src/context/login.ts
@@ -2,9 +2,9 @@ import { getScriptData } from '../utils/script-data';
 import { createMagicInstance } from '../utils/magic-instance';
 
 export async function login(): Promise<void> {
-  const { src, apiKey, redirectURI = `${window.location.origin}/callback`, debug } = getScriptData();
+  const { src, apiKey, locale, redirectURI = `${window.location.origin}/callback`, debug } = getScriptData();
 
-  const magic = createMagicInstance(apiKey, src.origin);
+  const magic = createMagicInstance(apiKey, src.origin, locale);
 
   async function handleOAuthLogin(provider: any) {
     await magic.pnp.saveLastUsedProvider(provider);

--- a/packages/@magic-sdk/pnp/src/context/logout.ts
+++ b/packages/@magic-sdk/pnp/src/context/logout.ts
@@ -4,8 +4,8 @@ import { createMagicInstance } from '../utils/magic-instance';
 export async function logout(): Promise<void> {
   // In this context, `loginURI` and `redirectURI` are the same.
   // We simply need a location to redirect to after attempting to logout.
-  const { src, apiKey, loginURI, redirectURI = window.location.origin } = getScriptData();
-  const magic = createMagicInstance(apiKey, src.origin);
+  const { src, apiKey, locale, loginURI, redirectURI = window.location.origin } = getScriptData();
+  const magic = createMagicInstance(apiKey, src.origin, locale);
   await magic.user.logout().catch(() => {});
   window.location.href = loginURI || redirectURI;
 }

--- a/packages/@magic-sdk/pnp/src/context/settings.ts
+++ b/packages/@magic-sdk/pnp/src/context/settings.ts
@@ -8,11 +8,12 @@ export async function settings(): Promise<void> {
   const {
     src,
     apiKey,
+    locale,
     redirectURI = `${window.location.origin}/callback`,
     loginURI = window.location.origin,
   } = getScriptData();
 
-  const magic = createMagicInstance(apiKey, src.origin);
+  const magic = createMagicInstance(apiKey, src.origin, locale);
 
   try {
     const prevUserMetadata = magic.pnp.encodeUserMetadata(await magic.user.getMetadata());

--- a/packages/@magic-sdk/pnp/src/utils/magic-instance.ts
+++ b/packages/@magic-sdk/pnp/src/utils/magic-instance.ts
@@ -1,7 +1,11 @@
 import { PlugNPlayExtension } from '../pnp-extension';
 import type { Magic, OAuthExtension } from '../types';
 
-export function createMagicInstance(apiKey?: string, endpoint?: string): Magic<[PlugNPlayExtension, OAuthExtension]> {
+export function createMagicInstance(
+  apiKey?: string,
+  endpoint?: string,
+  locale?: string,
+): Magic<[PlugNPlayExtension, OAuthExtension]> {
   const extensions = removeFalsey([
     new PlugNPlayExtension(),
     window.MagicOAuthExtension && new window.MagicOAuthExtension(),
@@ -9,6 +13,7 @@ export function createMagicInstance(apiKey?: string, endpoint?: string): Magic<[
 
   return new window.Magic(apiKey!, {
     endpoint,
+    locale: locale as any, // locale is strongly-typed as exact strings, so we have to cast to any here.
     extensions,
   });
 }

--- a/packages/@magic-sdk/pnp/src/utils/script-data.ts
+++ b/packages/@magic-sdk/pnp/src/utils/script-data.ts
@@ -1,15 +1,28 @@
+/* eslint-disable prefer-destructuring */
+
 const allPossiblePNPScripts = document.querySelectorAll('script[data-magic-publishable-api-key]');
 const thisScript = (document.currentScript ??
   allPossiblePNPScripts[allPossiblePNPScripts.length - 1]) as HTMLScriptElement;
 
 export function getScriptData() {
   const src = new URL(thisScript.getAttribute('src')!);
+
+  // Values derived from `data-*` attributes
   const apiKey = thisScript.dataset.magicPublishableApiKey;
-  const debug = !!thisScript.dataset.debug;
+  const locale = thisScript.dataset.locale;
   const redirectURI = getAbsoluteURL(thisScript.dataset.redirectUri);
   const loginURI = getAbsoluteURL(thisScript.dataset.loginUri);
+  const debug = !!thisScript.dataset.debug;
 
-  return { script: thisScript, src, apiKey, redirectURI, loginURI, debug };
+  return {
+    script: thisScript,
+    src,
+    apiKey,
+    locale,
+    redirectURI,
+    loginURI,
+    debug,
+  };
 }
 
 export type ScriptData = ReturnType<typeof getScriptData>;


### PR DESCRIPTION
Adds support for all of Magic SDK's localization features to `@magic-sdk/pnp`, which provides the frontend for [Magic Login Form](https://magic.link/docs/login-form).
