### PR TITLE
Remove 'semver' re-export from '@magic-sdk/provider' utils

### DIFF
--- a/packages/@magic-sdk/provider/src/util/index.ts
+++ b/packages/@magic-sdk/provider/src/util/index.ts
@@ -2,7 +2,6 @@ export * from './base64-json';
 export * from './events';
 export * from './get-payload-id';
 export * from './promise-tools';
-export * as semver from './semver';
 export * as storage from './storage';
 export * from './type-guards';
 export * from './url';


### PR DESCRIPTION
### 📦 Pull Request

Removes the (unnecessary) `export * as semver from './semver'` statement in `@magic-sdk/provider/src/utils/index.ts`.

### ✅ Fixed Issues

- Fixes #235 