### PR TITLE
move crypto-js to devDependencies to fix bundling error

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -27,10 +27,10 @@
     ]
   },
   "dependencies": {
-    "@magic-sdk/types": "^5.2.0",
-    "crypto-js": "^3.3.0"
+    "@magic-sdk/types": "^5.2.0"
   },
   "devDependencies": {
+    "crypto-js": "^3.3.0",
     "@types/crypto-js": "~3.1.47",
     "magic-sdk": "^6.2.1"
   }


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

This fixes the error (below) users on Next.js v12 would run into when starting their app.

```
Cannot find module '/.../node_modules/crypto-js/sha256' imported from /.../node_modules/@magic-ext/oauth/dist/modern/index.mjs
Did you mean to import crypto-js/sha256.js?`
```

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
