### PR TITLE
Deprecate test API key

### DIFF
--- a/packages/@magic-sdk/types/src/index.ts
+++ b/packages/@magic-sdk/types/src/index.ts
@@ -1,4 +1,5 @@
 // Only re-export types that are intended for the public API from this file.
+// Deprecate test API key in v7.0.0
 
 export * from './core/exception-types';
 export * from './core/i18n';

--- a/packages/magic-sdk/CHANGELOG.md
+++ b/packages/magic-sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # v6.1.4 (Thu Oct 21 2021)
 
+# v6.0.0 (Tue Sep 14 2021)
+
+#### 💥 Breaking Change
+
+- v7.0.0 Deprecate test API key
+
+#### Authors: 1
+
+- Harry ([harryEth](https://github.com/harryEth))
+
+---
+
 #### 🐛 Bug Fix
 
 - Revert to `.js` extension for ES module builds targeting webpack/CRA [#232](https://github.com/magiclabs/magic-js/pull/232) ([@smithki](https://github.com/smithki))

--- a/packages/magic-sdk/CHANGELOG.md
+++ b/packages/magic-sdk/CHANGELOG.md
@@ -1,17 +1,5 @@
 # v6.1.4 (Thu Oct 21 2021)
 
-# v6.0.0 (Tue Sep 14 2021)
-
-#### 💥 Breaking Change
-
-- v7.0.0 Deprecate test API key
-
-#### Authors: 1
-
-- Harry ([harryEth](https://github.com/harryEth))
-
----
-
 #### 🐛 Bug Fix
 
 - Revert to `.js` extension for ES module builds targeting webpack/CRA [#232](https://github.com/magiclabs/magic-js/pull/232) ([@smithki](https://github.com/smithki))

--- a/packages/magic-sdk/src/index.ts
+++ b/packages/magic-sdk/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+// Deprecate test API key in v7.0.0
 
 import { SDKBase, createSDK, InstanceWithExtensions, MagicSDKExtensionsOption } from '@magic-sdk/provider';
 import localForage from 'localforage';


### PR DESCRIPTION
### 📦 Pull Request

Deprecate test API key

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `major`: Breaking Change: Deprecate test API key

