### PR TITLE
Added `"./package.json"` to `"exports"` field

### DIFF
--- a/packages/@magic-ext/solana/package.json
+++ b/packages/@magic-ext/solana/package.json
@@ -20,7 +20,8 @@
   "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "./package.json": "./package.json"
   },
   "externals": {
     "include": [


### PR DESCRIPTION
### 📦 Pull Request

When importing to react native an error message is appearing: 
```
warn Package @magic-ext/solana has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in node_modules/@magic-ext/solana/package.json
```

Not sure if this is causing any issues but it is best practices to export the package.json if exports are defined. 

### ✅ Fixed Issues

Fixes #272 

### 🚨 Test instructions

Add to a react native android app and make sure the warning doesn't appear. 

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix
