### PR TITLE
Bump version of expo-web-browser for @magic-ext/react-native-oauth

### DIFF
--- a/packages/@magic-ext/react-native-oauth/package.json
+++ b/packages/@magic-ext/react-native-oauth/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@magic-sdk/types": "^7.1.0",
     "crypto-js": "^3.3.0",
-    "expo-web-browser": "^8.3.1"
+    "expo-web-browser": "^10.1.1"
   },
   "devDependencies": {
     "@magic-sdk/react-native": "^8.2.0",


### PR DESCRIPTION
### 📦 Pull Request

Bump `expo-web-browser` to `10.1.1` to improve compatibility with expo >=`^expo@43.0.0-beta`.
More https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc 

