### PR TITLE
Fix @magic-ext/harmony exports field for yarn pnp strict

### DIFF
--- a/packages/@magic-ext/harmony/package.json
+++ b/packages/@magic-ext/harmony/package.json
@@ -21,7 +21,7 @@
   "jsdelivr": "./dist/extension.js",
   "react-native": "./dist/react-native/index.native.js",
   "exports": {
-    "import": "./dist/es/index.mjs",
+    "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
   "externals": {


### PR DESCRIPTION
@magic-ext/harmony dist folder outputs index.js file - not index.mjs.

### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
