### PR TITLE
Enable bundle Id in Expo

### DIFF
--- a/packages/@magic-sdk/provider/src/core/sdk-environment.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk-environment.ts
@@ -16,7 +16,7 @@ export interface SDKEnvironment {
   defaultEndpoint: string;
   ViewController: ConstructorOf<ViewController>;
   configureStorage: () => Promise<typeof localForage>;
-  bundleId: string | null;
+  bundleId?: string | null;
 }
 
 export const SDKEnvironment: SDKEnvironment = {} as any;

--- a/packages/@magic-sdk/provider/src/core/sdk-environment.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk-environment.ts
@@ -16,6 +16,7 @@ export interface SDKEnvironment {
   defaultEndpoint: string;
   ViewController: ConstructorOf<ViewController>;
   configureStorage: () => Promise<typeof localForage>;
+  bundleId: string | null;
 }
 
 export const SDKEnvironment: SDKEnvironment = {} as any;

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -151,7 +151,7 @@ export class SDKBase {
       version,
       ext: isEmpty(extConfig) ? undefined : extConfig,
       locale: options?.locale || 'en_US',
-      bundleId: SDKEnvironment.bundleId || 'BundleIDMissing',
+      ...(SDKEnvironment.bundleId && { bundleId: SDKEnvironment.bundleId || 'BundleIDMissing' }),
     });
   }
 

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -151,6 +151,7 @@ export class SDKBase {
       version,
       ext: isEmpty(extConfig) ? undefined : extConfig,
       locale: options?.locale || 'en_US',
+      bundleId: SDKEnvironment.bundleId || 'BundleIDMissing',
     });
   }
 

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -151,7 +151,7 @@ export class SDKBase {
       version,
       ext: isEmpty(extConfig) ? undefined : extConfig,
       locale: options?.locale || 'en_US',
-      ...(SDKEnvironment.bundleId && { bundleId: SDKEnvironment.bundleId || 'BundleIDMissing' }),
+      ...(SDKEnvironment.bundleId ? { bundleId: SDKEnvironment.bundleId } : {}),
     });
   }
 

--- a/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
@@ -298,3 +298,19 @@ test('Initialize `Magic RN SDK`', () => {
   assertEncodedQueryParams(magic.parameters, { bundleId: bundleIdMock, sdk: 'magic-sdk-rn' });
   assertModuleInstanceTypes(magic);
 });
+
+test('Initialize `Magic RN SDK without bundleId`', () => {
+  const Ctor = createMagicSDKCtor({
+    sdkName: '@magic-sdk/react-native',
+    platform: 'react-native',
+    bundleId: null,
+  });
+  const magic = new Ctor(TEST_API_KEY);
+
+  expect(magic.apiKey).toBe(TEST_API_KEY);
+
+  expect(magic.endpoint).toBe(MAGIC_RELAYER_FULL_URL);
+
+  assertEncodedQueryParams(magic.parameters, { sdk: 'magic-sdk-rn' });
+  assertModuleInstanceTypes(magic);
+});

--- a/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
@@ -281,3 +281,20 @@ test('Does not warn upon construction of `MagicSDK` instance if `endpoint` param
   new Ctor(TEST_API_KEY);
   expect(consoleWarnStub).not.toBeCalled();
 });
+
+test('Initialize `Magic RN SDK`', () => {
+  const bundleIdMock = 'link.magic.test';
+  const Ctor = createMagicSDKCtor({
+    sdkName: '@magic-sdk/react-native',
+    platform: 'react-native',
+    bundleId: bundleIdMock,
+  });
+  const magic = new Ctor(TEST_API_KEY);
+
+  expect(magic.apiKey).toBe(TEST_API_KEY);
+
+  expect(magic.endpoint).toBe(MAGIC_RELAYER_FULL_URL);
+
+  assertEncodedQueryParams(magic.parameters, { bundleId: bundleIdMock, sdk: 'magic-sdk-rn' });
+  assertModuleInstanceTypes(magic);
+});

--- a/packages/@magic-sdk/react-native/jest.config.ts
+++ b/packages/@magic-sdk/react-native/jest.config.ts
@@ -8,7 +8,22 @@ const config: Config.InitialOptions = {
     '^.+\\.(js|jsx)$': 'babel-jest',
     '\\.(ts|tsx)$': 'ts-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!react-native|react-native-webview)'],
+  transformIgnorePatterns: [
+    "node_modules/(" +
+    "?!(jest-)?react-native" +
+    "|react-clone-referenced-element" +
+    "|@react-native-community" +
+    "|expo(nent)?" +
+    "|@expo(nent)?/.*" +
+    "|react-navigation" +
+    "|@react-navigation/.*" +
+    "|@unimodules/.*" +
+    "|unimodules" +
+    "|sentry-expo" +
+    "|native-base" +
+    "|@sentry/.*" +
+    "|native-base-*)"
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };
 

--- a/packages/@magic-sdk/react-native/package.json
+++ b/packages/@magic-sdk/react-native/package.json
@@ -36,12 +36,14 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/runtime": "~7.10.4",
+    "expo-modules-core": "0.9.2",
     "metro-react-native-babel-preset": "^0.66.2",
     "react": "^16.13.1",
     "react-native": "^0.62.2",
     "react-native-webview": "8.1.2"
   },
   "peerDependencies": {
+    "expo": "*",
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-webview": ">=8"

--- a/packages/@magic-sdk/react-native/package.json
+++ b/packages/@magic-sdk/react-native/package.json
@@ -24,6 +24,7 @@
     "@react-native-async-storage/async-storage": "^1.15.5",
     "@types/lodash": "^4.14.158",
     "buffer": "~5.6.0",
+    "expo-application": "^4.1.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",

--- a/packages/@magic-sdk/react-native/src/index.ts
+++ b/packages/@magic-sdk/react-native/src/index.ts
@@ -15,6 +15,7 @@ import localForage from 'localforage';
 import { URL as URLPolyfill, URLSearchParams as URLSearchParamsPolyfill } from 'whatwg-url';
 import { Buffer } from 'buffer';
 import * as _ from 'lodash';
+import * as Application from 'expo-application';
 import { driverWithoutSerialization } from '@aveq-research/localforage-asyncstorage-driver';
 import * as memoryDriver from 'localforage-driver-memory';
 import { ReactNativeWebViewController } from './react-native-webview-controller';
@@ -47,6 +48,7 @@ export const Magic = createSDK(SDKBaseReactNative, {
   platform: 'react-native',
   sdkName: '@magic-sdk/react-native',
   version: process.env.REACT_NATIVE_VERSION!,
+  bundleId: Application.applicationId,
   defaultEndpoint: 'https://box.magic.link/',
   ViewController: ReactNativeWebViewController,
   configureStorage: /* istanbul ignore next */ async () => {

--- a/packages/@magic-sdk/types/src/core/query-types.ts
+++ b/packages/@magic-sdk/types/src/core/query-types.ts
@@ -12,4 +12,5 @@ export interface QueryParameters {
   version?: string;
   ext?: any;
   locale?: string;
+  bundleId?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,6 +3369,7 @@ __metadata:
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
+    expo-application: ^4.1.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
     lodash: ^4.17.19
@@ -8647,6 +8648,15 @@ __metadata:
     jest-message-util: ^27.0.6
     jest-regex-util: ^27.0.6
   checksum: 26e63420b00620dffd3a7e98db9e815a31b2787930823a89d01fcc008b9827bd734e8104c58b91493054636fbc3b123cbaa48da5dc24b16ebe641b7ee98adeab
+  languageName: node
+  linkType: hard
+
+"expo-application@npm:^4.1.0":
+  version: 4.2.2
+  resolution: "expo-application@npm:4.2.2"
+  peerDependencies:
+    expo: "*"
+  checksum: c6088014fb0c89f8c04633c50fed4515c5ec67b582b9660824cbd9b30de849b0be0ac8a858d49b63da73b6bb2171d29048321f25d8bbc89effbe31717eb8ee99
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,6 +3370,7 @@ __metadata:
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
     expo-application: ^4.1.0
+    expo-modules-core: 0.9.2
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
     lodash: ^4.17.19
@@ -3381,6 +3382,7 @@ __metadata:
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
+    expo: "*"
     react: ">=16"
     react-native: ">=0.60"
     react-native-webview: ">=8"
@@ -6570,6 +6572,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compare-versions@npm:^3.4.0":
+  version: 3.6.0
+  resolution: "compare-versions@npm:3.6.0"
+  checksum: 7492a50cdaa2c27f5254eee7c4b38856e1c164991bab3d98d7fd067fe4b570d47123ecb92523b78338be86aa221668fd3868bfe8caa5587dc3ebbe1a03d52b5d
+  languageName: node
+  linkType: hard
+
 "component-emitter@npm:^1.2.1":
   version: 1.3.0
   resolution: "component-emitter@npm:1.3.0"
@@ -8657,6 +8666,16 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: c6088014fb0c89f8c04633c50fed4515c5ec67b582b9660824cbd9b30de849b0be0ac8a858d49b63da73b6bb2171d29048321f25d8bbc89effbe31717eb8ee99
+  languageName: node
+  linkType: hard
+
+"expo-modules-core@npm:0.9.2":
+  version: 0.9.2
+  resolution: "expo-modules-core@npm:0.9.2"
+  dependencies:
+    compare-versions: ^3.4.0
+    invariant: ^2.2.4
+  checksum: cc7a5efa50cdd193f3240c824276eae2aad4bbae256607529df6f039c9db3cea5bd898002096fb152026abeca33fc46755d3ea68644c7b25dfdb913d9cef383e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Sending bundle iD by using the Expo Application API
This change is a major bump that will completely disable bare-RN use case. 

### ✅ Fixed Issues

[SC54819](https://app.shortcut.com/magic-labs/story/54819/earncarrot-whitelist-mobile-app-feature-blocking-users)

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
