### PR TITLE
bump web-expo-browser version

### DIFF
--- a/packages/@magic-ext/react-native-oauth/package.json
+++ b/packages/@magic-ext/react-native-oauth/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@magic-sdk/types": "^8.0.0",
     "crypto-js": "^3.3.0",
-    "expo-web-browser": "^8.3.1"
+    "expo-web-browser": "^11.0.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native": "^8.2.1",

--- a/packages/@magic-ext/react-native-oauth/src/index.ts
+++ b/packages/@magic-ext/react-native-oauth/src/index.ts
@@ -27,7 +27,7 @@ export class OAuthExtension extends Extension.Internal<'oauth'> {
          * Response Type
          * https://docs.expo.io/versions/latest/sdk/webbrowser/#returns
          */
-        const res = await WebBrowser.openAuthSessionAsync(url, redirectURI);
+        const res = await WebBrowser.openAuthSessionAsync(url, redirectURI, {});
 
         if (res.type === 'success') {
           const queryString = new URL(res.url).search;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,7 +3162,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3170,7 +3170,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3178,7 +3178,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3186,7 +3186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3194,7 +3194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    magic-sdk: ^8.1.1
+    magic-sdk: ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -3202,7 +3202,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3210,7 +3210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -3223,7 +3223,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3231,7 +3231,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3239,18 +3239,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^2.1.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^3.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^7.1.1
+    "@magic-sdk/types": ^8.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^8.1.1
+    magic-sdk: ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -3258,7 +3258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3267,10 +3267,10 @@ __metadata:
   resolution: "@magic-ext/react-native-oauth@workspace:packages/@magic-ext/react-native-oauth"
   dependencies:
     "@magic-sdk/react-native": ^8.2.1
-    "@magic-sdk/types": ^7.1.1
+    "@magic-sdk/types": ^8.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    expo-web-browser: ^8.3.1
+    expo-web-browser: ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -3278,7 +3278,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3286,7 +3286,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3294,7 +3294,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3302,7 +3302,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3310,7 +3310,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -3318,21 +3318,31 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^4.1.1
+    "@magic-sdk/commons": ^5.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^4.1.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^5.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^8.1.1
-    "@magic-sdk/types": ^7.1.1
+    "@magic-sdk/provider": ^9.0.0
+    "@magic-sdk/types": ^8.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
   languageName: unknown
   linkType: soft
+
+"@magic-sdk/commons@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@magic-sdk/commons@npm:4.1.1"
+  peerDependencies:
+    "@magic-sdk/provider": ">=4.3.0"
+    "@magic-sdk/types": ">=3.1.1"
+  checksum: 82d9078014341d9672cdbbc240cd880786fdb021649246e49374790ca1104d11f2f48fdef3db5af6a45b82cdd1666d628a1bc4c107647fe970b22ec72d891e40
+  languageName: node
+  linkType: hard
 
 "@magic-sdk/pnp@workspace:packages/@magic-sdk/pnp":
   version: 0.0.0-use.local
@@ -3341,17 +3351,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^2.1.1
-    magic-sdk: ^8.1.1
+    "@magic-ext/oauth": ^3.0.0
+    magic-sdk: ^9.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^8.1.1, @magic-sdk/provider@^8.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^9.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^7.1.1
+    "@magic-sdk/types": ^8.0.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3362,6 +3372,19 @@ __metadata:
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft
+
+"@magic-sdk/provider@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "@magic-sdk/provider@npm:8.2.0"
+  dependencies:
+    "@magic-sdk/types": ^7.1.1
+    eventemitter3: ^4.0.4
+    web3-core: 1.5.2
+  peerDependencies:
+    localforage: ^1.7.4
+  checksum: 3be19d1926c26cc3a9490e8f364d1883d776c494496ac2d44176ef7b48ae612061663f3ee7e6a5c136fefd46f3f7070f6873470d06b4c40caaa7442db61c0498
+  languageName: node
+  linkType: hard
 
 "@magic-sdk/react-native@npm:^8.2.1":
   version: 8.2.1
@@ -3396,9 +3419,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^4.1.1
-    "@magic-sdk/provider": ^8.2.0
-    "@magic-sdk/types": ^7.2.0
+    "@magic-sdk/commons": ^5.0.0
+    "@magic-sdk/provider": ^9.0.0
+    "@magic-sdk/types": ^8.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3422,11 +3445,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^7.1.1, @magic-sdk/types@^7.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^8.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
   linkType: soft
+
+"@magic-sdk/types@npm:^7.1.1":
+  version: 7.2.0
+  resolution: "@magic-sdk/types@npm:7.2.0"
+  checksum: 1a74c9bb6a241b60c3e70c051963f5cf4031a2bda4c7c4c7ffced961b8fea7ff2f276fbe3e23bfc1a7cddc6599e690fd8a306ee90bf4e9570132e6ef567df63d
+  languageName: node
+  linkType: hard
 
 "@mrmlnc/readdir-enhanced@npm:^2.2.1":
   version: 2.2.1
@@ -8712,15 +8742,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-web-browser@npm:^8.3.1":
-  version: 8.6.0
-  resolution: "expo-web-browser@npm:8.6.0"
+"expo-web-browser@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "expo-web-browser@npm:11.0.0"
   dependencies:
     compare-urls: ^2.0.0
   peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: e4c105e91751ed9074903d05d1dd0ff69e6c52a46c0b62c131a104a2a8388783accb07dee73d920948bad8c6d9dbe355ac261afe121202e073f7a2f1c487eee3
+    expo: "*"
+  checksum: 93740703b138d4470786387772aafbe3f37e484f052ffeb7fed97d16077ce1fdbf3f1370c603ced6e134343bf5cc4e314eaedf22a6460a608e38a6a1af8deae4
   languageName: node
   linkType: hard
 
@@ -12660,16 +12689,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^8.1.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^9.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^4.1.1
-    "@magic-sdk/provider": ^8.1.1
-    "@magic-sdk/types": ^7.1.1
+    "@magic-sdk/commons": ^5.0.0
+    "@magic-sdk/provider": ^9.0.0
+    "@magic-sdk/types": ^8.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

This version bump will get rid of the dependency of unimodules

### ✅ Fixed Issues

https://app.shortcut.com/magic-labs/story/57975/react-native-oauth-ext-unimodules-deprecated

### 🚨 Test instructions



### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
