### PR TITLE
task: Decouple expo web browser from RN ext oauth

### DIFF
--- a/packages/@magic-ext/react-native-oauth/package.json
+++ b/packages/@magic-ext/react-native-oauth/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@magic-sdk/types": "^9.0.0",
     "crypto-js": "^3.3.0",
-    "expo-web-browser": "^11.0.0"
+    "react-native-inappbrowser-reborn": "^3.7.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native": "^8.2.1",

--- a/packages/@magic-ext/react-native-oauth/src/index.ts
+++ b/packages/@magic-ext/react-native-oauth/src/index.ts
@@ -1,4 +1,4 @@
-import * as WebBrowser from 'expo-web-browser';
+import { InAppBrowser as WebBrowser } from 'react-native-inappbrowser-reborn';
 import { Extension } from '@magic-sdk/react-native';
 import { createCryptoChallenge } from './crypto';
 import {
@@ -27,7 +27,7 @@ export class OAuthExtension extends Extension.Internal<'oauth'> {
          * Response Type
          * https://docs.expo.io/versions/latest/sdk/webbrowser/#returns
          */
-        const res = await WebBrowser.openAuthSessionAsync(url, redirectURI, {});
+        const res = await WebBrowser.openAuth(url, redirectURI, {});
 
         if (res.type === 'success') {
           const queryString = new URL(res.url).search;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,7 +3162,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3170,7 +3170,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3178,7 +3178,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3186,7 +3186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3194,7 +3194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    magic-sdk: ^9.1.0
+    magic-sdk: ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -3202,7 +3202,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3210,7 +3210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3218,7 +3218,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -3231,7 +3231,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3239,7 +3239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3247,18 +3247,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^3.1.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^4.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/types": ^9.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^9.1.0
+    magic-sdk: ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -3266,7 +3266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3275,10 +3275,10 @@ __metadata:
   resolution: "@magic-ext/react-native-oauth@workspace:packages/@magic-ext/react-native-oauth"
   dependencies:
     "@magic-sdk/react-native": ^8.2.1
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/types": ^9.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    expo-web-browser: ^11.0.0
+    react-native-inappbrowser-reborn: ^3.7.0
   languageName: unknown
   linkType: soft
 
@@ -3286,7 +3286,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3294,7 +3294,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3302,7 +3302,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3310,7 +3310,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3318,7 +3318,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
@@ -3326,16 +3326,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^5.1.0
+    "@magic-sdk/commons": ^6.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^5.1.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^6.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^9.1.0
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/provider": ^10.0.0
+    "@magic-sdk/types": ^9.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -3359,17 +3359,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^3.1.0
-    magic-sdk: ^9.1.0
+    "@magic-ext/oauth": ^4.0.0
+    magic-sdk: ^10.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^9.1.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^10.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/types": ^9.0.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3427,9 +3427,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^5.1.0
-    "@magic-sdk/provider": ^9.1.0
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/provider": ^10.0.0
+    "@magic-sdk/types": ^9.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3453,7 +3453,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^8.1.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^9.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -6634,15 +6634,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compare-urls@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "compare-urls@npm:2.0.0"
-  dependencies:
-    normalize-url: ^2.0.1
-  checksum: 706a305fcbafac63e3e3dafe71283b2fbef05ed18f64636e13bf201cdca164ff16463a7004023535497828f69b822ce44c3b43fcaa0e99d8976b26b1f326595c
-  languageName: node
-  linkType: hard
-
 "compare-versions@npm:^3.4.0":
   version: 3.6.0
   resolution: "compare-versions@npm:3.6.0"
@@ -8747,17 +8738,6 @@ __metadata:
     compare-versions: ^3.4.0
     invariant: ^2.2.4
   checksum: cc7a5efa50cdd193f3240c824276eae2aad4bbae256607529df6f039c9db3cea5bd898002096fb152026abeca33fc46755d3ea68644c7b25dfdb913d9cef383e
-  languageName: node
-  linkType: hard
-
-"expo-web-browser@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "expo-web-browser@npm:11.0.0"
-  dependencies:
-    compare-urls: ^2.0.0
-  peerDependencies:
-    expo: "*"
-  checksum: 93740703b138d4470786387772aafbe3f37e484f052ffeb7fed97d16077ce1fdbf3f1370c603ced6e134343bf5cc4e314eaedf22a6460a608e38a6a1af8deae4
   languageName: node
   linkType: hard
 
@@ -12697,16 +12677,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^9.1.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^10.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^5.1.0
-    "@magic-sdk/provider": ^9.1.0
-    "@magic-sdk/types": ^8.1.0
+    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/provider": ^10.0.0
+    "@magic-sdk/types": ^9.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown
@@ -13982,17 +13962,6 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "normalize-url@npm:2.0.1"
-  dependencies:
-    prepend-http: ^2.0.0
-    query-string: ^5.0.1
-    sort-keys: ^2.0.0
-  checksum: 30e337ee03fc7f360c7d2b966438657fabd2628925cc58bffc893982fe4d2c59b397ae664fa2c319cd83565af73eee88906e80bc5eec91bc32b601920e770d75
-  languageName: node
-  linkType: hard
-
 "normalize-url@npm:^3.3.0":
   version: 3.3.0
   resolution: "normalize-url@npm:3.3.0"
@@ -14404,6 +14373,15 @@ fsevents@^2.3.2:
   dependencies:
     is-wsl: ^1.1.0
   checksum: e5037facf3e03ed777537db3e2511ada37f351c4394e1dadccf9cac11d63b28447ae8b495b7b138659910fd78d918bafed546e47163673c4a4e43dbb5ac53c5d
+  languageName: node
+  linkType: hard
+
+"opencollective-postinstall@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "opencollective-postinstall@npm:2.0.3"
+  bin:
+    opencollective-postinstall: index.js
+  checksum: 0a68c5cef135e46d11e665d5077398285d1ce5311c948e8327b435791c409744d4a6bb9c55bd6507fb5f2ef34b0ad920565adcdaf974cbdae701aead6f32b396
   languageName: node
   linkType: hard
 
@@ -15120,13 +15098,6 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"prepend-http@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "prepend-http@npm:2.0.0"
-  checksum: 7694a9525405447662c1ffd352fcb41b6410c705b739b6f4e3a3e21cf5fdede8377890088e8934436b8b17ba55365a615f153960f30877bf0d0392f9e93503ea
-  languageName: node
-  linkType: hard
-
 "prettier-linter-helpers@npm:^1.0.0":
   version: 1.0.0
   resolution: "prettier-linter-helpers@npm:1.0.0"
@@ -15520,6 +15491,18 @@ pvutils@latest:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
+"react-native-inappbrowser-reborn@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "react-native-inappbrowser-reborn@npm:3.7.0"
+  dependencies:
+    invariant: ^2.2.4
+    opencollective-postinstall: ^2.0.3
+  peerDependencies:
+    react-native: ">=0.56"
+  checksum: b2177addf05cc02a20c5b9b8397c410ccf2fffba6baf1a49fbeb199ceaf4b9d4e959549915c5221f4345f35ec96620ecf25f650a5e268793103d95ffa7e44127
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Removes `expo-web-browser` dependency and replaces it with `react-native-inappbrowser-reborn`.

This allows both expo and bare RN apps to use this extension.

### ✅ Fixed Issues

https://github.com/magiclabs/magic-js/issues/313

### 🚨 Test instructions

Install this extension and add `react-native-inappbrowser-reborn` to your project (`yarn add react-native-inappbrowser`).

No changes are needed for OAuth login Implementation.

