### PR TITLE
Bidirectional RPC event support

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -3,8 +3,8 @@ import {
   MagicOutgoingWindowMessage,
   MagicIncomingWindowMessage,
   MagicPayloadMethod,
+  IntermediaryEvents,
 } from '@magic-sdk/types';
-import { IntermediaryEvents } from '@magic-sdk/types/src/modules/intermediary-types';
 import { createMalformedResponseError, MagicRPCError } from '../core/sdk-exceptions';
 import type { SDKBase } from '../core/sdk';
 import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload } from '../core/json-rpc';
@@ -63,8 +63,8 @@ export class BaseModule {
   protected createIntermediaryEvent<T = Function>(eventType: IntermediaryEvents, payloadId: string) {
     const e = (args: any) => {
       const res = createJsonRpcRequestPayload(MagicPayloadMethod.IntermediaryEvent, [{ payloadId, eventType, args }]);
-      return this.request(res);
+      this.request(res);
     };
-    return e as T;
+    return e as unknown as T;
   }
 }

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -1,7 +1,13 @@
-import { JsonRpcRequestPayload, MagicOutgoingWindowMessage, MagicIncomingWindowMessage } from '@magic-sdk/types';
+import {
+  JsonRpcRequestPayload,
+  MagicOutgoingWindowMessage,
+  MagicIncomingWindowMessage,
+  MagicPayloadMethod,
+} from '@magic-sdk/types';
+import { IntermediaryEvents } from '@magic-sdk/types/src/modules/intermediary-types';
 import { createMalformedResponseError, MagicRPCError } from '../core/sdk-exceptions';
 import type { SDKBase } from '../core/sdk';
-import { standardizeJsonRpcRequestPayload } from '../core/json-rpc';
+import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload } from '../core/json-rpc';
 import { createPromiEvent } from '../util/promise-tools';
 import type { ViewController } from '../core/view-controller';
 import type { EventsDefinition } from '../util/events';
@@ -52,5 +58,13 @@ export class BaseModule {
     });
 
     return promiEvent;
+  }
+
+  protected createIntermediaryEvent<T = Function>(eventType: IntermediaryEvents, payloadId: string) {
+    const e = (args: any) => {
+      const res = createJsonRpcRequestPayload(MagicPayloadMethod.IntermediaryEvent, [{ payloadId, eventType, args }]);
+      return this.request(res);
+    };
+    return e as T;
   }
 }

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -62,4 +62,5 @@ export enum MagicPayloadMethod {
   IsLoggedInTestMode = 'magic_auth_is_logged_in_testing_mode',
   LogoutTestMode = 'magic_auth_logout_testing_mode',
   UpdateEmailTestMode = 'magic_auth_update_email_testing_mode',
+  IntermediaryEvent = 'magic_intermediary_event',
 }

--- a/packages/@magic-sdk/types/src/index.ts
+++ b/packages/@magic-sdk/types/src/index.ts
@@ -10,3 +10,4 @@ export * from './core/query-types';
 export * from './modules/auth-types';
 export * from './modules/rpc-provider-types';
 export * from './modules/user-types';
+export * from './modules/intermediary-types';

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -31,4 +31,29 @@ export interface LoginWithEmailOTPConfiguration {
    * Specify the email address of the user attempting to login.
    */
   email: string;
+
+  /**
+   * When `true`, a pre-built modal interface will show to the user, directing
+   * them to check their email for the one time passcode (OTP) to complete their
+   * authentication.
+   *
+   * When `false`, developers will be able to implement their own custom UI to
+   * continue the email OTP flow.
+   */
+  showUI?: boolean;
 }
+
+export type LoginWithMagicLinkEvents = {
+  'email-sent': () => void;
+  'email-not-deliverable': () => void;
+  retry: () => void;
+};
+
+export type LoginWithEmailOTPEvents = {
+  'send-email-otp': (email: string) => void;
+  'verify-email-otp': (otp: string) => void;
+  'email-not-deliverable': () => void;
+  'invalid-email-format': () => void;
+  'invalid-email-otp': () => void;
+  'lockout-too-many-failed-attempts': () => void;
+};

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -1,4 +1,8 @@
 import { LoginWithEmailOTPEvents, LoginWithMagicLinkEvents } from './auth-types';
 
 export type IntermediaryEvents = keyof LoginWithEmailOTPEvents | keyof LoginWithMagicLinkEvents;
-export type IntermediaryEventPayload = { payloadId: string; eventType: IntermediaryEvents; args: any };
+export type IntermediaryEventPayload = {
+  payloadId: string;
+  eventType: IntermediaryEvents;
+  args: any;
+};

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -1,0 +1,4 @@
+import { LoginWithEmailOTPEvents, LoginWithMagicLinkEvents } from './auth-types';
+
+export type IntermediaryEvents = keyof LoginWithEmailOTPEvents | keyof LoginWithMagicLinkEvents;
+export type IntermediaryEventPayload = { payloadId: string; eventType: IntermediaryEvents; args: any };


### PR DESCRIPTION
### 📦 Pull Request

Link to TRD: https://www.notion.so/magiclabs/Bidirectional-RPC-Event-Support-5afcefad9bdc4c0c81cf221d008c4966

Relayer and the Magic SDK do not allow for passing data and messages back and forth during the execution of a RPC request. The idea is that we want the ability to send intermediary events during the execution of an RPC request. 
