### PR TITLE
Adds more Context about Expo dependency in `@magic-ext/react-native-oauth` to README

### DIFF
--- a/packages/@magic-ext/react-native-oauth/README.md
+++ b/packages/@magic-ext/react-native-oauth/README.md
@@ -1,8 +1,12 @@
 ## ⚠️ Package Split 
 
-Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you may have to remove this dependency.
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. With this in mind, bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` uses `expo-web-browser` as a dependency.
 
-In the future, we will release a new package to support bare-RN exclusively.
+If this dependency causes you issues, consider enabling the expo library via `npx install-expo-modules@latest`. For more context, you may check: https://docs.expo.dev/bare/installing-expo-modules.
+
+Another work around currently [under review](https://github.com/magiclabs/magic-js/pull/366) is replacing `expo-web-browser` with  [react native in-app browser](https://www.npmjs.com/package/react-native-inappbrowser-reborn). 
+
+We plan to release a new package to support bare-RN exclusively soon.
 
  
 

--- a/packages/@magic-ext/react-native-oauth/README.md
+++ b/packages/@magic-ext/react-native-oauth/README.md
@@ -1,1 +1,9 @@
-<!-- force publish -->
+## ⚠️ Package Split 
+
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you will may have to remove this dependency.
+
+In the future, we will release a new package to support bare-RN exclusively.
+
+ 
+
+

--- a/packages/@magic-ext/react-native-oauth/README.md
+++ b/packages/@magic-ext/react-native-oauth/README.md
@@ -1,6 +1,6 @@
 ## ⚠️ Package Split 
 
-Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you will may have to remove this dependency.
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you may have to remove this dependency.
 
 In the future, we will release a new package to support bare-RN exclusively.
 

--- a/packages/@magic-ext/react-native-oauth/README.md
+++ b/packages/@magic-ext/react-native-oauth/README.md
@@ -4,8 +4,6 @@ Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Na
 
 If this dependency causes you issues, consider enabling the expo library via `npx install-expo-modules@latest`. For more context, you may check: https://docs.expo.dev/bare/installing-expo-modules.
 
-Another work around currently [under review](https://github.com/magiclabs/magic-js/pull/366) is replacing `expo-web-browser` with  [react native in-app browser](https://www.npmjs.com/package/react-native-inappbrowser-reborn). 
-
 We plan to release a new package to support bare-RN exclusively soon.
 
  

--- a/packages/@magic-sdk/react-native/README.md
+++ b/packages/@magic-sdk/react-native/README.md
@@ -16,8 +16,6 @@ Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Na
 
 If this dependency causes you issues, consider enabling the expo library via `npx install-expo-modules@latest`. For more context, you may check: https://docs.expo.dev/bare/installing-expo-modules.
 
-Another work around currently [under review](https://github.com/magiclabs/magic-js/pull/366) is replacing `expo-web-browser` with  [react native in-app browser](https://www.npmjs.com/package/react-native-inappbrowser-reborn). We plan to release a new package to support bare-RN exclusively soon.
-
 This package will mainly support **Expo** framework in future releases.
 
 ## 📖 Documentation

--- a/packages/@magic-sdk/react-native/README.md
+++ b/packages/@magic-sdk/react-native/README.md
@@ -12,7 +12,7 @@
 
 ## Package Split!! 
 
-Since `9.0.0`, @magic-sdk/react-native package drops the support of bare React Native. You may stay on `^8.0.0` to keep your bare RN app functional. We will release a new package to support bare-RN exclusively.
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you will may have to remove this dependency. In the future, we will release a new package to support bare-RN exclusively.
 
 This package will mainly support **Expo** framework in future releases.
 

--- a/packages/@magic-sdk/react-native/README.md
+++ b/packages/@magic-sdk/react-native/README.md
@@ -12,7 +12,11 @@
 
 ## Package Split!! 
 
-Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you may have to remove this dependency. In the future, we will release a new package to support bare-RN exclusively.
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. With this in mind, bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` uses `expo-web-browser` as a dependency.
+
+If this dependency causes you issues, consider enabling the expo library via `npx install-expo-modules@latest`. For more context, you may check: https://docs.expo.dev/bare/installing-expo-modules.
+
+Another work around currently [under review](https://github.com/magiclabs/magic-js/pull/366) is replacing `expo-web-browser` with  [react native in-app browser](https://www.npmjs.com/package/react-native-inappbrowser-reborn). We plan to release a new package to support bare-RN exclusively soon.
 
 This package will mainly support **Expo** framework in future releases.
 

--- a/packages/@magic-sdk/react-native/README.md
+++ b/packages/@magic-sdk/react-native/README.md
@@ -12,7 +12,7 @@
 
 ## Package Split!! 
 
-Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you will may have to remove this dependency. In the future, we will release a new package to support bare-RN exclusively.
+Since `v9.0.0`, `@magic-sdk/react-native` package drops support of bare React Native (RN). You may stay on `^v8.0.0` to keep your bare RN app functional. All bare React Native applications utlilizing OAuth should note that `@magic-ext/react-native-oauth` grandfathered in `expo-web-browser` as a dependency. As a work around you may have to remove this dependency. In the future, we will release a new package to support bare-RN exclusively.
 
 This package will mainly support **Expo** framework in future releases.
 


### PR DESCRIPTION
### 📦 Pull Request

Adds more context about the use of `expo-web-browser` dependency in  `@magic-ext/react-native-oauth`.

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
