### PR TITLE
[Patch] Remote code execution in handlebars when compiling templates 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,7 +3162,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3170,7 +3170,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3178,7 +3178,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3186,7 +3186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3194,7 +3194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    magic-sdk: ^10.0.0
+    magic-sdk: ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -3202,7 +3202,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3210,7 +3210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3218,7 +3218,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -3231,7 +3231,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3239,7 +3239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3247,18 +3247,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^4.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^5.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^10.0.0
+    magic-sdk: ^11.0.0
   languageName: unknown
   linkType: soft
 
@@ -3266,7 +3266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3275,7 +3275,7 @@ __metadata:
   resolution: "@magic-ext/react-native-oauth@workspace:packages/@magic-ext/react-native-oauth"
   dependencies:
     "@magic-sdk/react-native": ^8.2.1
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     expo-application: ^5.0.1
@@ -3287,7 +3287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3295,7 +3295,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3303,7 +3303,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3311,7 +3311,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3319,7 +3319,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -3327,16 +3327,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^6.0.0
+    "@magic-sdk/commons": ^7.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^6.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^7.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^10.0.0
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/provider": ^11.0.0
+    "@magic-sdk/types": ^10.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -3360,17 +3360,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^4.0.0
-    magic-sdk: ^10.0.0
+    "@magic-ext/oauth": ^5.0.0
+    magic-sdk: ^11.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^10.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^11.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/types": ^10.0.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3428,9 +3428,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^6.0.0
-    "@magic-sdk/provider": ^10.0.0
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/commons": ^7.0.0
+    "@magic-sdk/provider": ^11.0.0
+    "@magic-sdk/types": ^10.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3454,7 +3454,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^9.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^10.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -9807,8 +9807,8 @@ fsevents@^2.3.2:
   linkType: hard
 
 "handlebars@npm:^4.7.6":
-  version: 4.7.6
-  resolution: "handlebars@npm:4.7.6"
+  version: 4.7.7
+  resolution: "handlebars@npm:4.7.7"
   dependencies:
     minimist: ^1.2.5
     neo-async: ^2.6.0
@@ -9820,7 +9820,7 @@ fsevents@^2.3.2:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 6fb9ba14c703cb6e77d5a1dcb37631126d25ae1503834b9b4f151d5324b52192a618d1944badc351588271cc28a8144093f85dbabc8c72278cfa2dbd09c70124
+  checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
   languageName: node
   linkType: hard
 
@@ -12707,16 +12707,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^10.0.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^11.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^6.0.0
-    "@magic-sdk/provider": ^10.0.0
-    "@magic-sdk/types": ^9.0.0
+    "@magic-sdk/commons": ^7.0.0
+    "@magic-sdk/provider": ^11.0.0
+    "@magic-sdk/types": ^10.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

The `magiclabs/magic-jsPublic` use `handlebars` are vulnerable to Remote Code Execution (RCE) when selecting certain compiling options to compile templates coming from an untrusted source. The package handlebars before 4.7.7 are vulnerable to Remote Code Execution (RCE) when selecting certain compiling options to compile templates coming from an untrusted source.

**PoCs:**
```js
<script src = "https://localhost/npm/handlebars@latest/dist/handlebars.js" > < /script> <script> / / compile the template
var s = ` {{#with (__lookupGetter__ "__proto__")}} {{#with (./constructor.getOwnPropertyDescriptor . "valueOf")}} 
{{#with ../constructor.prototype}} {{../../constructor.defineProperty . "hasOwnProperty" ..}} {{/with}} {{/with}} {{/with}} 
{{#with "constructor"}} {{#with split}} {{pop (push "alert('Vulnerable Handlebars JS when compiling in strict mode');")}} {{#with .}} 
{{#with (concat (lookup join (slice 0 1)))}} {{#each (slice 2 3)}} {{#with (apply 0 ../..)}} {{.}} {{/with}} {{/each}} {{/with}} {{/with}} {{/with}} {{/with}} `;
var template = Handlebars.compile(s, {
    strict: true
}); // execute the compiled template and print the output to the console console.log(template({})); </script>
```
```js
      }
      return obj[name];
      return container.lookupProperty(obj, name);
    },
```
[CVE-2021-23369](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23369) 
[CWE-94](https://cwe.mitre.org/data/definitions/94.html) 
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`




### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
