### PR TITLE
[CHORE] Add gh_token env var to auto version step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
             elif [[ $AUTO_VERSION ]]; then
               yarn lerna version "$AUTO_VERSION" --no-git-tag-version --no-push --yes
             fi
+          else
+            echo "Unable to bump version successfully." && exit 1
           fi
 
       - name: Create Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
           yarn
 
       - name: Apply semver updates (if any)
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           if yarn auto version; then
             AUTO_VERSION=$(yarn auto version)


### PR DESCRIPTION
### 📦 Pull Request

This adds the GH_TOKEN to the versioning step in github actions ci, since it is required by `yarn auto version`.
