### PR TITLE
feat: [sc-68022] Fix github action  publishing process in magic-js

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,5 @@ jobs:
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          yarn
           yarn build
           yarn auto shipit


### PR DESCRIPTION
Story details: https://app.shortcut.com/magic-labs/story/68022

* remove yarn command in Create Release phase, as it would fail due to a discrepancy in the yarn.lock file after bumping local versions

failed build
https://github.com/magiclabs/magic-js/actions/runs/3842939483/jobs/6544740907

Originally in CircleCI, the command sequence are
```
yarn auto version
yarn lerna version
yarn run build
yarn auto shipit
```

https://app.circleci.com/pipelines/github/magiclabs/magic-js/1242/workflows/bb743c78-9ec1-4acf-9fd6-0cacdfd9c027/jobs/3602