### PR TITLE
Replaces WebView View wrapper with SafeAreaView

### DIFF
--- a/packages/@magic-sdk/react-native-bare/README.md
+++ b/packages/@magic-sdk/react-native-bare/README.md
@@ -26,11 +26,13 @@ Integrating your app with Magic will require our client-side NPM package:
 npm install --save @magic-sdk/react-native-bare
 npm install --save react-native-device-info # Required Peer Dependency
 npm install --save @react-native-community/async-storage # Required Peer Dependency
+npm install --save react-native-safe-area-context # Required Peer Dependency
 
 # Via Yarn:
 yarn add @magic-sdk/react-native-bare
 ⁠yarn add react-native-device-info # Required Peer Dependency
 yarn add @react-native-community/async-storage # Required Peer Dependency
+yarn add react-native-safe-area-context # Required Peer Dependency
 ```
 
 ## ⚡️ Quick Start
@@ -42,17 +44,22 @@ Then, you can start authenticating users with _just one method!_
 ```tsx
 import React from 'react';
 import { Magic } from '@magic-sdk/react-native-bare';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 const magic = new Magic('YOUR_API_KEY');
 
 export default function App() {
   return <>
-    {/* Render the Magic iframe! */}
-    <magic.Relayer />
-    {...}
+	 <SafeAreaProvider>
+	    {/* Render the Magic iframe! */}
+	    <magic.Relayer />
+	    {...}
+	 </SafeAreaProvider>
   </>
 }
 
 // Somewhere else in your code...
 await magic.auth.loginWithMagicLink({ email: 'your.email@example.com' });
 ```
+## 👀 SafeAreaView
+Please note that as of **v14.0.0** our React Native package offerings wrap the `<magic.Relayer />` in [react-native-safe-area-context's](https://github.com/th3rdwave/react-native-safe-area-context) `<SafeAreaView />`. To prevent any adverse behavior in your app, please place the Magic iFrame React component at the root view of your application wrapped in a [SafeAreaProvider](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) as described in the documentation. 

--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -29,7 +29,6 @@
     "lodash": "^4.17.19",
     "process": "~0.11.10",
     "react-native-device-info": "^10.3.0",
-    "react-native-safe-area-context": "^4.4.1",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },
@@ -42,14 +41,16 @@
     "react": "^16.13.1",
     "react-native": "^0.62.2",
     "react-native-device-info": "^10.3.0",
-    "react-native-webview": "8.1.2"
+    "react-native-webview": "8.1.2",
+    "react-native-safe-area-context": "^4.4.1"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": ">=1.12.1",
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-device-info": ">=10.3.0",
-    "react-native-webview": ">=8"
+    "react-native-webview": ">=8",
+    "react-native-safe-area-context": ">=4.4.1"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -41,16 +41,16 @@
     "react": "^16.13.1",
     "react-native": "^0.62.2",
     "react-native-device-info": "^10.3.0",
-    "react-native-webview": "8.1.2",
-    "react-native-safe-area-context": "^4.4.1"
+    "react-native-safe-area-context": "^4.4.1",
+    "react-native-webview": "8.1.2"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": ">=1.12.1",
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-device-info": ">=10.3.0",
-    "react-native-webview": ">=8",
-    "react-native-safe-area-context": ">=4.4.1"
+    "react-native-safe-area-context": ">=4.4.1",
+    "react-native-webview": ">=8"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.19",
     "process": "~0.11.10",
     "react-native-device-info": "^10.3.0",
+    "react-native-safe-area-context": "^4.4.1",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
@@ -120,14 +121,14 @@ export class ReactNativeWebViewController extends ViewController {
     }, []);
 
     return (
-      <View ref={containerRef} style={containerStyles}>
+      <SafeAreaView ref={containerRef} style={containerStyles}>
         <WebView
           ref={webViewRef}
           source={{ uri: `${this.endpoint}/send/?params=${encodeURIComponent(this.parameters)}` }}
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
         />
-      </View>
+      </SafeAreaView>
     );
   };
 

--- a/packages/@magic-sdk/react-native-bare/test/mocks.ts
+++ b/packages/@magic-sdk/react-native-bare/test/mocks.ts
@@ -8,6 +8,7 @@ const noopModule = () => ({});
 export function removeReactDependencies() {
   jest.mock('react', noopModule);
   jest.mock('react-native-webview', noopModule);
+  jest.mock('react-native-safe-area-context', noopModule);
 
   // The `localforage` driver we use to enable React Native's `AsyncStorage`
   // currently uses an `import` statement at the top of it's index file, this is

--- a/packages/@magic-sdk/react-native-expo/README.md
+++ b/packages/@magic-sdk/react-native-expo/README.md
@@ -24,13 +24,15 @@ Please note that splitting the `Expo` and `Bare React Native` Magic package is a
  # Via NPM:
  npm install --save @magic-sdk/react-native-expo
  npm install --save react-native-webview@^8.0.0 # Required Peer Dependency
+ npm install --save react-native-safe-area-context # Required Peer Dependency
 
  # Via Yarn:
  yarn add @magic-sdk/react-native-expo
  yarn add react-native-webview@^8.0.0 # Required Peer Dependency
+ yarn add react-native-safe-area-context # Required Peer Dependency
  ```
 
- ## ⚡️ Quick Start
+## ⚡️ Quick Start
 
  Sign up or log in to the [developer dashboard](https://dashboard.magic.link) to receive API keys that will allow your application to interact with Magic's authentication APIs.
 
@@ -39,20 +41,29 @@ Please note that splitting the `Expo` and `Bare React Native` Magic package is a
  ```tsx
  import React from 'react';
  import { Magic } from '@magic-sdk/react-native-expo';
+ import { SafeAreaProvider } from 'react-native-safe-area-context';
+ 
  const magic = new Magic('YOUR_API_KEY');
+ 
  export default function App() {
-   return <>
-     {/* Render the Magic iframe! */}
-     <magic.Relayer />
-     {...}
+  return <>
+	  <SafeAreaProvider>
+	     {/* Render the Magic iframe! */}
+	     <magic.Relayer />
+	     {...}
+	  </SafeAreaProvider>
    </>
  }
  // Somewhere else in your code...
  await magic.auth.loginWithMagicLink({ email: 'your.email@example.com' });
  ```
- ## 🙌🏾 Troubleshooting
+ 
+## 👀 SafeAreaView
+Please note that as of **v14.0.0** our React Native package offerings wrap the `<magic.Relayer />` in [react-native-safe-area-context's](https://github.com/th3rdwave/react-native-safe-area-context) `<SafeAreaView />`. To prevent any adverse behavior in your app, please place the Magic iFrame React component at the root view of your application wrapped in a [SafeAreaProvider](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) as described in the documentation.
 
- ### Symlinking in Monorepo w/ Metro
+## 🙌🏾 Troubleshooting
+
+### Symlinking in Monorepo w/ Metro
 
 For React Native projects living within a **monorepo** that run into the following `TypeError: Undefined is not an object` error: 
 

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -29,6 +29,7 @@
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",
     "process": "~0.11.10",
+    "react-native-safe-area-context": "^4.4.1",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -40,15 +40,15 @@
     "metro-react-native-babel-preset": "^0.66.2",
     "react": "^16.13.1",
     "react-native": "^0.62.2",
-    "react-native-webview": "8.1.2",
-    "react-native-safe-area-context": "^4.4.1"
+    "react-native-safe-area-context": "^4.4.1",
+    "react-native-webview": "8.1.2"
   },
   "peerDependencies": {
     "expo": "*",
     "react": ">=16",
     "react-native": ">=0.60",
-    "react-native-webview": ">=8",
-    "react-native-safe-area-context": ">=4.4.1"
+    "react-native-safe-area-context": ">=4.4.1",
+    "react-native-webview": ">=8"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -29,7 +29,6 @@
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",
     "process": "~0.11.10",
-    "react-native-safe-area-context": "^4.4.1",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },
@@ -41,13 +40,15 @@
     "metro-react-native-babel-preset": "^0.66.2",
     "react": "^16.13.1",
     "react-native": "^0.62.2",
-    "react-native-webview": "8.1.2"
+    "react-native-webview": "8.1.2",
+    "react-native-safe-area-context": "^4.4.1"
   },
   "peerDependencies": {
     "expo": "*",
     "react": ">=16",
     "react-native": ">=0.60",
-    "react-native-webview": ">=8"
+    "react-native-webview": ">=8",
+    "react-native-safe-area-context": ">=4.4.1"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
@@ -120,14 +121,14 @@ export class ReactNativeWebViewController extends ViewController {
     }, []);
 
     return (
-      <View ref={containerRef} style={containerStyles}>
+      <SafeAreaView ref={containerRef} style={containerStyles}>
         <WebView
           ref={webViewRef}
           source={{ uri: `${this.endpoint}/send/?params=${encodeURIComponent(this.parameters)}` }}
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
         />
-      </View>
+      </SafeAreaView>
     );
   };
 

--- a/packages/@magic-sdk/react-native-expo/test/mocks.ts
+++ b/packages/@magic-sdk/react-native-expo/test/mocks.ts
@@ -8,6 +8,7 @@ const noopModule = () => ({});
 export function removeReactDependencies() {
   jest.mock('react', noopModule);
   jest.mock('react-native-webview', noopModule);
+  jest.mock('react-native-safe-area-context', noopModule);
 
   // The `localforage` driver we use to enable React Native's `AsyncStorage`
   // currently uses an `import` statement at the top of it's index file, this is

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,6 +3005,7 @@ __metadata:
     react: ^16.13.1
     react-native: ^0.62.2
     react-native-device-info: ^10.3.0
+    react-native-safe-area-context: ^4.4.1
     react-native-webview: 8.1.2
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
@@ -3040,6 +3041,7 @@ __metadata:
     process: ~0.11.10
     react: ^16.13.1
     react-native: ^0.62.2
+    react-native-safe-area-context: ^4.4.1
     react-native-webview: 8.1.2
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
@@ -15296,6 +15298,16 @@ fsevents@^2.3.2:
   peerDependencies:
     react-native: ">=0.56"
   checksum: b2177addf05cc02a20c5b9b8397c410ccf2fffba6baf1a49fbeb199ceaf4b9d4e959549915c5221f4345f35ec96620ecf25f650a5e268793103d95ffa7e44127
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "react-native-safe-area-context@npm:4.4.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: ef7c41ea59a34b114c6481fb130e66ef85e8d5b88acb46279131367761ca9fbf22cd310fe613f49b6c9b56dbd83e044be640f0532eda1d3856bf708e96335a35
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^13.1.0
+    "@magic-sdk/react-native-bare": ^13.1.1
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2859,7 +2859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^13.1.0
+    "@magic-sdk/react-native-expo": ^13.1.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2982,7 +2982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^13.1.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^13.1.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3014,11 +3014,12 @@ __metadata:
     react: ">=16"
     react-native: ">=0.60"
     react-native-device-info: ">=10.3.0"
+    react-native-safe-area-context: ">=4.4.1"
     react-native-webview: ">=8"
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^13.1.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^13.1.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3049,6 +3050,7 @@ __metadata:
     expo: "*"
     react: ">=16"
     react-native: ">=0.60"
+    react-native-safe-area-context: ">=4.4.1"
     react-native-webview: ">=8"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

Replaces the View wrapping the RN SDK package `WebView` with a SafeAreaView to prevent UI overlap with device hardware. 

### ✅ Fixed Issues

- Fixes #422 

### 🚨 Test instructions

Using either the [bare](https://github.com/magiclabs/react-native-demo/tree/main/bare/MagicBareRnExample) or [expo](https://github.com/magiclabs/react-native-demo/tree/main/expo/MagicExpoRNExample) sample apps, install either `@magic-sdk/react-native-bare@13.1.1-9591571-2` or `@magic-sdk/react-native-expo@13.1.1-9591571` canary versions. Update [the login method](https://github.com/magiclabs/react-native-demo/blob/main/expo/MagicExpoRNExample/screens/LoginScreen.tsx#L28-L40) to utilize [Magic's SMS login feature](https://magic.link/docs/auth/login-methods/sms/integration/react-native#make-a-request).

### Screenshots

### Before
![Screenshot 2023-01-12 at 4 45 14 PM](https://user-images.githubusercontent.com/13407884/212212895-716d8499-5b76-4281-88df-f8930995a268.png)

### After
![Screenshot 2023-01-12 at 4 29 11 PM](https://user-images.githubusercontent.com/13407884/212212885-a973448b-9cf2-4ec3-8edc-7326f6e6e411.png)


### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
