### PR TITLE
Adds react-native-inappbrowser-reborn as peer to Bare RN OAuth

### DIFF
--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -27,12 +27,12 @@
   "dependencies": {
     "@magic-sdk/types": "^10.0.1",
     "crypto-js": "^3.3.0",
-    "react-native-device-info": "^10.3.0",
-    "react-native-inappbrowser-reborn": "^3.7.0"
+    "react-native-device-info": "^10.3.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native-bare": "^13.1.0",
-    "@types/crypto-js": "~3.1.47"
+    "@types/crypto-js": "~3.1.47",
+    "react-native-inappbrowser-reborn": "^3.7.0"
   },
   "peerDependencies": {
     "@magic-sdk/react-native-bare": ">=13.0.0",

--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -35,6 +35,7 @@
     "@types/crypto-js": "~3.1.47"
   },
   "peerDependencies": {
-    "@magic-sdk/react-native-bare": ">=13.0.0"
+    "@magic-sdk/react-native-bare": ">=13.0.0",
+    "react-native-inappbrowser-reborn": ">=3.7.0"
   }
 }

--- a/packages/@magic-sdk/react-native-bare/README.md
+++ b/packages/@magic-sdk/react-native-bare/README.md
@@ -24,9 +24,13 @@ Integrating your app with Magic will require our client-side NPM package:
 ```bash
 # Via NPM:
 npm install --save @magic-sdk/react-native-bare
+npm install --save react-native-device-info # Required Peer Dependency
+npm install --save @react-native-community/async-storage # Required Peer Dependency
 
 # Via Yarn:
 yarn add @magic-sdk/react-native-bare
+⁠yarn add react-native-device-info # Required Peer Dependency
+yarn add @react-native-community/async-storage # Required Peer Dependency
 ```
 
 ## ⚡️ Quick Start

--- a/packages/@magic-sdk/react-native-expo/README.md
+++ b/packages/@magic-sdk/react-native-expo/README.md
@@ -23,8 +23,11 @@ Please note that splitting the `Expo` and `Bare React Native` Magic package is a
  ```bash
  # Via NPM:
  npm install --save @magic-sdk/react-native-expo
+ npm install --save react-native-webview@^8.0.0 # Required Peer Dependency
+
  # Via Yarn:
  yarn add @magic-sdk/react-native-expo
+ yarn add react-native-webview@^8.0.0 # Required Peer Dependency
  ```
 
  ## ⚡️ Quick Start

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,7 +2723,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2731,7 +2731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2739,7 +2739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2747,7 +2747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2755,7 +2755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    magic-sdk: ^13.0.0
+    magic-sdk: ^13.1.0
   languageName: unknown
   linkType: soft
 
@@ -2763,7 +2763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2771,7 +2771,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2779,7 +2779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2792,7 +2792,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2800,7 +2800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2808,18 +2808,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.1.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/types": ^11.1.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.0.0
+    magic-sdk: ^13.1.0
   languageName: unknown
   linkType: soft
 
@@ -2835,7 +2835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^13.0.1
+    "@magic-sdk/react-native-bare": ^13.1.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2851,6 +2851,7 @@ __metadata:
     react-native-inappbrowser-reborn: ^3.7.0
   peerDependencies:
     "@magic-sdk/react-native-bare": ">=13.0.0"
+    react-native-inappbrowser-reborn: ">=3.7.0"
   languageName: unknown
   linkType: soft
 
@@ -2858,7 +2859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^13.0.1
+    "@magic-sdk/react-native-expo": ^13.1.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2873,7 +2874,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2881,7 +2882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2889,7 +2890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2897,7 +2898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2905,7 +2906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2913,16 +2914,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.0.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^9.1.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.0.0
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/provider": ^13.1.0
+    "@magic-sdk/types": ^11.1.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2946,17 +2947,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.0.0
-    magic-sdk: ^13.0.0
+    "@magic-ext/oauth": ^7.1.0
+    magic-sdk: ^13.1.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^13.1.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/types": ^11.1.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2981,7 +2982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^13.0.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^13.1.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2989,9 +2990,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.0.0
-    "@magic-sdk/provider": ^13.0.0
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/provider": ^13.1.0
+    "@magic-sdk/types": ^11.1.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
@@ -3016,7 +3017,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^13.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^13.1.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3024,9 +3025,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.0.0
-    "@magic-sdk/provider": ^13.0.0
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/provider": ^13.1.0
+    "@magic-sdk/types": ^11.1.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3050,7 +3051,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^11.1.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12319,16 +12320,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.0.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.1.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.0.0
-    "@magic-sdk/provider": ^13.0.0
-    "@magic-sdk/types": ^11.0.0
+    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/provider": ^13.1.0
+    "@magic-sdk/types": ^11.1.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

Adds `react-native-inappbrowser-reborn` as a peer dependency to our Bare RN OAuth Extension. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
