### PR TITLE
Permit React Native entry to Magic Connect Extension

### DIFF
--- a/packages/@magic-ext/connect/README.md
+++ b/packages/@magic-ext/connect/README.md
@@ -18,23 +18,35 @@ See the [developer documentation](https://magic.link/docs/connect) to learn how 
 
 Integrating your app with Magic will require our client-side NPM package and the Connect extension:
 
+### Web Browser:
 ```bash
 # Via NPM:
-npm install --save magic-sdk @magic-ext/connect # If you're targeting web browsers
-npm install --save @magic-sdk/react-native-bare @magic-ext/connect # If you're targeting Bare React Native
-npm install --save @magic-sdk/react-native-expo @magic-ext/connect # If you're targeting Expo React Native
+npm install --save magic-sdk @magic-ext/connect
 
 # Via Yarn:
-yarn add magic-sdk @magic-ext/connect # If you're targeting web browsers
-yarn add @magic-sdk/react-native-bare @magic-ext/connect # If you're targeting Bare React Native
-yarn add @magic-sdk/react-native-expo @magic-ext/connect # If you're targeting Expo React Native
+yarn add magic-sdk @magic-ext/connect
 ```
-
 Alternatively, you can load via CDN with by adding a script tag to your app’s `<head>`:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/magic-sdk/dist/magic.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@magic-ext/connect/dist/extension.js"></script>
+```
+### Bare React Native:
+```bash
+# Via NPM:
+npm install --save @magic-sdk/react-native-bare @magic-ext/connect
+
+# Via Yarn:
+yarn add @magic-sdk/react-native-bare @magic-ext/connect
+```
+### Expo React Native:
+```bash
+# Via NPM:
+npm install --save @magic-sdk/react-native-expo @magic-ext/connect
+
+# Via Yarn:
+yarn add @magic-sdk/react-native-expo @magic-ext/connect
 ```
 
 ## ⚡️ Quick Start

--- a/packages/@magic-ext/connect/README.md
+++ b/packages/@magic-ext/connect/README.md
@@ -1,4 +1,4 @@
-# 🔒 Magic Connect Extension for Web Browsers
+# 🔒 Magic Connect Extension for Web Browsers and React Native Apps
 
 [![<MagicLabs>](https://circleci.com/gh/magiclabs/magic-js.svg?style=shield)](https://circleci.com/gh/magiclabs/magic-js)
 
@@ -20,10 +20,14 @@ Integrating your app with Magic will require our client-side NPM package and the
 
 ```bash
 # Via NPM:
-npm install --save magic-sdk @magic-ext/connect
+npm install --save magic-sdk @magic-ext/connect # If you're targeting web browsers
+npm install --save @magic-sdk/react-native-bare @magic-ext/connect # If you're targeting Bare React Native
+npm install --save @magic-sdk/react-native-expo @magic-ext/connect # If you're targeting Expo React Native
 
 # Via Yarn:
-yarn add magic-sdk @magic-ext/connect
+yarn add magic-sdk @magic-ext/connect # If you're targeting web browsers
+yarn add @magic-sdk/react-native-bare @magic-ext/connect # If you're targeting Bare React Native
+yarn add @magic-sdk/react-native-expo @magic-ext/connect # If you're targeting Expo React Native
 ```
 
 Alternatively, you can load via CDN with by adding a script tag to your app’s `<head>`:
@@ -41,7 +45,9 @@ From your login page:
 
 ```ts
 import Web3 from 'web3';
-import { Magic } from 'magic-sdk';
+import { Magic } from 'magic-sdk'; // web browsers
+import { Magic } from '@magic-sdk/react-native-bare'; // Bare React Native
+import { Magic } from '@magic-sdk/react-native-expo'; // Expo React Native
 import { ConnectExtension } from '@magic-ext/connect';
 
 const magic = new Magic('YOUR_API_KEY', {

--- a/packages/@magic-ext/connect/package.json
+++ b/packages/@magic-ext/connect/package.json
@@ -23,10 +23,10 @@
   },
   "externals": {
     "include": [
-      "magic-sdk"
+      "@magic-sdk/commons"
     ]
   },
   "devDependencies": {
-    "magic-sdk": "^13.1.0"
+    "@magic-sdk/commons": "^9.1.0"
   }
 }

--- a/packages/@magic-ext/connect/src/index.ts
+++ b/packages/@magic-ext/connect/src/index.ts
@@ -1,4 +1,4 @@
-import { Extension } from 'magic-sdk';
+import { Extension } from '@magic-sdk/commons';
 import { MagicConnectPayloadMethod, UserInfo, WalletInfo } from './types';
 
 export class ConnectExtension extends Extension.Internal<'connect', any> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    magic-sdk: ^13.1.0
+    "@magic-sdk/commons": ^9.1.0
   languageName: unknown
   linkType: soft
 
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^13.1.1
+    "@magic-sdk/react-native-bare": ^14.0.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2859,7 +2859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^13.1.1
+    "@magic-sdk/react-native-expo": ^14.0.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2982,7 +2982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^13.1.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^14.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3019,7 +3019,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^13.1.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^14.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:


### PR DESCRIPTION
### 📦 Pull Request

Permits React Native apps to utilize Magic Connect Extension. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

Utilize [this PR](https://github.com/magiclabs/react-native-demo/pull/17) to test or use either a bare or expo app from [the demos](https://github.com/magiclabs/react-native-demo) and install the canary version of the package via:

```
yarn add @magic-ext/connect@6.2.0-280e018
```
Follow the instructions in the [updated README](https://github.com/magiclabs/magic-js/compare/ariflo-sc-67874-mc-rn-expo?expand=1#diff-27937a4b2ed8380ab55bba3ebd8794b7cc5111d008c4f5660f2a8837a804e747) and verify MC modal opens as illustrated below:

### iOS Screenshot
![2023-01-19 14 06 29](https://user-images.githubusercontent.com/13407884/213576476-0817a70d-6a83-46d2-beac-4dce4d1fe714.gif)

### Android Screenshot
![2023-01-19 14 05 20](https://user-images.githubusercontent.com/13407884/213576507-4d432cd7-e7a9-4f5f-ac53-6a72a3f2ac39.gif)

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
