### PR TITLE
Prevents Relayer from Overriding Status Bar Color

### DIFF
--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -42,7 +42,7 @@
     "react-native": "^0.62.2",
     "react-native-device-info": "^10.3.0",
     "react-native-safe-area-context": "^4.4.1",
-    "react-native-webview": "8.1.2"
+    "react-native-webview": "^11.26.0"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": ">=1.12.1",

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -127,6 +127,7 @@ export class ReactNativeWebViewController extends ViewController {
           source={{ uri: `${this.endpoint}/send/?params=${encodeURIComponent(this.parameters)}` }}
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
+          autoManageStatusBarEnabled={false}
         />
       </SafeAreaView>
     );

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -41,7 +41,7 @@
     "react": "^16.13.1",
     "react-native": "^0.62.2",
     "react-native-safe-area-context": "^4.4.1",
-    "react-native-webview": "8.1.2"
+    "react-native-webview": "^11.26.0"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -127,6 +127,7 @@ export class ReactNativeWebViewController extends ViewController {
           source={{ uri: `${this.endpoint}/send/?params=${encodeURIComponent(this.parameters)}` }}
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
+          autoManageStatusBarEnabled={false}
         />
       </SafeAreaView>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,7 +3006,7 @@ __metadata:
     react-native: ^0.62.2
     react-native-device-info: ^10.3.0
     react-native-safe-area-context: ^4.4.1
-    react-native-webview: 8.1.2
+    react-native-webview: ^11.26.0
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
@@ -3043,7 +3043,7 @@ __metadata:
     react: ^16.13.1
     react-native: ^0.62.2
     react-native-safe-area-context: ^4.4.1
-    react-native-webview: 8.1.2
+    react-native-webview: ^11.26.0
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
@@ -15313,16 +15313,16 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:8.1.2":
-  version: 8.1.2
-  resolution: "react-native-webview@npm:8.1.2"
+"react-native-webview@npm:^11.26.0":
+  version: 11.26.0
+  resolution: "react-native-webview@npm:11.26.0"
   dependencies:
     escape-string-regexp: 2.0.0
     invariant: 2.2.4
   peerDependencies:
-    react: ^16.9
-    react-native: ">=0.60 <0.62"
-  checksum: 7c22f9250899b0cf498283e794d9e6327115b2fde55efa613de0dca8964ab9bce979bbc53b5dd8677afa2c813007870ab0b5bfa79b7ccb756075ae8620977c86
+    react: "*"
+    react-native: "*"
+  checksum: 9335fd21cdb9a883e241650cf66421a72d0456c905d8da2948bdc168124b8eec944c86e5f1730d4985fb4b3fe8554363c08765f0c5e6c0014035620cb7450378
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Upgrades our React Native package offerings `react-native-webview` to the latest and utilizes `autoManageStatusBarEnabled` attribute in Webview to prevent style bug.

### ✅ Fixed Issues

- Fixes #434 

### 🚨 Test instructions

Utilize expo [demo app](https://github.com/magiclabs/react-native-demo/tree/main/expo/MagicExpoRNExample) and `yarn add @magic-sdk/react-native-expo@14.0.1-903c2bf-2` canary version. Check issue ☝️  for reproduction steps. 

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
