### PR TITLE
Bumps `react-native-webview` peer dependency Requirement to `>=11.0.0`

### DIFF
--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -50,7 +50,7 @@
     "react-native": ">=0.60",
     "react-native-device-info": ">=10.3.0",
     "react-native-safe-area-context": ">=4.4.1",
-    "react-native-webview": ">=8"
+    "react-native-webview": ">=11.0.0"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -48,7 +48,7 @@
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-safe-area-context": ">=4.4.1",
-    "react-native-webview": ">=8"
+    "react-native-webview": ">=11.0.0"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,7 +3015,7 @@ __metadata:
     react-native: ">=0.60"
     react-native-device-info: ">=10.3.0"
     react-native-safe-area-context: ">=4.4.1"
-    react-native-webview: ">=8"
+    react-native-webview: ">=11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3051,7 +3051,7 @@ __metadata:
     react: ">=16"
     react-native: ">=0.60"
     react-native-safe-area-context: ">=4.4.1"
-    react-native-webview: ">=8"
+    react-native-webview: ">=11.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### 📦 Pull Request

Bumps `react-native-webview` peer dependency Requirement to `>=11.0.0`

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
