### PR TITLE
Permit React Native SDK to Utlize Bitcoin extension

### DIFF
--- a/packages/@magic-ext/bitcoin/package.json
+++ b/packages/@magic-ext/bitcoin/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,7 +2723,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2731,7 +2731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2739,7 +2739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2747,7 +2747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2755,7 +2755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2763,7 +2763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2771,7 +2771,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2779,7 +2779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2792,7 +2792,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2800,7 +2800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2808,18 +2808,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.1.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.2.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/types": ^11.2.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.1.0
+    magic-sdk: ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2835,7 +2835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^14.1.0
+    "@magic-sdk/react-native-bare": ^14.2.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2859,7 +2859,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^14.1.0
+    "@magic-sdk/react-native-expo": ^14.2.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2874,7 +2874,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2882,7 +2882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2890,7 +2890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2898,7 +2898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2906,7 +2906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
@@ -2914,16 +2914,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.1.0
+    "@magic-sdk/commons": ^9.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.1.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^9.2.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.1.0
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/provider": ^13.2.0
+    "@magic-sdk/types": ^11.2.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2947,17 +2947,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.1.0
-    magic-sdk: ^13.1.0
+    "@magic-ext/oauth": ^7.2.0
+    magic-sdk: ^13.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.1.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^13.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/types": ^11.2.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2982,7 +2982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^14.1.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^14.2.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2990,9 +2990,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.1.0
-    "@magic-sdk/provider": ^13.1.0
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/provider": ^13.2.0
+    "@magic-sdk/types": ^11.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
@@ -3019,7 +3019,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^14.1.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^14.2.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3027,9 +3027,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.1.0
-    "@magic-sdk/provider": ^13.1.0
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/provider": ^13.2.0
+    "@magic-sdk/types": ^11.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3055,7 +3055,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.1.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^11.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12324,16 +12324,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.1.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.2.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.1.0
-    "@magic-sdk/provider": ^13.1.0
-    "@magic-sdk/types": ^11.1.0
+    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/provider": ^13.2.0
+    "@magic-sdk/types": ^11.2.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

Removes legacy entry file location for react-native packages to permit React Native SDKs to use Bitcoin extension.

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

Utilized Sample RN Demo app in PR https://github.com/magiclabs/react-native-demo/pull/32 as illustrated below:

![2023-02-14 12 35 53](https://user-images.githubusercontent.com/13407884/218860047-fae5f2c4-ed36-4a07-8b21-5515f1d7f976.gif)

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
