### PR TITLE
Udpates `expo-web-browser` to the latest for `@magic-ext/react-native-expo-oauth`

### DIFF
--- a/packages/@magic-ext/react-native-expo-oauth/package.json
+++ b/packages/@magic-ext/react-native-expo-oauth/package.json
@@ -28,7 +28,7 @@
     "@magic-sdk/types": "^10.0.0",
     "crypto-js": "^3.3.0",
     "expo-application": "^5.0.1",
-    "expo-web-browser": "^11.0.0"
+    "expo-web-browser": "^12.0.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native-expo": "^14.3.0",

--- a/packages/@magic-ext/react-native-expo-oauth/package.json
+++ b/packages/@magic-ext/react-native-expo-oauth/package.json
@@ -28,7 +28,7 @@
     "@magic-sdk/types": "^10.0.0",
     "crypto-js": "^3.3.0",
     "expo-application": "^5.0.1",
-    "expo-web-browser": "^12.0.0"
+    "expo-web-browser": ">=12.0.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native-expo": "^14.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2738,7 +2738,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2746,7 +2746,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2754,7 +2754,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2762,7 +2762,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2770,7 +2770,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2778,7 +2778,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2786,7 +2786,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2799,7 +2799,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2807,7 +2807,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2815,18 +2815,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.2.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/types": ^11.3.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.2.0
+    magic-sdk: ^13.3.0
   languageName: unknown
   linkType: soft
 
@@ -2842,7 +2842,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2850,7 +2850,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^14.2.0
+    "@magic-sdk/react-native-bare": ^14.3.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2866,12 +2866,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^14.2.0
+    "@magic-sdk/react-native-expo": ^14.3.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     expo-application: ^5.0.1
-    expo-web-browser: ^11.0.0
+    expo-web-browser: ">=12.0.0"
   peerDependencies:
     "@magic-sdk/react-native-expo": ">=13.0.0"
   languageName: unknown
@@ -2881,7 +2881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2889,7 +2889,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2897,7 +2897,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2905,7 +2905,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2913,7 +2913,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
@@ -2921,16 +2921,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.2.0
+    "@magic-sdk/commons": ^9.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.2.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^9.3.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.2.0
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/provider": ^13.3.0
+    "@magic-sdk/types": ^11.3.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2954,17 +2954,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.2.0
-    magic-sdk: ^13.2.0
+    "@magic-ext/oauth": ^7.3.0
+    magic-sdk: ^13.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^13.3.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/types": ^11.3.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2989,7 +2989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^14.2.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^14.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2997,9 +2997,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.2.0
-    "@magic-sdk/provider": ^13.2.0
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/commons": ^9.3.0
+    "@magic-sdk/provider": ^13.3.0
+    "@magic-sdk/types": ^11.3.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
@@ -3026,7 +3026,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^14.2.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^14.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3034,9 +3034,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.2.0
-    "@magic-sdk/provider": ^13.2.0
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/commons": ^9.3.0
+    "@magic-sdk/provider": ^13.3.0
+    "@magic-sdk/types": ^11.3.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3062,7 +3062,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^11.3.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -8356,14 +8356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-web-browser@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "expo-web-browser@npm:11.0.0"
+"expo-web-browser@npm:>=12.0.0":
+  version: 12.1.1
+  resolution: "expo-web-browser@npm:12.1.1"
   dependencies:
     compare-urls: ^2.0.0
+    url: ^0.11.0
   peerDependencies:
     expo: "*"
-  checksum: 93740703b138d4470786387772aafbe3f37e484f052ffeb7fed97d16077ce1fdbf3f1370c603ced6e134343bf5cc4e314eaedf22a6460a608e38a6a1af8deae4
+  checksum: d6a1c48170cfae7fb7038bcf479a520ab59a84b5f2a90b68abc2570c25e88dbd60a643282fbd4406451576198bab4019c668b119e40e674d0184d3f233011ab7
   languageName: node
   linkType: hard
 
@@ -12335,16 +12336,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.2.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.3.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.2.0
-    "@magic-sdk/provider": ^13.2.0
-    "@magic-sdk/types": ^11.2.0
+    "@magic-sdk/commons": ^9.3.0
+    "@magic-sdk/provider": ^13.3.0
+    "@magic-sdk/types": ^11.3.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown
@@ -15156,6 +15157,13 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
@@ -15222,6 +15230,13 @@ fsevents@^2.3.2:
     split-on-first: ^1.0.0
     strict-uri-encode: ^2.0.0
   checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -18299,6 +18314,16 @@ typescript@~4.4.2:
   version: 1.0.0
   resolution: "url-set-query@npm:1.0.0"
   checksum: 5ad73525e8f3ab55c6bf3ddc70a43912e65ff9ce655d7868fdcefdf79f509cfdddde4b07150797f76186f1a47c0ecd2b7bb3687df8f84757dee4110cf006e12d
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "url@npm:0.11.0"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Updates `expo-web-browser` to the latest to permit higher minimum iOS version supported. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
