### PR TITLE
Sc 68969 immutable stark error

### DIFF
--- a/packages/@magic-sdk/provider/package.json
+++ b/packages/@magic-sdk/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/provider",
-  "version": "13.6.0",
+  "version": "13.6.1-4bcf4d3",
   "description": "Core business logic for Magic SDK packages.",
   "author": "Magic Labs <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-sdk/provider/package.json
+++ b/packages/@magic-sdk/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/provider",
-  "version": "13.6.1-4bcf4d3",
+  "version": "13.6.0",
   "description": "Core business logic for Magic SDK packages.",
   "author": "Magic Labs <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-sdk/provider/src/core/sdk-exceptions.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk-exceptions.ts
@@ -28,6 +28,7 @@ export class MagicRPCError extends Error {
 
   public code: RPCErrorCode | number;
   public rawMessage: string;
+  public data: any;
 
   constructor(sourceError?: JsonRpcError | null) {
     super();
@@ -36,6 +37,7 @@ export class MagicRPCError extends Error {
     this.rawMessage = sourceError?.message || 'Internal error';
     this.code = isJsonRpcErrorCode(codeNormalized) ? codeNormalized : RPCErrorCode.InternalError;
     this.message = `Magic RPC Error: [${this.code}] ${this.rawMessage}`;
+    this.data = sourceError?.data || undefined;
 
     Object.setPrototypeOf(this, MagicRPCError.prototype);
   }

--- a/packages/@magic-sdk/provider/test/spec/core/sdk-exceptions/magic-rpc-error/constructor.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/sdk-exceptions/magic-rpc-error/constructor.spec.ts
@@ -1,6 +1,9 @@
 import browserEnv from '@ikscodes/browser-env';
 import { MagicRPCError } from '../../../../../src/core/sdk-exceptions';
 
+const exampleData =
+  '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000011555345525f554e52454749535445524544000000000000000000000000000000';
+
 beforeEach(() => {
   browserEnv.restore();
 });
@@ -9,12 +12,14 @@ test('Initialize `MagicRPCError` with object argument', () => {
   const err = new MagicRPCError({
     code: -32603,
     message: 'hello world',
+    data: exampleData,
   });
 
   expect(err instanceof MagicRPCError).toBe(true);
   expect(err.code).toBe(-32603);
   expect(err.message).toBe('Magic RPC Error: [-32603] hello world');
   expect(err.rawMessage).toBe('hello world');
+  expect(err.data).toBe(exampleData);
 });
 
 test('Initialize MagicRPCError with `null` argument', () => {
@@ -24,6 +29,7 @@ test('Initialize MagicRPCError with `null` argument', () => {
   expect(err.code).toBe(-32603);
   expect(err.message).toBe('Magic RPC Error: [-32603] Internal error');
   expect(err.rawMessage).toBe('Internal error');
+  expect(err.data).toBe(undefined);
 });
 
 test('Initialize MagicRPCError with `undefined` argument', () => {
@@ -33,16 +39,20 @@ test('Initialize MagicRPCError with `undefined` argument', () => {
   expect(err.code).toBe(-32603);
   expect(err.message).toBe('Magic RPC Error: [-32603] Internal error');
   expect(err.rawMessage).toBe('Internal error');
+  expect(err.data).toBe(undefined);
 });
 
 test('Initialize MagicRPCError with unknown error code argument', () => {
   const err = new MagicRPCError({
+    // @ts-ignore
     code: 1,
     message: 'hello world',
+    data: exampleData,
   });
 
   expect(err instanceof MagicRPCError).toBe(true);
   expect(err.code).toBe(-32603);
   expect(err.message).toBe('Magic RPC Error: [-32603] hello world');
   expect(err.rawMessage).toBe('hello world');
+  expect(err.data).toBe(exampleData);
 });

--- a/packages/@magic-sdk/provider/test/spec/modules/base-module/request.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/base-module/request.spec.ts
@@ -46,7 +46,11 @@ test('Resolves with a successful response', async () => {
 test('Rejects with a `MagicRPCError` upon request failed', async () => {
   const response = new JsonRpcResponse(requestPayload).applyError({ code: -32603, message: 'hello world' });
   const { baseModule } = createBaseModule(jest.fn().mockImplementation(() => Promise.resolve(response)));
-  const expectedError = new MagicRPCError({ code: -32603, message: 'hello world' });
+  const expectedError = new MagicRPCError({
+    code: -32603,
+    message: 'hello world',
+    data: '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000011555345525f554e52454749535445524544000000000000000000000000000000',
+  });
   await expect(() => baseModule.request(requestPayload)).rejects.toThrow(expectedError);
 });
 

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -24,6 +24,7 @@ export interface JsonRpcBatchRequestCallback {
 export interface JsonRpcError {
   message: string;
   code: RPCErrorCode;
+  data?: any;
 }
 
 export interface JsonRpcResponsePayload<ResultType = any> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,7 +2731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2739,7 +2739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2747,7 +2747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2755,7 +2755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2763,7 +2763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2771,7 +2771,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2779,7 +2779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2787,7 +2787,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2800,7 +2800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2808,7 +2808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2816,18 +2816,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.5.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.6.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/types": ^11.6.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.5.0
+    magic-sdk: ^13.6.0
   languageName: unknown
   linkType: soft
 
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2851,7 +2851,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^14.5.0
+    "@magic-sdk/react-native-bare": ^14.6.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2867,7 +2867,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^14.5.0
+    "@magic-sdk/react-native-expo": ^14.6.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2882,7 +2882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2890,7 +2890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2898,7 +2898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2906,7 +2906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2914,7 +2914,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
@@ -2922,16 +2922,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/commons": ^9.6.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.5.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^9.6.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.5.0
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/provider": ^13.6.0
+    "@magic-sdk/types": ^11.6.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2955,17 +2955,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.5.0
-    magic-sdk: ^13.5.0
+    "@magic-ext/oauth": ^7.6.0
+    magic-sdk: ^13.6.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.5.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^13.6.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/types": ^11.6.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2990,7 +2990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^14.5.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^14.6.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2998,9 +2998,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.5.0
-    "@magic-sdk/provider": ^13.5.0
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/provider": ^13.6.0
+    "@magic-sdk/types": ^11.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
@@ -3027,7 +3027,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^14.5.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^14.6.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3035,9 +3035,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.5.0
-    "@magic-sdk/provider": ^13.5.0
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/provider": ^13.6.0
+    "@magic-sdk/types": ^11.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3063,7 +3063,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.5.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^11.6.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12338,16 +12338,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.5.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.6.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.5.0
-    "@magic-sdk/provider": ^13.5.0
-    "@magic-sdk/types": ^11.5.0
+    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/provider": ^13.6.0
+    "@magic-sdk/types": ^11.6.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,7 +2731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2739,7 +2739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2747,7 +2747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2755,7 +2755,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2763,7 +2763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2771,7 +2771,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2779,7 +2779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2787,7 +2787,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2800,7 +2800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2808,7 +2808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2816,18 +2816,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.6.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.5.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/types": ^11.5.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.6.0
+    magic-sdk: ^13.5.0
   languageName: unknown
   linkType: soft
 
@@ -2843,7 +2843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2851,7 +2851,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^14.6.0
+    "@magic-sdk/react-native-bare": ^14.5.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2867,7 +2867,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^14.6.0
+    "@magic-sdk/react-native-expo": ^14.5.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2882,7 +2882,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2890,7 +2890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2898,7 +2898,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2906,7 +2906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2914,7 +2914,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
@@ -2922,16 +2922,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.6.0
+    "@magic-sdk/commons": ^9.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.6.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^9.5.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.6.0
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/provider": ^13.5.0
+    "@magic-sdk/types": ^11.5.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2955,17 +2955,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.6.0
-    magic-sdk: ^13.6.0
+    "@magic-ext/oauth": ^7.5.0
+    magic-sdk: ^13.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.6.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^13.5.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/types": ^11.5.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2990,7 +2990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^14.6.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^14.5.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2998,9 +2998,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.6.0
-    "@magic-sdk/provider": ^13.6.0
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/provider": ^13.5.0
+    "@magic-sdk/types": ^11.5.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
@@ -3027,7 +3027,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^14.6.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^14.5.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3035,9 +3035,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.6.0
-    "@magic-sdk/provider": ^13.6.0
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/provider": ^13.5.0
+    "@magic-sdk/types": ^11.5.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3063,7 +3063,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.6.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^11.5.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12338,16 +12338,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.6.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.5.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.6.0
-    "@magic-sdk/provider": ^13.6.0
-    "@magic-sdk/types": ^11.6.0
+    "@magic-sdk/commons": ^9.5.0
+    "@magic-sdk/provider": ^13.5.0
+    "@magic-sdk/types": ^11.5.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
# 📦 Why? (Required)

Immutable tested this line of code with 3 providers
- magic provider
- alchemy provider
- json rpc provider
`await contract.connect(PROVIDER).isRegistered(userPublicStarkKey);`

The error from Ethers using the Magic Provider was different than the Alchemy / JSON RPC Providers
This fix makes the error from the Magic Provider consistent with the other providers

Ethers expects a data key to be present in the RPC error - if data is present from bubbled up error, we now map this in the MagicRPCError - see here https://www.jsonrpc.org/specification#response_object

## How was it tested? (Required)

How did you test/validate correctness of changes?

1. Recreate the error in a 3rd party app ([example](https://codesandbox.io/s/magic-stark-contract-bug-prod-3w0zdf?file=/src/App.tsx:1592-1656))
2. Set breakpoints in the ethers library to figure out where the error was called, and what data was missing
3. Modified phantom locally to map the missing data
4. Modified magic-sdk locally, linked changes to the 3rd party app using the magic-sdk
5. Verified that the error from the Magic Provider is consistent now with the other providers
6. Create the canary version of magic-sdk, push to npm, test the canary version in a 3rd party app

### Screenshots (Optional)

Previous issue - inconsistent errors from Magic (top) and JSON RPC Provider / Alchemy provider (expected - middle, bottom)
<img width="856" alt="3 errors - issue" src="https://user-images.githubusercontent.com/30577966/226069311-726cdfff-68f5-4c13-9465-2955216c734e.png">


https://user-images.githubusercontent.com/30577966/226449717-dffe6800-75e3-4811-b197-c4552f24045b.mov


3 consistent errors (after fixes) - Magic, JSON RPC, and Alchemy
<img width="589" alt="3 errrors" src="https://user-images.githubusercontent.com/30577966/226067252-f2e5b1b0-e4c7-4ab0-bb09-fbb68640257b.png">


### Reviewer Notes (Optional)

For this to pass, the magic-sdk PR should be merged in first (type from magic-sdk now expects the data key)

### [PR Description Guide](https://fortmatic.atlassian.net/wiki/spaces/HR/pages/1130430465/Frontend+PR+Description+Examples)


### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
