### PR TITLE
`@react-native-community/async-storage` => `@react-native-async-storage/async-storage` in RN Bare Package

### DIFF
--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.15.0",
     "@babel/plugin-transform-flow-strip-types": "^7.14.5",
     "@babel/runtime": "~7.10.4",
-    "@react-native-community/async-storage": "^1.12.1",
+    "@react-native-async-storage/async-storage": "^1.15.5",
     "metro-react-native-babel-preset": "^0.66.2",
     "react": "^16.13.1",
     "react-native": "^0.62.2",
@@ -45,7 +45,7 @@
     "react-native-webview": "^11.26.0"
   },
   "peerDependencies": {
-    "@react-native-community/async-storage": ">=1.12.1",
+    "@react-native-async-storage/async-storage": ">=1.15.5",
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-device-info": ">=10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,7 +2768,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2776,7 +2776,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2784,7 +2784,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2792,7 +2792,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2800,7 +2800,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/connect@workspace:packages/@magic-ext/connect"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2808,7 +2808,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2816,7 +2816,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2824,7 +2824,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2837,7 +2837,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2845,7 +2845,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2853,18 +2853,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.3.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^8.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/types": ^12.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.3.1
+    magic-sdk: ^14.0.0
   languageName: unknown
   linkType: soft
 
@@ -2880,7 +2880,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2888,7 +2888,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^14.6.2
+    "@magic-sdk/react-native-bare": ^15.0.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2904,7 +2904,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^14.6.2
+    "@magic-sdk/react-native-expo": ^15.0.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2919,7 +2919,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2927,7 +2927,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2935,7 +2935,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2943,7 +2943,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2951,7 +2951,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -2959,16 +2959,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^9.6.2
+    "@magic-sdk/commons": ^10.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^9.6.2, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^10.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^13.6.2
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/provider": ^14.0.0
+    "@magic-sdk/types": ^12.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2992,18 +2992,18 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.3.1
-    magic-sdk: ^13.3.1
+    "@magic-ext/oauth": ^8.0.0
+    magic-sdk: ^14.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^13.6.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^14.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
     "@coinbase/wallet-sdk": 3.6.3
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/types": ^12.0.0
     "@peculiar/webcrypto": ^1.1.7
     "@walletconnect/web3-provider": ^1.8.0
     eventemitter3: ^4.0.4
@@ -3029,7 +3029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^14.6.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^15.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3037,9 +3037,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.6.2
-    "@magic-sdk/provider": ^13.6.2
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/commons": ^10.0.0
+    "@magic-sdk/provider": ^14.0.0
+    "@magic-sdk/types": ^12.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3065,7 +3065,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^14.6.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^15.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3073,9 +3073,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^9.6.2
-    "@magic-sdk/provider": ^13.6.2
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/commons": ^10.0.0
+    "@magic-sdk/provider": ^14.0.0
+    "@magic-sdk/types": ^12.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3101,7 +3101,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^11.6.2, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^12.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -13365,16 +13365,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.3.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^14.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^9.6.2
-    "@magic-sdk/provider": ^13.6.2
-    "@magic-sdk/types": ^11.6.2
+    "@magic-sdk/commons": ^10.0.0
+    "@magic-sdk/provider": ^14.0.0
+    "@magic-sdk/types": ^12.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,14 +2857,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^7.6.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^7.3.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
     "@magic-sdk/types": ^11.6.2
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^13.6.2
+    magic-sdk: ^13.3.1
   languageName: unknown
   linkType: soft
 
@@ -2992,8 +2992,8 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^7.6.2
-    magic-sdk: ^13.6.2
+    "@magic-ext/oauth": ^7.3.1
+    magic-sdk: ^13.3.1
   languageName: unknown
   linkType: soft
 
@@ -3041,7 +3041,6 @@ __metadata:
     "@magic-sdk/provider": ^13.6.2
     "@magic-sdk/types": ^11.6.2
     "@react-native-async-storage/async-storage": ^1.15.5
-    "@react-native-community/async-storage": ^1.12.1
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
     localforage: ^1.7.4
@@ -3057,7 +3056,7 @@ __metadata:
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
-    "@react-native-community/async-storage": ">=1.12.1"
+    "@react-native-async-storage/async-storage": ">=1.15.5"
     react: ">=16"
     react-native: ">=0.60"
     react-native-device-info: ">=10.3.0"
@@ -3593,18 +3592,6 @@ __metadata:
   peerDependencies:
     react-native: ^0.0.0-0 || 0.60 - 0.71 || 1000.0.0
   checksum: 691f2b74498160d0b532f673402d8affeecb28b005b1c6d6fa2e7c87f89ab3068177e8e2d2686738306e7592a39c6d7148aa4c426b7e8e149c43a336ad446648
-  languageName: node
-  linkType: hard
-
-"@react-native-community/async-storage@npm:^1.12.1":
-  version: 1.12.1
-  resolution: "@react-native-community/async-storage@npm:1.12.1"
-  dependencies:
-    deep-assign: ^3.0.0
-  peerDependencies:
-    react: ^16.8
-    react-native: ">=0.59"
-  checksum: 68b519eb9fc50899257878440fd49a500d4b35c3899311c56c672e779df6516f0760204f6c8edcb3e83398c61a775822996aac6974be4b55a04ad30448d8662d
   languageName: node
   linkType: hard
 
@@ -7447,15 +7434,6 @@ __metadata:
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
   checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
-  languageName: node
-  linkType: hard
-
-"deep-assign@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "deep-assign@npm:3.0.0"
-  dependencies:
-    is-obj: ^1.0.0
-  checksum: 9041ccc72ae1980f014d4b745d6135d8f0e71d60ac433397550789c27e6b4d14bc0de2af69777e09f97e1d0da3007a8d78de36f7bf9df931c9968b68fc9546ab
   languageName: node
   linkType: hard
 
@@ -13387,7 +13365,7 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^13.6.2, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^13.3.1, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:


### PR DESCRIPTION
### 📦 Pull Request

`@react-native-community/async-storage` has been deprecated and replaced by `@react-native-async-storage/async-storage`. This updates our dependencies to match the update.

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
