### PR TITLE
Remove Beta Warning from RN packages

### DIFF
--- a/packages/@magic-sdk/react-native-bare/README.md
+++ b/packages/@magic-sdk/react-native-bare/README.md
@@ -10,9 +10,6 @@
   <a href="https://github.com/magiclabs/magic-js/blob/master/CONTRIBUTING.md">Contributing Guide</a>
 </p>
 
-## ⚠️ Major Change: Package Split Beta ⚠️ 
-Please note that splitting the `Expo` and `Bare React Native` Magic packages is a part of a **beta** release. Take whatever precautions necessary to verify use before installing on your production application. As always, in the case something goes awry, you may open an issue and revert your package to the previous pre-split stable bare react native version `magic-sdk/react-native@^8.0.0`.
-
 ## 📖 Documentation
 
 See the [developer documentation](https://magic.link/docs) to learn how you can master the Magic SDK in a matter of minutes.

--- a/packages/@magic-sdk/react-native-expo/README.md
+++ b/packages/@magic-sdk/react-native-expo/README.md
@@ -9,9 +9,6 @@
    <a href="https://github.com/magiclabs/magic-js/blob/master/CONTRIBUTING.md">Contributing Guide</a>
  </p>
 
-## ⚠️ Major Change: Package Split Beta ⚠️ 
-Please note that splitting the `Expo` and `Bare React Native` Magic package is a part of a **beta** release. Take whatever precautions necessary to verify use before installing on your production application. As always, in the case something goes awry, you may open an issue and revert your package to the previous pre-split stable version `magic-sdk/react-native@x.x.x`.
-
  ## 📖 Documentation
 
  See the [developer documentation](https://magic.link/docs) to learn how you can master the Magic SDK in a matter of minutes.


### PR DESCRIPTION
### 📦 Pull Request

Removes the Beta label from our react native packages. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-bare-oauth@11.2.0-canary.491.4641410358.0
  npm install @magic-ext/react-native-expo-oauth@11.2.0-canary.491.4641410358.0
  npm install @magic-sdk/react-native-bare@17.2.0-canary.491.4641410358.0
  npm install @magic-sdk/react-native-expo@17.2.0-canary.491.4641410358.0
  # or 
  yarn add @magic-ext/react-native-bare-oauth@11.2.0-canary.491.4641410358.0
  yarn add @magic-ext/react-native-expo-oauth@11.2.0-canary.491.4641410358.0
  yarn add @magic-sdk/react-native-bare@17.2.0-canary.491.4641410358.0
  yarn add @magic-sdk/react-native-expo@17.2.0-canary.491.4641410358.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
