### PR TITLE
React Native Expo SDK WebView Url Tap Navigate to Device Browser when `open_in_device_browser` is True

### DIFF
--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
@@ -8,6 +8,7 @@ import { isTypedArray } from 'lodash';
 import Global = NodeJS.Global;
 
 const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
+const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
 
 /**
  * Builds the Magic `<WebView>` overlay styles. These base styles enable
@@ -128,6 +129,16 @@ export class ReactNativeWebViewController extends ViewController {
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
           autoManageStatusBarEnabled={false}
+          onShouldStartLoadWithRequest={(event) => {
+            const queryParams = new URLSearchParams(event.url.split('?')[1]);
+            const openInDeviceBrowser = queryParams.get(OPEN_IN_DEVICE_BROWSER);
+
+            if (openInDeviceBrowser) {
+              Linking.openURL(event.url);
+              return false;
+            }
+            return true;
+          }}
         />
       </SafeAreaView>
     );

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -160,7 +160,7 @@ export class ReactNativeWebViewController extends ViewController {
       // The typed Array is stringified in Mgbox with a flag as notation.
       const data: any = JSON.parse(event.nativeEvent.data, (key, value) => {
         try {
-          if (value && typeof value === 'object' && value.flag && value.flag === 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY') {
+          if (value && typeof value === 'object' && value.flag && value.flag === MAGIC_PAYLOAD_FLAG_TYPED_ARRAY) {
             return new (global[value.constructor as keyof Global] as any)(value.data.split(','));
           }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,14 +2820,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^11.1.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^11.1.3, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
     "@magic-sdk/types": ^15.1.2
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^17.1.2
+    magic-sdk: ^17.1.3
   languageName: unknown
   linkType: soft
 
@@ -2955,8 +2955,8 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^11.1.2
-    magic-sdk: ^17.1.2
+    "@magic-ext/oauth": ^11.1.3
+    magic-sdk: ^17.1.3
   languageName: unknown
   linkType: soft
 
@@ -12316,7 +12316,7 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^17.1.2, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^17.1.3, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:


### PR DESCRIPTION
### 📦 Pull Request

Utilizes `react-native-webview`'s `onShouldStartLoadWithRequest` to detect if a url contains `open_in_device_browser` query and determine if link should be opened on device browser app. 

### ✅ Fixed Issues

N/A

### 🚨 Test instructions

Tested the following flow against https://github.com/fortmatic/phantom/pull/2489 update to Relayer with our [React Native Demo Apps](https://github.com/magiclabs/react-native-demo) on iOS and Android. 
## Android
![2023-05-09 14 43 47](https://github.com/magiclabs/magic-js/assets/13407884/dacf188e-7260-4ab3-90cf-248a8ffedbfd)

## iOS
![2023-05-09 13 24 34](https://github.com/magiclabs/magic-js/assets/13407884/deded454-f1cd-461d-ae0a-5caca34d6204)


### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-expo-oauth@12.2.0-canary.508.4931052988.0
  npm install @magic-sdk/react-native-expo@18.2.0-canary.508.4931052988.0
  # or 
  yarn add @magic-ext/react-native-expo-oauth@12.2.0-canary.508.4931052988.0
  yarn add @magic-sdk/react-native-expo@18.2.0-canary.508.4931052988.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
