### PR TITLE
Add typings to package.json export

### DIFF
--- a/packages/@magic-ext/aptos/package.json
+++ b/packages/@magic-ext/aptos/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"
   },

--- a/packages/@magic-sdk/commons/package.json
+++ b/packages/@magic-sdk/commons/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"
   },

--- a/packages/@magic-sdk/provider/package.json
+++ b/packages/@magic-sdk/provider/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"
   },

--- a/packages/@magic-sdk/types/package.json
+++ b/packages/@magic-sdk/types/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"
   },

--- a/packages/magic-sdk/package.json
+++ b/packages/magic-sdk/package.json
@@ -19,6 +19,7 @@
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/magic.js",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"
   },


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]
Cannot find types of magic-sdk in vite-react app

<img width="916" alt="image" src="https://github.com/magiclabs/magic-js/assets/9082598/e05e733d-1a9f-422c-9262-37875adb8194">


### ✅ Fixed Issues

- https://github.com/gxmari007/vite-plugin-eslint/pull/60
- https://github.com/moleculerjs/moleculer/pull/1210

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]
Create a new vite-react app with the below commend
```bash
npx vite@latest
```
Install magic-sdk and check if types of magic-sdk is loaded


### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/aptos@1.0.1-canary.517.5359958472.0
  npm install @magic-ext/auth@1.0.1-canary.517.5359958472.0
  npm install @magic-ext/avalanche@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/bitcoin@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/conflux@11.0.1-canary.517.5359958472.0
  npm install @magic-ext/cosmos@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/ed25519@9.0.1-canary.517.5359958472.0
  npm install @magic-ext/flow@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/gdkms@1.0.1-canary.517.5359958472.0
  npm install @magic-ext/harmony@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/icon@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/near@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/oauth@12.0.1-canary.517.5359958472.0
  npm install @magic-ext/polkadot@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/react-native-bare-oauth@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/react-native-expo-oauth@13.0.2-canary.517.5359958472.0
  npm install @magic-ext/solana@14.0.1-canary.517.5359958472.0
  npm install @magic-ext/taquito@10.0.1-canary.517.5359958472.0
  npm install @magic-ext/terra@10.0.1-canary.517.5359958472.0
  npm install @magic-ext/tezos@13.0.1-canary.517.5359958472.0
  npm install @magic-ext/webauthn@12.0.1-canary.517.5359958472.0
  npm install @magic-ext/zilliqa@13.0.1-canary.517.5359958472.0
  npm install @magic-sdk/commons@14.0.1-canary.517.5359958472.0
  npm install @magic-sdk/pnp@12.0.1-canary.517.5359958472.0
  npm install @magic-sdk/provider@18.0.1-canary.517.5359958472.0
  npm install @magic-sdk/react-native-bare@19.0.1-canary.517.5359958472.0
  npm install @magic-sdk/react-native-expo@19.0.2-canary.517.5359958472.0
  npm install @magic-sdk/types@15.4.1-canary.517.5359958472.0
  npm install magic-sdk@18.0.1-canary.517.5359958472.0
  # or 
  yarn add @magic-ext/algorand@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/aptos@1.0.1-canary.517.5359958472.0
  yarn add @magic-ext/auth@1.0.1-canary.517.5359958472.0
  yarn add @magic-ext/avalanche@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/bitcoin@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/conflux@11.0.1-canary.517.5359958472.0
  yarn add @magic-ext/cosmos@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/ed25519@9.0.1-canary.517.5359958472.0
  yarn add @magic-ext/flow@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/gdkms@1.0.1-canary.517.5359958472.0
  yarn add @magic-ext/harmony@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/icon@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/near@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/oauth@12.0.1-canary.517.5359958472.0
  yarn add @magic-ext/polkadot@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/react-native-bare-oauth@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/react-native-expo-oauth@13.0.2-canary.517.5359958472.0
  yarn add @magic-ext/solana@14.0.1-canary.517.5359958472.0
  yarn add @magic-ext/taquito@10.0.1-canary.517.5359958472.0
  yarn add @magic-ext/terra@10.0.1-canary.517.5359958472.0
  yarn add @magic-ext/tezos@13.0.1-canary.517.5359958472.0
  yarn add @magic-ext/webauthn@12.0.1-canary.517.5359958472.0
  yarn add @magic-ext/zilliqa@13.0.1-canary.517.5359958472.0
  yarn add @magic-sdk/commons@14.0.1-canary.517.5359958472.0
  yarn add @magic-sdk/pnp@12.0.1-canary.517.5359958472.0
  yarn add @magic-sdk/provider@18.0.1-canary.517.5359958472.0
  yarn add @magic-sdk/react-native-bare@19.0.1-canary.517.5359958472.0
  yarn add @magic-sdk/react-native-expo@19.0.2-canary.517.5359958472.0
  yarn add @magic-sdk/types@15.4.1-canary.517.5359958472.0
  yarn add magic-sdk@18.0.1-canary.517.5359958472.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
