### PR TITLE
Add conditional for `useInstead` of `loginWithMagicLink` `createDeprecationWarning` call

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -35,7 +35,9 @@ export class AuthModule extends BaseModule {
     createDeprecationWarning({
       method: 'auth.loginWithMagicLink()',
       removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: isRNMobilePackage ? 'auth.loginWithEmailOTP()' : '@magic-ext/auth auth.loginWithMagicLink()',
+      useInstead: isRNMobilePackage
+        ? '@magic-ext/auth auth.loginWithEmailOTP()'
+        : '@magic-ext/auth auth.loginWithMagicLink()',
     }).log();
 
     const { email, showUI = true, redirectURI } = configuration;

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -27,11 +27,17 @@ export class AuthModule extends BaseModule {
    * of 15 minutes).
    */
   public loginWithMagicLink(configuration: LoginWithMagicLinkConfiguration) {
+    const isRNMobilePackage =
+      SDKEnvironment.sdkName === '@magic-sdk/react-native' ||
+      SDKEnvironment.sdkName === '@magic-sdk/react-native-bare' ||
+      SDKEnvironment.sdkName === '@magic-sdk/react-native-expo';
+
     createDeprecationWarning({
       method: 'auth.loginWithMagicLink()',
       removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: '@magic-ext/auth auth.loginWithMagicLink()',
+      useInstead: isRNMobilePackage ? 'auth.loginWithEmailOTP()' : '@magic-ext/auth auth.loginWithMagicLink()',
     }).log();
+
     const { email, showUI = true, redirectURI } = configuration;
 
     const requestPayload = createJsonRpcRequestPayload(


### PR DESCRIPTION
### 📦 Pull Request

Adds a `isRNMobilePackage` variable to encourage RN package users to use `auth.loginWithEmailOTP()` instead of the `@magic-ext/auth auth.loginWithMagicLink()` as they will be unable to do so on the next major release. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/aptos@0.2.1-canary.518.5018092432.0
  npm install @magic-ext/auth@0.2.4-canary.518.5018092432.0
  npm install @magic-ext/avalanche@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/bitcoin@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/conflux@10.1.4-canary.518.5018092432.0
  npm install @magic-ext/cosmos@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/ed25519@8.1.4-canary.518.5018092432.0
  npm install @magic-ext/flow@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/harmony@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/icon@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/near@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/oauth@11.1.5-canary.518.5018092432.0
  npm install @magic-ext/polkadot@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/react-native-bare-oauth@12.2.2-canary.518.5018092432.0
  npm install @magic-ext/react-native-expo-oauth@12.2.2-canary.518.5018092432.0
  npm install @magic-ext/solana@13.1.4-canary.518.5018092432.0
  npm install @magic-ext/taquito@9.1.4-canary.518.5018092432.0
  npm install @magic-ext/terra@9.1.4-canary.518.5018092432.0
  npm install @magic-ext/tezos@12.1.4-canary.518.5018092432.0
  npm install @magic-ext/webauthn@11.1.4-canary.518.5018092432.0
  npm install @magic-ext/zilliqa@12.1.4-canary.518.5018092432.0
  npm install @magic-sdk/commons@13.1.4-canary.518.5018092432.0
  npm install @magic-sdk/pnp@11.1.5-canary.518.5018092432.0
  npm install @magic-sdk/provider@17.1.4-canary.518.5018092432.0
  npm install @magic-sdk/react-native-bare@18.2.2-canary.518.5018092432.0
  npm install @magic-sdk/react-native-expo@18.2.2-canary.518.5018092432.0
  npm install magic-sdk@17.1.5-canary.518.5018092432.0
  # or 
  yarn add @magic-ext/algorand@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/aptos@0.2.1-canary.518.5018092432.0
  yarn add @magic-ext/auth@0.2.4-canary.518.5018092432.0
  yarn add @magic-ext/avalanche@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/bitcoin@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/conflux@10.1.4-canary.518.5018092432.0
  yarn add @magic-ext/cosmos@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/ed25519@8.1.4-canary.518.5018092432.0
  yarn add @magic-ext/flow@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/harmony@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/icon@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/near@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/oauth@11.1.5-canary.518.5018092432.0
  yarn add @magic-ext/polkadot@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/react-native-bare-oauth@12.2.2-canary.518.5018092432.0
  yarn add @magic-ext/react-native-expo-oauth@12.2.2-canary.518.5018092432.0
  yarn add @magic-ext/solana@13.1.4-canary.518.5018092432.0
  yarn add @magic-ext/taquito@9.1.4-canary.518.5018092432.0
  yarn add @magic-ext/terra@9.1.4-canary.518.5018092432.0
  yarn add @magic-ext/tezos@12.1.4-canary.518.5018092432.0
  yarn add @magic-ext/webauthn@11.1.4-canary.518.5018092432.0
  yarn add @magic-ext/zilliqa@12.1.4-canary.518.5018092432.0
  yarn add @magic-sdk/commons@13.1.4-canary.518.5018092432.0
  yarn add @magic-sdk/pnp@11.1.5-canary.518.5018092432.0
  yarn add @magic-sdk/provider@17.1.4-canary.518.5018092432.0
  yarn add @magic-sdk/react-native-bare@18.2.2-canary.518.5018092432.0
  yarn add @magic-sdk/react-native-expo@18.2.2-canary.518.5018092432.0
  yarn add magic-sdk@17.1.5-canary.518.5018092432.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
