### PR TITLE
Add recovery to DeepLink page

### DIFF
--- a/packages/@magic-sdk/types/src/core/deep-link-pages.ts
+++ b/packages/@magic-sdk/types/src/core/deep-link-pages.ts
@@ -1,3 +1,4 @@
 export enum DeepLinkPage {
   MFA = 'mfa',
+  Recovery = 'recovery',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,7 +2731,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2739,7 +2739,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
     aptos: ^1.8.5
   peerDependencies:
     aptos: ^1.8.5
@@ -2750,7 +2750,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2758,7 +2758,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2766,7 +2766,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2774,7 +2774,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2782,7 +2782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2790,7 +2790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2798,7 +2798,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2811,7 +2811,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2819,7 +2819,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2827,18 +2827,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^11.1.6, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^11.2.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/types": ^15.2.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^17.1.6
+    magic-sdk: ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2854,7 +2854,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2862,7 +2862,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^18.2.3
+    "@magic-sdk/react-native-bare": ^18.3.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2878,7 +2878,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^18.2.3
+    "@magic-sdk/react-native-expo": ^18.3.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2893,7 +2893,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2901,7 +2901,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2909,7 +2909,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2917,7 +2917,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2925,7 +2925,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
@@ -2933,16 +2933,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^13.1.5
+    "@magic-sdk/commons": ^13.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^13.1.5, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^13.2.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^17.1.5
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/provider": ^17.2.0
+    "@magic-sdk/types": ^15.2.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2966,17 +2966,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^11.1.6
-    magic-sdk: ^17.1.6
+    "@magic-ext/oauth": ^11.2.0
+    magic-sdk: ^17.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^17.1.5, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^17.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/types": ^15.2.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3001,7 +3001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/react-native-bare@^18.2.3, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^18.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3009,9 +3009,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^13.1.5
-    "@magic-sdk/provider": ^17.1.5
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/commons": ^13.2.0
+    "@magic-sdk/provider": ^17.2.0
+    "@magic-sdk/types": ^15.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3037,7 +3037,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^18.2.3, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^18.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3045,9 +3045,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^13.1.5
-    "@magic-sdk/provider": ^17.1.5
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/commons": ^13.2.0
+    "@magic-sdk/provider": ^17.2.0
+    "@magic-sdk/types": ^15.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3073,7 +3073,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^15.1.4, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^15.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12402,16 +12402,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^17.1.6, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^17.2.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^13.1.5
-    "@magic-sdk/provider": ^17.1.5
-    "@magic-sdk/types": ^15.1.4
+    "@magic-sdk/commons": ^13.2.0
+    "@magic-sdk/provider": ^17.2.0
+    "@magic-sdk/types": ^15.2.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/aptos@0.3.1-canary.523.5071472728.0
  npm install @magic-ext/auth@0.3.1-canary.523.5071472728.0
  npm install @magic-ext/avalanche@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/bitcoin@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/conflux@10.2.1-canary.523.5071472728.0
  npm install @magic-ext/cosmos@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/ed25519@8.2.1-canary.523.5071472728.0
  npm install @magic-ext/flow@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/harmony@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/icon@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/near@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/oauth@11.2.1-canary.523.5071472728.0
  npm install @magic-ext/polkadot@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/react-native-bare-oauth@12.3.1-canary.523.5071472728.0
  npm install @magic-ext/react-native-expo-oauth@12.3.1-canary.523.5071472728.0
  npm install @magic-ext/solana@13.2.1-canary.523.5071472728.0
  npm install @magic-ext/taquito@9.2.1-canary.523.5071472728.0
  npm install @magic-ext/terra@9.2.1-canary.523.5071472728.0
  npm install @magic-ext/tezos@12.2.1-canary.523.5071472728.0
  npm install @magic-ext/webauthn@11.2.1-canary.523.5071472728.0
  npm install @magic-ext/zilliqa@12.2.1-canary.523.5071472728.0
  npm install @magic-sdk/commons@13.2.1-canary.523.5071472728.0
  npm install @magic-sdk/pnp@11.2.1-canary.523.5071472728.0
  npm install @magic-sdk/provider@17.2.1-canary.523.5071472728.0
  npm install @magic-sdk/react-native-bare@18.3.1-canary.523.5071472728.0
  npm install @magic-sdk/react-native-expo@18.3.1-canary.523.5071472728.0
  npm install @magic-sdk/types@15.2.1-canary.523.5071472728.0
  npm install magic-sdk@17.2.1-canary.523.5071472728.0
  # or 
  yarn add @magic-ext/algorand@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/aptos@0.3.1-canary.523.5071472728.0
  yarn add @magic-ext/auth@0.3.1-canary.523.5071472728.0
  yarn add @magic-ext/avalanche@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/bitcoin@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/conflux@10.2.1-canary.523.5071472728.0
  yarn add @magic-ext/cosmos@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/ed25519@8.2.1-canary.523.5071472728.0
  yarn add @magic-ext/flow@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/harmony@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/icon@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/near@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/oauth@11.2.1-canary.523.5071472728.0
  yarn add @magic-ext/polkadot@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/react-native-bare-oauth@12.3.1-canary.523.5071472728.0
  yarn add @magic-ext/react-native-expo-oauth@12.3.1-canary.523.5071472728.0
  yarn add @magic-ext/solana@13.2.1-canary.523.5071472728.0
  yarn add @magic-ext/taquito@9.2.1-canary.523.5071472728.0
  yarn add @magic-ext/terra@9.2.1-canary.523.5071472728.0
  yarn add @magic-ext/tezos@12.2.1-canary.523.5071472728.0
  yarn add @magic-ext/webauthn@11.2.1-canary.523.5071472728.0
  yarn add @magic-ext/zilliqa@12.2.1-canary.523.5071472728.0
  yarn add @magic-sdk/commons@13.2.1-canary.523.5071472728.0
  yarn add @magic-sdk/pnp@11.2.1-canary.523.5071472728.0
  yarn add @magic-sdk/provider@17.2.1-canary.523.5071472728.0
  yarn add @magic-sdk/react-native-bare@18.3.1-canary.523.5071472728.0
  yarn add @magic-sdk/react-native-expo@18.3.1-canary.523.5071472728.0
  yarn add @magic-sdk/types@15.2.1-canary.523.5071472728.0
  yarn add magic-sdk@17.2.1-canary.523.5071472728.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
