### PR TITLE
Replace magic-sdk to @magic-sdk/provider for rn support

### DIFF
--- a/packages/@magic-ext/aptos/package.json
+++ b/packages/@magic-ext/aptos/package.json
@@ -23,18 +23,18 @@
   },
   "externals": {
     "include": [
-      "@magic-sdk/commons"
+      "@magic-sdk/commons",
+      "@magic-sdk/provider"
     ]
   },
   "devDependencies": {
     "@aptos-labs/wallet-adapter-core": "^2.2.0",
     "@magic-sdk/commons": "^13.3.0",
-    "aptos": "^1.8.5",
-    "magic-sdk": "^17.3.0"
+    "@magic-sdk/provider": "^17.3.0",
+    "aptos": "^1.8.5"
   },
   "peerDependencies": {
     "@aptos-labs/wallet-adapter-core": "^2.2.0",
-    "aptos": "^1.8.5",
-    "magic-sdk": "^17.3.0"
+    "aptos": "^1.8.5"
   }
 }

--- a/packages/@magic-ext/aptos/package.json
+++ b/packages/@magic-ext/aptos/package.json
@@ -16,7 +16,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/aptos/src/MagicAptosWallet.ts
+++ b/packages/@magic-ext/aptos/src/MagicAptosWallet.ts
@@ -8,7 +8,8 @@ import {
   WalletReadyState,
 } from '@aptos-labs/wallet-adapter-core';
 import { TxnBuilderTypes, Types } from 'aptos';
-import type { Extension, Magic } from 'magic-sdk';
+import { Extension } from '@magic-sdk/commons';
+import { InstanceWithExtensions, SDKBase } from '@magic-sdk/provider';
 import { AptosExtension } from '.';
 import { APTOS_NETWORKS, APTOS_NODE_URLS, APTOS_WALLET_NAME, ICON_BASE64 } from './constants';
 import { MagicAptosWalletConfig } from './type';
@@ -20,14 +21,17 @@ export class MagicAptosWallet implements AdapterPlugin {
 
   readonly providerName = 'magicWalletMA';
 
-  provider: Magic<[AptosExtension, Extension]> | undefined;
+  provider: InstanceWithExtensions<SDKBase, [AptosExtension, Extension]> | undefined;
   config?: MagicAptosWalletConfig;
 
   readyState?: WalletReadyState = WalletReadyState.Loadable;
 
   private accountInfo: AccountInfo | null;
 
-  constructor(magic: Magic<[AptosExtension, Extension]> | undefined, magicAptosWalletConfig?: MagicAptosWalletConfig) {
+  constructor(
+    magic: InstanceWithExtensions<SDKBase, [AptosExtension, Extension]> | undefined,
+    magicAptosWalletConfig?: MagicAptosWalletConfig,
+  ) {
     this.provider = magic;
     this.accountInfo = null;
     this.config = magicAptosWalletConfig;

--- a/packages/@magic-ext/aptos/src/index.native.ts
+++ b/packages/@magic-ext/aptos/src/index.native.ts
@@ -1,1 +1,0 @@
-export * from './index';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,12 +2753,11 @@ __metadata:
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
     "@magic-sdk/commons": ^13.3.0
+    "@magic-sdk/provider": ^17.3.0
     aptos: ^1.8.5
-    magic-sdk: ^17.3.0
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
     aptos: ^1.8.5
-    magic-sdk: ^17.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Replace magic-sdk to @magic-sdk/provider for rn support and remove `react-native` filed not used.

Since the aptos-js SDK relies on browser-specific APIs such as TextDecoder and TextEncoder, we need to provide a guideline for installing a text polyfill.

Option 1.
1. Install [react-native-polyfill-globals](https://github.com/acostalima/react-native-polyfill-globals)
```bash
$ yarn add react-native-polyfill-globals text-encoding
```
2. Put the below code into your root file.
```react
import { polyfill as polyfillEncoding } from "react-native-polyfill-globals/src/encoding";

polyfillEncoding();
```

Option 2.
1. Install [text-encoding-polyfill](https://www.npmjs.com/package/text-encoding-polyfill)
```bash
$ yarn add text-encoding-polyfill
```
2. Put the below code into your root file.
```react
import "text-encoding-polyfill";
```

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

- https://app.shortcut.com/magic-labs/story/79458/aptos-support-rn

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
