### PR TITLE
Remove approval step for canary releases [sc-80045]

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-20.04
     name: Canary
     needs: build
-    environment: production
     steps:
       - uses: actions/checkout@v3
         with:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,7 +2901,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^19.0.0
+    "@magic-sdk/react-native-expo": ^19.0.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3060,7 +3060,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^19.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^19.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:


### PR DESCRIPTION
### 📦 Pull Request

Remove approval step for canary releases

### ✅ Fixed Issues

- Fixes #80045

### 🚨 Test instructions

Validate canary release on next merge to master is auto published

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/aptos@1.0.1-canary.549.5359900236.0
  npm install @magic-ext/auth@1.0.1-canary.549.5359900236.0
  npm install @magic-ext/avalanche@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/bitcoin@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/conflux@11.0.1-canary.549.5359900236.0
  npm install @magic-ext/cosmos@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/ed25519@9.0.1-canary.549.5359900236.0
  npm install @magic-ext/flow@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/gdkms@1.0.1-canary.549.5359900236.0
  npm install @magic-ext/harmony@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/icon@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/near@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/oauth@12.0.1-canary.549.5359900236.0
  npm install @magic-ext/polkadot@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/react-native-bare-oauth@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/react-native-expo-oauth@13.0.2-canary.549.5359900236.0
  npm install @magic-ext/solana@14.0.1-canary.549.5359900236.0
  npm install @magic-ext/taquito@10.0.1-canary.549.5359900236.0
  npm install @magic-ext/terra@10.0.1-canary.549.5359900236.0
  npm install @magic-ext/tezos@13.0.1-canary.549.5359900236.0
  npm install @magic-ext/webauthn@12.0.1-canary.549.5359900236.0
  npm install @magic-ext/zilliqa@13.0.1-canary.549.5359900236.0
  npm install @magic-sdk/commons@14.0.1-canary.549.5359900236.0
  npm install @magic-sdk/pnp@12.0.1-canary.549.5359900236.0
  npm install @magic-sdk/provider@18.0.1-canary.549.5359900236.0
  npm install @magic-sdk/react-native-bare@19.0.1-canary.549.5359900236.0
  npm install @magic-sdk/react-native-expo@19.0.2-canary.549.5359900236.0
  npm install magic-sdk@18.0.1-canary.549.5359900236.0
  # or 
  yarn add @magic-ext/algorand@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/aptos@1.0.1-canary.549.5359900236.0
  yarn add @magic-ext/auth@1.0.1-canary.549.5359900236.0
  yarn add @magic-ext/avalanche@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/bitcoin@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/conflux@11.0.1-canary.549.5359900236.0
  yarn add @magic-ext/cosmos@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/ed25519@9.0.1-canary.549.5359900236.0
  yarn add @magic-ext/flow@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/gdkms@1.0.1-canary.549.5359900236.0
  yarn add @magic-ext/harmony@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/icon@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/near@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/oauth@12.0.1-canary.549.5359900236.0
  yarn add @magic-ext/polkadot@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/react-native-bare-oauth@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/react-native-expo-oauth@13.0.2-canary.549.5359900236.0
  yarn add @magic-ext/solana@14.0.1-canary.549.5359900236.0
  yarn add @magic-ext/taquito@10.0.1-canary.549.5359900236.0
  yarn add @magic-ext/terra@10.0.1-canary.549.5359900236.0
  yarn add @magic-ext/tezos@13.0.1-canary.549.5359900236.0
  yarn add @magic-ext/webauthn@12.0.1-canary.549.5359900236.0
  yarn add @magic-ext/zilliqa@13.0.1-canary.549.5359900236.0
  yarn add @magic-sdk/commons@14.0.1-canary.549.5359900236.0
  yarn add @magic-sdk/pnp@12.0.1-canary.549.5359900236.0
  yarn add @magic-sdk/provider@18.0.1-canary.549.5359900236.0
  yarn add @magic-sdk/react-native-bare@19.0.1-canary.549.5359900236.0
  yarn add @magic-sdk/react-native-expo@19.0.2-canary.549.5359900236.0
  yarn add magic-sdk@18.0.1-canary.549.5359900236.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
