### PR TITLE
Revert nft.checkout

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/nft.ts
+++ b/packages/@magic-sdk/provider/src/modules/nft.ts
@@ -18,21 +18,6 @@ export class NFTModule extends BaseModule {
   /* Start an NFT Checkout flow with Paypal */
   public async checkout(options: NFTCheckoutRequest) {
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.NFTCheckout, [options]);
-    const response = await this.request<NFTCheckoutResponse>(requestPayload);
-
-    if (response?.viewInWallet) {
-      const requestViewInWalletPayload = createJsonRpcRequestPayload(MagicPayloadMethod.ShowUI, [
-        {
-          deeplink: 'collectible-details',
-          params: {
-            contractAddress: options.contractAddress,
-            tokenId: options.tokenId,
-          },
-        },
-      ]);
-      await this.request<NFTCheckoutResponse>(requestViewInWalletPayload);
-    }
-
-    return response;
+    return this.request<NFTCheckoutResponse>(requestPayload);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,7 +2743,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2752,8 +2752,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^14.0.0
-    "@magic-sdk/provider": ^18.0.0
+    "@magic-sdk/commons": ^14.2.0
+    "@magic-sdk/provider": ^18.2.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2765,7 +2765,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2773,7 +2773,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2781,7 +2781,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2789,7 +2789,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2797,7 +2797,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2805,7 +2805,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2813,7 +2813,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
     "@onflow/fcl": 0.0.41
     "@onflow/types": 0.0.3
   peerDependencies:
@@ -2826,7 +2826,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2834,7 +2834,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2842,7 +2842,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2850,18 +2850,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^12.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^12.2.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/types": ^15.6.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^18.0.0
+    magic-sdk: ^18.2.0
   languageName: unknown
   linkType: soft
 
@@ -2869,7 +2869,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2877,7 +2877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2885,7 +2885,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^19.0.0
+    "@magic-sdk/react-native-bare": ^19.2.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2901,7 +2901,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^19.0.1
+    "@magic-sdk/react-native-expo": ^19.2.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2916,7 +2916,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2924,7 +2924,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2932,7 +2932,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2940,7 +2940,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2948,7 +2948,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
@@ -2956,16 +2956,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^14.0.0
+    "@magic-sdk/commons": ^14.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^14.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^14.2.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^18.0.0
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/provider": ^18.2.0
+    "@magic-sdk/types": ^15.6.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -2979,17 +2979,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^12.0.0
-    magic-sdk: ^18.0.0
+    "@magic-ext/oauth": ^12.2.0
+    magic-sdk: ^18.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^18.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^18.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/types": ^15.6.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3001,7 +3001,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^19.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^19.2.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3009,9 +3009,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^14.0.0
-    "@magic-sdk/provider": ^18.0.0
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/commons": ^14.2.0
+    "@magic-sdk/provider": ^18.2.0
+    "@magic-sdk/types": ^15.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3037,7 +3037,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^19.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^19.2.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3045,9 +3045,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^14.0.0
-    "@magic-sdk/provider": ^18.0.0
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/commons": ^14.2.0
+    "@magic-sdk/provider": ^18.2.0
+    "@magic-sdk/types": ^15.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3073,7 +3073,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^15.4.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^15.6.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12418,16 +12418,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^18.0.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^18.2.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^14.0.0
-    "@magic-sdk/provider": ^18.0.0
-    "@magic-sdk/types": ^15.4.0
+    "@magic-sdk/commons": ^14.2.0
+    "@magic-sdk/provider": ^18.2.0
+    "@magic-sdk/types": ^15.6.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

ref #https://github.com/fortmatic/phantom/pull/2720
After the above PR, we don't need to handle `deeplink` in SDK anymore.
So, I reverted the logic.


### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/aptos@1.2.1-canary.560.5422742339.0
  npm install @magic-ext/auth@1.2.1-canary.560.5422742339.0
  npm install @magic-ext/avalanche@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/bitcoin@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/conflux@11.2.1-canary.560.5422742339.0
  npm install @magic-ext/cosmos@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/ed25519@9.2.1-canary.560.5422742339.0
  npm install @magic-ext/flow@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/gdkms@1.2.1-canary.560.5422742339.0
  npm install @magic-ext/harmony@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/icon@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/near@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/oauth@12.2.1-canary.560.5422742339.0
  npm install @magic-ext/oidc@1.1.1-canary.560.5422742339.0
  npm install @magic-ext/polkadot@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/react-native-bare-oauth@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/react-native-expo-oauth@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/solana@14.2.1-canary.560.5422742339.0
  npm install @magic-ext/taquito@10.2.1-canary.560.5422742339.0
  npm install @magic-ext/terra@10.2.1-canary.560.5422742339.0
  npm install @magic-ext/tezos@13.2.1-canary.560.5422742339.0
  npm install @magic-ext/webauthn@12.2.1-canary.560.5422742339.0
  npm install @magic-ext/zilliqa@13.2.1-canary.560.5422742339.0
  npm install @magic-sdk/commons@14.2.1-canary.560.5422742339.0
  npm install @magic-sdk/pnp@12.2.1-canary.560.5422742339.0
  npm install @magic-sdk/provider@18.2.1-canary.560.5422742339.0
  npm install @magic-sdk/react-native-bare@19.2.1-canary.560.5422742339.0
  npm install @magic-sdk/react-native-expo@19.2.1-canary.560.5422742339.0
  npm install magic-sdk@18.2.1-canary.560.5422742339.0
  # or 
  yarn add @magic-ext/algorand@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/aptos@1.2.1-canary.560.5422742339.0
  yarn add @magic-ext/auth@1.2.1-canary.560.5422742339.0
  yarn add @magic-ext/avalanche@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/bitcoin@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/conflux@11.2.1-canary.560.5422742339.0
  yarn add @magic-ext/cosmos@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/ed25519@9.2.1-canary.560.5422742339.0
  yarn add @magic-ext/flow@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/gdkms@1.2.1-canary.560.5422742339.0
  yarn add @magic-ext/harmony@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/icon@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/near@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/oauth@12.2.1-canary.560.5422742339.0
  yarn add @magic-ext/oidc@1.1.1-canary.560.5422742339.0
  yarn add @magic-ext/polkadot@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/react-native-bare-oauth@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/react-native-expo-oauth@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/solana@14.2.1-canary.560.5422742339.0
  yarn add @magic-ext/taquito@10.2.1-canary.560.5422742339.0
  yarn add @magic-ext/terra@10.2.1-canary.560.5422742339.0
  yarn add @magic-ext/tezos@13.2.1-canary.560.5422742339.0
  yarn add @magic-ext/webauthn@12.2.1-canary.560.5422742339.0
  yarn add @magic-ext/zilliqa@13.2.1-canary.560.5422742339.0
  yarn add @magic-sdk/commons@14.2.1-canary.560.5422742339.0
  yarn add @magic-sdk/pnp@12.2.1-canary.560.5422742339.0
  yarn add @magic-sdk/provider@18.2.1-canary.560.5422742339.0
  yarn add @magic-sdk/react-native-bare@19.2.1-canary.560.5422742339.0
  yarn add @magic-sdk/react-native-expo@19.2.1-canary.560.5422742339.0
  yarn add magic-sdk@18.2.1-canary.560.5422742339.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
