### PR TITLE
Adds merge_group to Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - "master"
   pull_request:
+  merge_group:
+   types: [checks_requested]
 
 jobs:
   lint:


### PR DESCRIPTION
### 📦 Pull Request

We need to [trigger `merge_group` checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) in order to get merge queuing to work. 

### ✅ Fixed Issues

N/A

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
