### PR TITLE
Adds merge_group to Canary Workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - "master"
+  merge_group:
+    types: [checks_requested]
 
 env:
   GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "master"
+  pull_request:
+  merge_group:
+   types: [checks_requested]
 
 env:
   GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - "master"
-  pull_request:
-  merge_group:
-   types: [checks_requested]
 
 env:
   GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
### 📦 Pull Request

We need to [trigger `merge_group` checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) in order to get merge queuing to work. 

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
