### PR TITLE
Fix Version History of RN OAuth Packages

### DIFF
--- a/packages/@magic-ext/react-native-bare-oauth/CHANGELOG.md
+++ b/packages/@magic-ext/react-native-bare-oauth/CHANGELOG.md
@@ -28,7 +28,7 @@
 #### Authors: 2
 
 - Arian Flores ([@Ariflo](https://github.com/Ariflo))
-- Jerry Liu ([@Ethella](https://github.com/Ethella))
+- Jerry Liu ([@Ethella](https://github.com/Ethella)) 
 
 ---
 

--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-ext/react-native-bare-oauth",
-  "version": "13.4.1",
+  "version": "13.4.2",
   "description": "Magic SDK OAuth Extension for Bare React Native environments.",
   "author": "Magic <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-ext/react-native-expo-oauth/CHANGELOG.md
+++ b/packages/@magic-ext/react-native-expo-oauth/CHANGELOG.md
@@ -28,7 +28,7 @@
 #### Authors: 2
 
 - Arian Flores ([@Ariflo](https://github.com/Ariflo))
-- Jerry Liu ([@Ethella](https://github.com/Ethella))
+- Jerry Liu ([@Ethella](https://github.com/Ethella)) 
 
 ---
 

--- a/packages/@magic-ext/react-native-expo-oauth/package.json
+++ b/packages/@magic-ext/react-native-expo-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-ext/react-native-expo-oauth",
-  "version": "13.4.2",
+  "version": "13.4.3",
   "description": "Magic SDK OAuth Extension for Expo React Native environments.",
   "author": "Magic <team@magic.link> (https://magic.link/)",
   "license": "MIT",


### PR DESCRIPTION
### 📦 Pull Request

- Fix Version History of RN OAuth Packages
- Test Merge Queuing

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-bare-oauth@13.4.3-canary.574.5513673038.0
  npm install @magic-ext/react-native-expo-oauth@13.4.4-canary.574.5513673038.0
  # or 
  yarn add @magic-ext/react-native-bare-oauth@13.4.3-canary.574.5513673038.0
  yarn add @magic-ext/react-native-expo-oauth@13.4.4-canary.574.5513673038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
