### PR TITLE
[FEAT]: adding optional useDevApi param for nft checkout

### DIFF
--- a/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
@@ -1,6 +1,5 @@
 import browserEnv from '@ikscodes/browser-env';
 import { createMagicSDK } from '../../../factories';
-import { isPromiEvent } from '../../../../src/util';
 
 beforeEach(() => {
   browserEnv.restore();
@@ -34,6 +33,42 @@ test('checkout method should return a PromiEvent', () => {
       name: 'NFT Checkout Test',
       imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
       quantity: 1,
+    },
+  ]);
+});
+
+test('checkout method should accept all optional parameters', () => {
+  const magic = createMagicSDK();
+
+  magic.nft.request = jest.fn().mockReturnValue({
+    status: 'complete',
+    viewInWallet: true,
+  });
+
+  magic.nft.checkout({
+    contractId: '1cd4cfe8-b997-466e-8b0d-ff1177222ba4',
+    contractAddress: '0x375625833431b22623ce222e55b1cd15a459ba49',
+    tokenId: '1',
+    name: 'NFT Checkout Test',
+    imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
+    quantity: 1,
+    walletAddress: '0x5a7b63a3a2af31a2d4a020645e11ea99012ef7bf',
+    useDevApi: true,
+  });
+
+  const requestPayload = magic.nft.request.mock.calls[0][0];
+  console.log(requestPayload.params);
+  expect(requestPayload.method).toBe('magic_nft_checkout');
+  expect(requestPayload.params).toMatchObject([
+    {
+      contractId: '1cd4cfe8-b997-466e-8b0d-ff1177222ba4',
+      contractAddress: '0x375625833431b22623ce222e55b1cd15a459ba49',
+      tokenId: '1',
+      name: 'NFT Checkout Test',
+      imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
+      quantity: 1,
+      walletAddress: '0x5a7b63a3a2af31a2d4a020645e11ea99012ef7bf',
+      useDevApi: true,
     },
   ]);
 });

--- a/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
@@ -53,7 +53,7 @@ test('checkout method should accept all optional parameters', () => {
     imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
     quantity: 1,
     walletAddress: '0x5a7b63a3a2af31a2d4a020645e11ea99012ef7bf',
-    useDevApi: true,
+    useDevNFTApi: true,
   });
 
   const requestPayload = magic.nft.request.mock.calls[0][0];
@@ -68,7 +68,7 @@ test('checkout method should accept all optional parameters', () => {
       imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
       quantity: 1,
       walletAddress: '0x5a7b63a3a2af31a2d4a020645e11ea99012ef7bf',
-      useDevApi: true,
+      useDevNFTApi: true,
     },
   ]);
 });

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -92,6 +92,8 @@ export interface NFTCheckoutRequest {
   quantity: number;
   // Checkout UI compares against session wallet, if == then show “Magic Wallet”
   walletAddress?: string;
+  // if true, use dev NFT API (internal use only)
+  useDevApi?: boolean;
 }
 
 export type NFTCheckoutStatus = 'processed' | 'declined' | 'expired';

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -93,7 +93,7 @@ export interface NFTCheckoutRequest {
   // Checkout UI compares against session wallet, if == then show “Magic Wallet”
   walletAddress?: string;
   // if true, use dev NFT API (internal use only)
-  useDevApi?: boolean;
+  useDevNFTApi?: boolean;
 }
 
 export type NFTCheckoutStatus = 'processed' | 'declined' | 'expired';

--- a/yarn.lock
+++ b/yarn.lock
@@ -19342,9 +19342,9 @@ typescript@~4.4.2:
   linkType: hard
 
 "word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
-  version: 1.2.3
-  resolution: "word-wrap@npm:1.2.3"
-  checksum: 30b48f91fcf12106ed3186ae4fa86a6a1842416df425be7b60485de14bec665a54a68e4b5156647dec3a70f25e84d270ca8bc8cd23182ed095f5c7206a938c1f
+  version: 1.2.4
+  resolution: "word-wrap@npm:1.2.4"
+  checksum: 8f1f2e0a397c0e074ca225ba9f67baa23f99293bc064e31355d426ae91b8b3f6b5f6c1fc9ae5e9141178bb362d563f55e62fd8d5c31f2a77e3ade56cb3e35bd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Adding a new parameter for the NFT Checkout SDK function, to enable Magic internal users to test new features using the development NFT API.

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
