### PR TITLE
Add optional nftEndpoint param

### DIFF
--- a/packages/@magic-ext/auth/src/index.ts
+++ b/packages/@magic-ext/auth/src/index.ts
@@ -18,6 +18,7 @@ interface SDKEnvironment {
   version: string;
   platform: 'web' | 'react-native';
   defaultEndpoint: string;
+  defaultNFTEndpoint: string;
   ViewController: ConstructorOf<ViewController>;
   configureStorage: () => Promise<typeof localForage>;
   bundleId?: string | null;

--- a/packages/@magic-sdk/provider/src/core/sdk-environment.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk-environment.ts
@@ -14,6 +14,7 @@ export interface SDKEnvironment {
   version: string;
   platform: 'web' | 'react-native';
   defaultEndpoint: string;
+  defaultNFTEndpoint: string;
   ViewController: ConstructorOf<ViewController>;
   configureStorage: () => Promise<typeof localForage>;
   bundleId?: string | null;

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -91,6 +91,7 @@ export interface MagicSDKAdditionalConfiguration<
   TExt extends MagicSDKExtensionsOption<TCustomExtName> = any,
 > {
   endpoint?: string;
+  nftEndpoint?: string;
   locale?: SupportedLocale;
   network?: EthNetworkConfiguration;
   extensions?: TExt;
@@ -142,7 +143,7 @@ export class SDKBase {
       createReactNativeEndpointConfigurationWarning().log();
     }
 
-    const { defaultEndpoint, version } = SDKEnvironment;
+    const { defaultEndpoint, defaultNFTEndpoint, version } = SDKEnvironment;
     this.testMode = !!options?.testMode;
     this.endpoint = createURL(options?.endpoint ?? defaultEndpoint).origin;
 
@@ -161,6 +162,7 @@ export class SDKBase {
       API_KEY: this.apiKey,
       DOMAIN_ORIGIN: window.location ? window.location.origin : '',
       ETH_NETWORK: options?.network,
+      nftEndpoint: options?.nftEndpoint ?? defaultNFTEndpoint,
       host: createURL(this.endpoint).host,
       sdk: sdkNameToEnvName[SDKEnvironment.sdkName],
       version,

--- a/packages/@magic-sdk/provider/test/constants.ts
+++ b/packages/@magic-sdk/provider/test/constants.ts
@@ -1,4 +1,5 @@
 export const MAGIC_RELAYER_FULL_URL = 'https://auth.magic.link';
+export const MAGIC_NFT_API_URL = 'https://nft-api.magic.link';
 export const TEST_API_KEY = 'pk_test_123';
 export const LIVE_API_KEY = 'pk_live_123';
 export const ENCODED_QUERY_PARAMS = 'testqueryparams';

--- a/packages/@magic-sdk/provider/test/factories.ts
+++ b/packages/@magic-sdk/provider/test/factories.ts
@@ -1,6 +1,6 @@
 import * as memoryDriver from 'localforage-driver-memory';
 import localForage from 'localforage';
-import { MAGIC_RELAYER_FULL_URL, ENCODED_QUERY_PARAMS, TEST_API_KEY } from './constants';
+import { MAGIC_RELAYER_FULL_URL, ENCODED_QUERY_PARAMS, TEST_API_KEY, MAGIC_NFT_API_URL } from './constants';
 import { ViewController } from '../src';
 import type { SDKEnvironment } from '../src/core/sdk-environment';
 
@@ -41,6 +41,7 @@ export function createMagicSDKCtor(environment: { [P in keyof SDKEnvironment]?: 
     platform: 'web',
     version: '1.0.0-test',
     defaultEndpoint: MAGIC_RELAYER_FULL_URL,
+    defaultNFTEndpoint: MAGIC_NFT_API_URL,
     ViewController: TestViewController,
     configureStorage: async () => {
       const lf = localForage.createInstance({});

--- a/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/sdk/constructor.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-new, class-methods-use-this, global-require */
 
 import browserEnv from '@ikscodes/browser-env';
-import { MAGIC_RELAYER_FULL_URL, TEST_API_KEY } from '../../../constants';
+import { MAGIC_NFT_API_URL, MAGIC_RELAYER_FULL_URL, TEST_API_KEY } from '../../../constants';
 import { createMagicSDKCtor } from '../../../factories';
 import { AuthModule } from '../../../../src/modules/auth';
 import { UserModule } from '../../../../src/modules/user';
@@ -18,6 +18,7 @@ function assertEncodedQueryParams(parameters: string, expectedParams: any = {}) 
   const defaultExpectedParams = {
     API_KEY: TEST_API_KEY,
     DOMAIN_ORIGIN: 'null',
+    nftEndpoint: MAGIC_NFT_API_URL,
     host: 'auth.magic.link',
     sdk: 'magic-sdk',
     version: '1.0.0-test',
@@ -64,6 +65,15 @@ test('Initialize `MagicSDK` with custom endpoint', () => {
   expect(magic.apiKey).toBe(TEST_API_KEY);
   expect(magic.endpoint).toBe('https://example.com');
   assertEncodedQueryParams(magic.parameters, { host: 'example.com' });
+  assertModuleInstanceTypes(magic);
+});
+
+test('Initialize `MagicSDK` with custom nftEnpoint', () => {
+  const Ctor = createMagicSDKCtor();
+  const magic = new Ctor(TEST_API_KEY, { nftEndpoint: 'https://example.com' });
+
+  expect(magic.apiKey).toBe(TEST_API_KEY);
+  assertEncodedQueryParams(magic.parameters, { nftEndpoint: 'https://example.com' });
   assertModuleInstanceTypes(magic);
 });
 

--- a/packages/@magic-sdk/provider/test/spec/modules/user/getInfo.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/getInfo.spec.ts
@@ -21,3 +21,16 @@ test('Generate JSON RPC request payload with method `magic_get_info` and the act
   expect(requestPayload.method).toBe('magic_get_info');
   expect(requestPayload.params).toEqual([{ walletType: 'metamask' }]);
 });
+
+test('Generate JSON RPC request payload with method `magic_get_info`', async () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  await storage.setItem('mc_active_wallet', 'metamask');
+
+  await magic.user.getInfo();
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_get_info');
+  expect(requestPayload.params).toEqual([{ walletType: 'metamask' }]);
+});

--- a/packages/@magic-sdk/react-native-bare/src/index.ts
+++ b/packages/@magic-sdk/react-native-bare/src/index.ts
@@ -50,6 +50,7 @@ export const Magic = createSDK(SDKBaseReactNative, {
   version: process.env.BARE_REACT_NATIVE_VERSION!,
   bundleId: getBundleId(),
   defaultEndpoint: 'https://box.magic.link/',
+  defaultNFTEndpoint: 'https://nft-api.magic.link/',
   ViewController: ReactNativeWebViewController,
   configureStorage: /* istanbul ignore next */ async () => {
     const lf = localForage.createInstance({

--- a/packages/@magic-sdk/react-native-expo/src/index.ts
+++ b/packages/@magic-sdk/react-native-expo/src/index.ts
@@ -50,6 +50,7 @@ export const Magic = createSDK(SDKBaseReactNative, {
   version: process.env.EXPO_REACT_NATIVE_VERSION!,
   bundleId: Application.applicationId,
   defaultEndpoint: 'https://box.magic.link/',
+  defaultNFTEndpoint: 'https://nft-api.magic.link/',
   ViewController: ReactNativeWebViewController,
   configureStorage: /* istanbul ignore next */ async () => {
     const lf = localForage.createInstance({

--- a/packages/@magic-sdk/types/src/core/query-types.ts
+++ b/packages/@magic-sdk/types/src/core/query-types.ts
@@ -13,4 +13,5 @@ export interface QueryParameters {
   ext?: any;
   locale?: string;
   bundleId?: string;
+  nftEndpoint?: string;
 }

--- a/packages/magic-sdk/src/index.cdn.ts
+++ b/packages/magic-sdk/src/index.cdn.ts
@@ -14,6 +14,7 @@ const Magic = Object.assign(
     sdkName: 'magic-sdk',
     version: process.env.WEB_VERSION!,
     defaultEndpoint: 'https://auth.magic.link/',
+    defaultNFTEndpoint: 'https://nft-api.magic.link/',
     ViewController: IframeController,
     configureStorage: /* istanbul ignore next */ async () => {
       const lf = localForage.createInstance({

--- a/packages/magic-sdk/src/index.ts
+++ b/packages/magic-sdk/src/index.ts
@@ -13,6 +13,7 @@ export const Magic = createSDK(SDKBase, {
   sdkName: 'magic-sdk',
   version: process.env.WEB_VERSION!,
   defaultEndpoint: 'https://auth.magic.link/',
+  defaultNFTEndpoint: 'https://nft-api.magic.link/',
   ViewController: IframeController,
   configureStorage: async () => {
     const lf = localForage.createInstance({


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Create a magic instance with `nftEnpoint` param so that internal developers point to nft-api endpoint they want 

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

Add `nftEndpoint` param in SDK config

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/aptos@1.5.0-canary.586.5627642781.0
  npm install @magic-ext/auth@1.5.0-canary.586.5627642781.0
  npm install @magic-ext/avalanche@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/bitcoin@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/conflux@11.5.0-canary.586.5627642781.0
  npm install @magic-ext/cosmos@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/ed25519@9.5.0-canary.586.5627642781.0
  npm install @magic-ext/flow@13.6.0-canary.586.5627642781.0
  npm install @magic-ext/gdkms@1.5.0-canary.586.5627642781.0
  npm install @magic-ext/harmony@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/icon@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/near@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/oauth@12.5.0-canary.586.5627642781.0
  npm install @magic-ext/oidc@1.4.0-canary.586.5627642781.0
  npm install @magic-ext/polkadot@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/react-native-bare-oauth@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/react-native-expo-oauth@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/solana@14.5.0-canary.586.5627642781.0
  npm install @magic-ext/taquito@10.5.0-canary.586.5627642781.0
  npm install @magic-ext/terra@10.5.0-canary.586.5627642781.0
  npm install @magic-ext/tezos@13.5.0-canary.586.5627642781.0
  npm install @magic-ext/webauthn@12.5.0-canary.586.5627642781.0
  npm install @magic-ext/zilliqa@13.5.0-canary.586.5627642781.0
  npm install @magic-sdk/commons@14.5.0-canary.586.5627642781.0
  npm install @magic-sdk/pnp@12.5.0-canary.586.5627642781.0
  npm install @magic-sdk/provider@18.5.0-canary.586.5627642781.0
  npm install @magic-sdk/react-native-bare@19.5.0-canary.586.5627642781.0
  npm install @magic-sdk/react-native-expo@19.5.0-canary.586.5627642781.0
  npm install @magic-sdk/types@15.7.0-canary.586.5627642781.0
  npm install magic-sdk@18.5.0-canary.586.5627642781.0
  # or 
  yarn add @magic-ext/algorand@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/aptos@1.5.0-canary.586.5627642781.0
  yarn add @magic-ext/auth@1.5.0-canary.586.5627642781.0
  yarn add @magic-ext/avalanche@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/bitcoin@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/conflux@11.5.0-canary.586.5627642781.0
  yarn add @magic-ext/cosmos@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/ed25519@9.5.0-canary.586.5627642781.0
  yarn add @magic-ext/flow@13.6.0-canary.586.5627642781.0
  yarn add @magic-ext/gdkms@1.5.0-canary.586.5627642781.0
  yarn add @magic-ext/harmony@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/icon@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/near@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/oauth@12.5.0-canary.586.5627642781.0
  yarn add @magic-ext/oidc@1.4.0-canary.586.5627642781.0
  yarn add @magic-ext/polkadot@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/react-native-bare-oauth@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/react-native-expo-oauth@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/solana@14.5.0-canary.586.5627642781.0
  yarn add @magic-ext/taquito@10.5.0-canary.586.5627642781.0
  yarn add @magic-ext/terra@10.5.0-canary.586.5627642781.0
  yarn add @magic-ext/tezos@13.5.0-canary.586.5627642781.0
  yarn add @magic-ext/webauthn@12.5.0-canary.586.5627642781.0
  yarn add @magic-ext/zilliqa@13.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/commons@14.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/pnp@12.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/provider@18.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/react-native-bare@19.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/react-native-expo@19.5.0-canary.586.5627642781.0
  yarn add @magic-sdk/types@15.7.0-canary.586.5627642781.0
  yarn add magic-sdk@18.5.0-canary.586.5627642781.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
