### PR TITLE
Enables WebView Inspection for RN SDKs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -7,8 +7,7 @@ on:
     types: [checks_requested]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-  GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
@@ -19,10 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -54,10 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,7 @@ on:
       - "master"
 
 env:
-  GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-  GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
@@ -17,10 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -67,10 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -42,7 +42,7 @@
     "react-native": "^0.62.2",
     "react-native-device-info": "^10.3.0",
     "react-native-safe-area-context": "^4.4.1",
-    "react-native-webview": "^11.26.0"
+    "react-native-webview": "^12.4.0"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.15.5",
@@ -50,7 +50,7 @@
     "react-native": ">=0.60",
     "react-native-device-info": ">=10.3.0",
     "react-native-safe-area-context": ">=4.4.1",
-    "react-native-webview": ">=11.0.0"
+    "react-native-webview": ">=12.4.0"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -128,6 +128,7 @@ export class ReactNativeWebViewController extends ViewController {
           source={{ uri: `${this.endpoint}/send/?params=${encodeURIComponent(this.parameters)}` }}
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
+          webviewDebuggingEnabled
           autoManageStatusBarEnabled={false}
           onShouldStartLoadWithRequest={(event) => {
             const queryParams = new URLSearchParams(event.url.split('?')[1]);

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -41,14 +41,14 @@
     "react": "^16.13.1",
     "react-native": "^0.62.2",
     "react-native-safe-area-context": "^4.4.1",
-    "react-native-webview": "^11.26.0"
+    "react-native-webview": ">=12.4.0"
   },
   "peerDependencies": {
     "expo": "*",
     "react": ">=16",
     "react-native": ">=0.60",
     "react-native-safe-area-context": ">=4.4.1",
-    "react-native-webview": ">=11.26.0"
+    "react-native-webview": ">=12.4.0"
   },
   "gitHead": "1ef062ea699d48d5e9a9375a93b7c147632b05ca"
 }

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -129,6 +129,7 @@ export class ReactNativeWebViewController extends ViewController {
           onMessage={handleWebViewMessage}
           style={this.styles['magic-webview']}
           autoManageStatusBarEnabled={false}
+          webviewDebuggingEnabled
           onShouldStartLoadWithRequest={(event) => {
             const queryParams = new URLSearchParams(event.url.split('?')[1]);
             const openInDeviceBrowser = queryParams.get(OPEN_IN_DEVICE_BROWSER);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3098,7 +3098,7 @@ __metadata:
     react-native: ^0.62.2
     react-native-device-info: ^10.3.0
     react-native-safe-area-context: ^4.4.1
-    react-native-webview: ^11.26.0
+    react-native-webview: ^12.4.0
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
@@ -3107,7 +3107,7 @@ __metadata:
     react-native: ">=0.60"
     react-native-device-info: ">=10.3.0"
     react-native-safe-area-context: ">=4.4.1"
-    react-native-webview: ">=11.0.0"
+    react-native-webview: ">=12.4.0"
   languageName: unknown
   linkType: soft
 
@@ -3135,7 +3135,7 @@ __metadata:
     react: ^16.13.1
     react-native: ^0.62.2
     react-native-safe-area-context: ^4.4.1
-    react-native-webview: ^11.26.0
+    react-native-webview: ">=12.4.0"
     tslib: ^2.0.3
     whatwg-url: ~8.1.0
   peerDependencies:
@@ -3143,7 +3143,7 @@ __metadata:
     react: ">=16"
     react-native: ">=0.60"
     react-native-safe-area-context: ">=4.4.1"
-    react-native-webview: ">=11.26.0"
+    react-native-webview: ">=12.4.0"
   languageName: unknown
   linkType: soft
 
@@ -15815,16 +15815,29 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:^11.26.0":
-  version: 11.26.1
-  resolution: "react-native-webview@npm:11.26.1"
+"react-native-webview@npm:>=12.4.0":
+  version: 13.2.3
+  resolution: "react-native-webview@npm:13.2.3"
   dependencies:
     escape-string-regexp: 2.0.0
     invariant: 2.2.4
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: d2f95a89e944a2f1e8cf402e4e274f3568edae42e7ef190915e9fba8004a01d699c962459bdc9688c159060538e90aea3017cab24e6f4112021cbbc10ef57104
+  checksum: 4b3d14503aa622fc8bbf8b069437af06509bcfa9f2a84654d4904fce4e164132e738a73fc918694d45c14b9f460a05a2ce8389bd7fad21df95bb3b3911046ea7
+  languageName: node
+  linkType: hard
+
+"react-native-webview@npm:^12.4.0":
+  version: 12.4.0
+  resolution: "react-native-webview@npm:12.4.0"
+  dependencies:
+    escape-string-regexp: 2.0.0
+    invariant: 2.2.4
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: f7bd69b71af6bd2f62ae290aa40d8d7e7191dd7fd451327b2b6fcde7f8035e85de89d9f8f9e6c8ca913850e0efc91e195181f41c17df68516a47ff50977a49a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

Enables WebView Inspection for RN SDKs released in version 12.4 of the library: https://github.com/react-native-webview/react-native-webview/pull/2937

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-bare-oauth@13.4.7-canary.587.5626126964.0
  npm install @magic-ext/react-native-expo-oauth@13.4.8-canary.587.5626126964.0
  npm install @magic-sdk/react-native-bare@19.4.2-canary.587.5626126964.0
  npm install @magic-sdk/react-native-expo@19.4.2-canary.587.5626126964.0
  # or 
  yarn add @magic-ext/react-native-bare-oauth@13.4.7-canary.587.5626126964.0
  yarn add @magic-ext/react-native-expo-oauth@13.4.8-canary.587.5626126964.0
  yarn add @magic-sdk/react-native-bare@19.4.2-canary.587.5626126964.0
  yarn add @magic-sdk/react-native-expo@19.4.2-canary.587.5626126964.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
