### PR TITLE
Remove React-native entry from @magic-ext/auth Package.json

### DIFF
--- a/packages/@magic-ext/auth/package.json
+++ b/packages/@magic-ext/auth/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/scripts/bin/wsrun/build-package.ts
+++ b/scripts/bin/wsrun/build-package.ts
@@ -88,7 +88,6 @@ async function reactNativeBareHybridExtension(watch?: boolean) {
     target: pkgJson.target,
     output: pkgJson['react-native-bare'],
     externals: getExternalsFromPkgJson(pkgJson),
-    isRN: true,
     sourcemap: true,
   });
 }
@@ -102,7 +101,6 @@ async function reactNativeExpoHybridExtension(watch?: boolean) {
     target: pkgJson.target,
     output: pkgJson['react-native-expo'],
     externals: getExternalsFromPkgJson(pkgJson),
-    isRN: true,
     sourcemap: true,
   });
 }

--- a/scripts/utils/esbuild.ts
+++ b/scripts/utils/esbuild.ts
@@ -18,7 +18,6 @@ interface ESBuildOptions {
   name?: string;
   globals?: Record<string, string>;
   externals?: string[];
-  isRN?: boolean;
 }
 
 export async function build(options: ESBuildOptions) {
@@ -32,7 +31,7 @@ export async function build(options: ESBuildOptions) {
         platform: options.target ?? 'browser',
         format: options.format ?? 'cjs',
         globalName: options.format === 'iife' ? options.name : undefined,
-        entryPoints: [await getEntrypoint(options.format, options.isRN)],
+        entryPoints: [await getEntrypoint(options.format)],
         sourcemap: options.sourcemap,
         outfile: options.output,
         tsconfig: 'node_modules/.temp/tsconfig.build.json',
@@ -109,7 +108,7 @@ export async function emitTypes(watch?: boolean) {
  * Resolves the entrypoint file for ESBuild,
  * based on the format and target platform.
  */
-async function getEntrypoint(format?: Format, isRN?: boolean) {
+async function getEntrypoint(format?: Format) {
   const findEntrypoint = async (indexTarget?: string) => {
     if (format && (await existsAsync(path.resolve(process.cwd(), `./src/index.${indexTarget}.ts`)))) {
       return `src/index.${indexTarget}.ts`;
@@ -117,10 +116,6 @@ async function getEntrypoint(format?: Format, isRN?: boolean) {
 
     return 'src/index.ts';
   };
-
-  if (isRN) {
-    return findEntrypoint('native');
-  }
 
   switch (format) {
     case 'iife':

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2826,8 +2826,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^14.4.1
-    "@magic-sdk/provider": ^18.4.1
+    "@magic-sdk/commons": ^14.5.0
+    "@magic-sdk/provider": ^18.5.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2839,7 +2839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2847,7 +2847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2871,7 +2871,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2879,7 +2879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2887,7 +2887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2900,7 +2900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2908,7 +2908,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2916,7 +2916,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2924,18 +2924,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^12.4.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^12.5.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/types": ^15.7.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^18.4.1
+    magic-sdk: ^18.5.0
   languageName: unknown
   linkType: soft
 
@@ -2943,7 +2943,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2951,7 +2951,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2959,7 +2959,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^19.4.1
+    "@magic-sdk/react-native-bare": ^19.5.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2975,7 +2975,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^19.4.1
+    "@magic-sdk/react-native-expo": ^19.5.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2990,7 +2990,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -2998,7 +2998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -3006,7 +3006,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -3014,7 +3014,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -3022,7 +3022,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
@@ -3030,16 +3030,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^14.4.1
+    "@magic-sdk/commons": ^14.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^14.4.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^14.5.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^18.4.1
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/provider": ^18.5.0
+    "@magic-sdk/types": ^15.7.0
   peerDependencies:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
@@ -3053,17 +3053,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^12.4.1
-    magic-sdk: ^18.4.1
+    "@magic-ext/oauth": ^12.5.0
+    magic-sdk: ^18.5.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^18.4.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^18.5.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/types": ^15.7.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3075,7 +3075,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^19.4.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^19.5.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3083,9 +3083,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^14.4.1
-    "@magic-sdk/provider": ^18.4.1
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/commons": ^14.5.0
+    "@magic-sdk/provider": ^18.5.0
+    "@magic-sdk/types": ^15.7.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3111,7 +3111,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^19.4.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^19.5.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3119,9 +3119,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^14.4.1
-    "@magic-sdk/provider": ^18.4.1
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/commons": ^14.5.0
+    "@magic-sdk/provider": ^18.5.0
+    "@magic-sdk/types": ^15.7.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3147,7 +3147,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^15.6.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^15.7.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12773,16 +12773,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^18.4.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^18.5.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^14.4.1
-    "@magic-sdk/provider": ^18.4.1
-    "@magic-sdk/types": ^15.6.1
+    "@magic-sdk/commons": ^14.5.0
+    "@magic-sdk/provider": ^18.5.0
+    "@magic-sdk/types": ^15.7.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

Similar to what was done on commit https://github.com/magiclabs/magic-js/pull/525/commits/4b3a106681d8745994184b9ed5b1667344399fc2, we need to remove this attribute to permit the extension to work with our RN packages. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/auth@1.5.1-canary.595.5673997790.0
  # or 
  yarn add @magic-ext/auth@1.5.1-canary.595.5673997790.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
