### PR TITLE
Set peer dependency for hedera

### DIFF
--- a/packages/@magic-ext/hedera/package.json
+++ b/packages/@magic-ext/hedera/package.json
@@ -29,5 +29,8 @@
   },
   "devDependencies": {
     "@magic-sdk/commons": "^14.6.0"
+  },
+  "peerDependencies": {
+    "@hashgraph/sdk": "^2.31.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,6 +2919,8 @@ __metadata:
   resolution: "@magic-ext/hedera@workspace:packages/@magic-ext/hedera"
   dependencies:
     "@magic-sdk/commons": ^14.6.0
+  peerDependencies:
+    "@hashgraph/sdk": ^2.31.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

https://app.shortcut.com/magic-labs/story/77214/blockchain-update-hedera-sdk-package

We need to set peerDependency for hedera so that we can make sure a developer uses over 2.31.0 version

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/hedera@1.0.1-canary.604.5820404689.0
  # or 
  yarn add @magic-ext/hedera@1.0.1-canary.604.5820404689.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
