### PR TITLE
no need to check for sdk platform here.

### DIFF
--- a/packages/@magic-ext/auth/src/index.ts
+++ b/packages/@magic-ext/auth/src/index.ts
@@ -131,7 +131,7 @@ export class AuthExtension extends Extension.Internal<'auth', any> {
   public loginWithCredential(credentialOrQueryString?: string) {
     let credentialResolved = credentialOrQueryString ?? '';
 
-    if (!credentialOrQueryString && SDKEnvironment.platform === 'web') {
+    if (!credentialOrQueryString) {
       credentialResolved = window.location.search;
 
       // Remove the query from the redirect callback as a precaution.


### PR DESCRIPTION
### 📦 Pull Request

SDK Environment object was used incorrectly in the extension object.
Also, we can actually remove this check as the gating of redirectUris on mobile is already handled on the relayer side

### ✅ Fixed Issues

https://app.shortcut.com/magic-labs/story/82618/authextension-loginwithcredential-broken

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/auth@2.2.0-canary.605.5824411184.0
  # or 
  yarn add @magic-ext/auth@2.2.0-canary.605.5824411184.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
