### PR TITLE
import extension from @magic-sdk/commons instead of magick-sdk

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -23,7 +23,8 @@
   },
   "externals": {
     "include": [
-      "magic-sdk"
+      "@magic-sdk/commons",
+      "@magic-sdk/provider"
     ]
   },
   "dependencies": {
@@ -31,7 +32,6 @@
   },
   "devDependencies": {
     "@types/crypto-js": "~3.1.47",
-    "crypto-js": "^3.3.0",
-    "magic-sdk": "^19.3.1"
+    "crypto-js": "^3.3.0"
   }
 }

--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -27,10 +27,8 @@
       "@magic-sdk/provider"
     ]
   },
-  "dependencies": {
-    "@magic-sdk/types": "^16.3.1"
-  },
   "devDependencies": {
+    "@magic-sdk/commons": "^15.3.1",
     "@types/crypto-js": "~3.1.47",
     "crypto-js": "^3.3.0"
   }

--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -27,9 +27,11 @@
       "@magic-sdk/provider"
     ]
   },
-  "devDependencies": {
-    "@magic-sdk/commons": "^15.3.1",
+  "dependencies": {
     "@types/crypto-js": "~3.1.47",
     "crypto-js": "^3.3.0"
+  },
+  "devDependencies": {
+    "@magic-sdk/commons": "^15.3.1"
   }
 }

--- a/packages/@magic-ext/oauth/src/index.ts
+++ b/packages/@magic-ext/oauth/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { Extension } from 'magic-sdk';
+import { Extension } from '@magic-sdk/commons';
 import {
   OAuthErrorData,
   OAuthPayloadMethods,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2826,8 +2826,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^15.3.0
-    "@magic-sdk/provider": ^19.3.0
+    "@magic-sdk/commons": ^15.3.1
+    "@magic-sdk/provider": ^19.3.1
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2839,7 +2839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2847,7 +2847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2871,7 +2871,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2879,7 +2879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2887,7 +2887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2900,8 +2900,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/commons": ^15.3.1
+    "@magic-sdk/types": ^16.3.1
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2910,7 +2910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2928,7 +2928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2936,18 +2936,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^13.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^13.3.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/types": ^16.3.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
-    magic-sdk: ^19.3.0
   languageName: unknown
   linkType: soft
 
@@ -2955,7 +2954,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2963,7 +2962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -2971,7 +2970,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^20.3.0
+    "@magic-sdk/react-native-bare": ^20.3.1
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2987,7 +2986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^20.3.0
+    "@magic-sdk/react-native-expo": ^20.3.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3002,7 +3001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -3010,7 +3009,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -3018,7 +3017,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -3026,7 +3025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -3034,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
@@ -3042,16 +3041,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^15.3.0
+    "@magic-sdk/commons": ^15.3.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^15.3.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^15.3.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^19.3.0
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/provider": ^19.3.1
+    "@magic-sdk/types": ^16.3.1
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -3075,17 +3074,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^13.3.0
-    magic-sdk: ^19.3.0
+    "@magic-ext/oauth": ^13.3.1
+    magic-sdk: ^19.3.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^19.3.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^19.3.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/types": ^16.3.1
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3097,7 +3096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^20.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^20.3.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3105,9 +3104,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^15.3.0
-    "@magic-sdk/provider": ^19.3.0
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/commons": ^15.3.1
+    "@magic-sdk/provider": ^19.3.1
+    "@magic-sdk/types": ^16.3.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3133,7 +3132,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^20.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^20.3.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3141,9 +3140,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^15.3.0
-    "@magic-sdk/provider": ^19.3.0
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/commons": ^15.3.1
+    "@magic-sdk/provider": ^19.3.1
+    "@magic-sdk/types": ^16.3.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3169,7 +3168,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^16.3.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^16.3.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12828,16 +12827,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^19.3.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^19.3.1, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^15.3.0
-    "@magic-sdk/provider": ^19.3.0
-    "@magic-sdk/types": ^16.3.0
+    "@magic-sdk/commons": ^15.3.1
+    "@magic-sdk/provider": ^19.3.1
+    "@magic-sdk/types": ^16.3.1
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,7 +2944,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/types": ^16.3.1
+    "@magic-sdk/commons": ^15.3.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

getting a dependency error when trying to import the OAuthExtension module
<img width="1109" alt="Screenshot 2023-09-01 at 11 26 04 AM" src="https://github.com/magiclabs/magic-js/assets/794721/58dfa6e9-6b81-4b99-a195-8fa293f9e4df">

and it's likely due to us including magic-sdk as a dependency in the extension itself

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/oauth@13.3.2-canary.618.6051652890.0
  npm install @magic-sdk/pnp@13.3.2-canary.618.6051652890.0
  # or 
  yarn add @magic-ext/oauth@13.3.2-canary.618.6051652890.0
  yarn add @magic-sdk/pnp@13.3.2-canary.618.6051652890.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
