### PR TITLE
chore(hedera): update package.json exports to support Typescript bundler module resolution

### DIFF
--- a/packages/@magic-ext/hedera/package.json
+++ b/packages/@magic-ext/hedera/package.json
@@ -19,8 +19,14 @@
   "jsdelivr": "./dist/extension.js",
   "react-native": "./dist/react-native/index.native.js",
   "exports": {
-    "import": "./dist/es/index.mjs",
-    "require": "./dist/cjs/index.js"
+    "import": {
+      "default": "./dist/es/index.mjs",
+      "types": "./dist/types/index.d.ts"
+    },
+    "require": {
+      "default": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
   },
   "externals": {
     "include": [


### PR DESCRIPTION

### 📦 Pull Request

TypeScript `bundler` module resolution requires the following change to work. Otherwise TypeScript cannot read the type definitions.

```
error TS7016: Could not find a declaration file for module '@magic-ext/hedera'. '/Users/mehcode/.../node_modules/.pnpm/@magic-ext+hedera@1.0.1_@hashgraph+sdk@2.34.1/node_modules/@magic-ext/hedera/dist/es/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/mehcode/.../node_modules/@magic-ext/hedera/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@magic-ext/hedera' library may need to update its package.json or typings.
```

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 

- `patch`: Bug Fix?
