### PR TITLE
Update @magic-ext/oauth crypto-js es module dependency

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -28,10 +28,10 @@
     ]
   },
   "dependencies": {
-    "@types/crypto-js": "~3.1.47",
-    "crypto-js": "^3.3.0"
+    "crypto-js": "4.1.1"
   },
   "devDependencies": {
-    "@magic-sdk/commons": "^16.0.1"
+    "@magic-sdk/commons": "^16.0.1",
+    "@types/crypto-js": "4.1.2"
   }
 }

--- a/packages/@magic-ext/oauth/src/crypto.ts
+++ b/packages/@magic-ext/oauth/src/crypto.ts
@@ -1,4 +1,4 @@
-import { WordArray, SHA256 } from 'crypto-js';
+import SHA256 from 'crypto-js/sha256';
 import Base64 from 'crypto-js/enc-base64';
 
 const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
@@ -18,9 +18,9 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: WordArray): string;
+function base64URLEncodeFromByteArray(wordArray: CryptoJS.lib.WordArray): string;
 function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
-function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
+function base64URLEncodeFromByteArray(arg: CryptoJS.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   };

--- a/packages/@magic-ext/oauth/src/crypto.ts
+++ b/packages/@magic-ext/oauth/src/crypto.ts
@@ -1,5 +1,4 @@
-import { WordArray } from 'crypto-js';
-import sha256Fallback from 'crypto-js/sha256';
+import { WordArray, SHA256 } from 'crypto-js';
 import Base64 from 'crypto-js/enc-base64';
 
 const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
@@ -50,7 +49,7 @@ async function sha256(message: string) {
     return crypto.subtle.digest('SHA-256', bytes).then(base64URLEncodeFromByteArray);
   }
 
-  return base64URLEncodeFromByteArray(sha256Fallback(message));
+  return base64URLEncodeFromByteArray(SHA256(message));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2826,8 +2826,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^16.0.0
-    "@magic-sdk/provider": ^20.0.0
+    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/provider": ^20.0.1
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2839,7 +2839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2847,7 +2847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2871,7 +2871,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2879,7 +2879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2887,7 +2887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2900,7 +2900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
     "@magic-sdk/types": ^17.0.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2910,7 +2910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2928,7 +2928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2936,17 +2936,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^14.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^14.0.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
-    "@types/crypto-js": ~3.1.47
-    crypto-js: ^3.3.0
+    "@magic-sdk/commons": ^16.0.1
+    "@types/crypto-js": 4.1.2
+    crypto-js: 4.1.1
   languageName: unknown
   linkType: soft
 
@@ -2954,7 +2954,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2962,7 +2962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -2970,7 +2970,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^21.0.0
+    "@magic-sdk/react-native-bare": ^21.0.1
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2986,7 +2986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^21.0.0
+    "@magic-sdk/react-native-expo": ^21.0.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3001,7 +3001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -3009,7 +3009,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -3017,7 +3017,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -3025,7 +3025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
@@ -3041,15 +3041,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^16.0.0
+    "@magic-sdk/commons": ^16.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^16.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^16.0.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^20.0.0
+    "@magic-sdk/provider": ^20.0.1
     "@magic-sdk/types": ^17.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -3074,12 +3074,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^14.0.0
-    magic-sdk: ^20.0.0
+    "@magic-ext/oauth": ^14.0.1
+    magic-sdk: ^20.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^20.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^20.0.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -3096,7 +3096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^21.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^21.0.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3104,8 +3104,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.0.0
-    "@magic-sdk/provider": ^20.0.0
+    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/provider": ^20.0.1
     "@magic-sdk/types": ^17.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -3132,7 +3132,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^21.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^21.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3140,8 +3140,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.0.0
-    "@magic-sdk/provider": ^20.0.0
+    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/provider": ^20.0.1
     "@magic-sdk/types": ^17.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -3996,6 +3996,13 @@ __metadata:
   version: 5.0.2
   resolution: "@types/command-line-usage@npm:5.0.2"
   checksum: 9c0eabf5e86a405d118dcfb5f4bceae43080efe603a0f240664716a05283dcb389e94e999188d12b10a0aa4452a920445131f1011e7484403f146607cd2577f0
+  languageName: node
+  linkType: hard
+
+"@types/crypto-js@npm:4.1.2":
+  version: 4.1.2
+  resolution: "@types/crypto-js@npm:4.1.2"
+  checksum: 9a39c6627186f53a1885647889ee376f5858604316023ff2c8226869ad51c9c57ff49bd730deaa751f729fbf611296896e1392862752c5ae9fadf61c64ef3fd2
   languageName: node
   linkType: hard
 
@@ -6946,6 +6953,13 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:4.1.1":
+  version: 4.1.1
+  resolution: "crypto-js@npm:4.1.1"
+  checksum: b3747c12ee3a7632fab3b3e171ea50f78b182545f0714f6d3e7e2858385f0f4101a15f2517e033802ce9d12ba50a391575ff4638c9de3dd9b2c4bc47768d5425
   languageName: node
   linkType: hard
 
@@ -12827,15 +12841,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^20.0.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^20.0.1, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^16.0.0
-    "@magic-sdk/provider": ^20.0.0
+    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/provider": ^20.0.1
     "@magic-sdk/types": ^17.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Update `@magic-ext/oauth` crypto-js dependency due to ES module error in nextjs build.

<img width="881" alt="image" src="https://github.com/magiclabs/magic-js/assets/18487241/515d7d51-3f75-4c8d-b77a-86e234aff8a6">






### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/oauth@14.0.2-canary.627.6219764474.0
  npm install @magic-sdk/pnp@14.0.2-canary.627.6219764474.0
  # or 
  yarn add @magic-ext/oauth@14.0.2-canary.627.6219764474.0
  yarn add @magic-sdk/pnp@14.0.2-canary.627.6219764474.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
