### PR TITLE
Removes Deprecation Warnings for`@magic-ext/auth` methods

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -13,8 +13,8 @@ import { BaseModule } from './base-module';
 import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { SDKEnvironment } from '../core/sdk-environment';
 import { UpdateEmailEvents } from './user';
-import { createDeprecationWarning } from '../core/sdk-exceptions';
 import { isMajorVersionAtLeast } from '../util/version-check';
+import { createDeprecationWarning } from '../core/sdk-exceptions';
 
 export const ProductConsolidationMethodRemovalVersions = {
   'magic-sdk': 'v18.0.0',
@@ -35,19 +35,19 @@ export class AuthModule extends BaseModule {
       SDKEnvironment.sdkName === '@magic-sdk/react-native-bare' ||
       SDKEnvironment.sdkName === '@magic-sdk/react-native-expo';
 
+    // RN SDK major version is greater than or equal to v19
     if (isRNMobilePackage && isMajorVersionAtLeast(SDKEnvironment.version, 19)) {
       throw new Error(
         'loginWithMagicLink() is deprecated for this package, please utlize a passcode method like loginWithSMS or loginWithEmailOTP instead.',
       );
+    } else if (isRNMobilePackage) {
+      // RN SDK major version is less than v19
+      createDeprecationWarning({
+        method: 'auth.loginWithMagicLink()',
+        removalVersions: ProductConsolidationMethodRemovalVersions,
+        useInstead: 'auth.loginWithEmailOTP()',
+      }).log();
     }
-
-    createDeprecationWarning({
-      method: 'auth.loginWithMagicLink()',
-      removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: isRNMobilePackage
-        ? '@magic-ext/auth auth.loginWithEmailOTP()'
-        : '@magic-ext/auth auth.loginWithMagicLink()',
-    }).log();
 
     const { email, showUI = true, redirectURI } = configuration;
 
@@ -64,11 +64,6 @@ export class AuthModule extends BaseModule {
    * of 15 minutes)
    */
   public loginWithSMS(configuration: LoginWithSmsConfiguration) {
-    createDeprecationWarning({
-      method: 'auth.loginWithSMS()',
-      removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: '@magic-ext/auth auth.loginWithSMS()',
-    }).log();
     const { phoneNumber } = configuration;
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithSmsTestMode : MagicPayloadMethod.LoginWithSms,
@@ -116,11 +111,6 @@ export class AuthModule extends BaseModule {
    * `window.location.search`.
    */
   public loginWithCredential(credentialOrQueryString?: string) {
-    createDeprecationWarning({
-      method: 'auth.loginWithCredential()',
-      removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: '@magic-ext/auth auth.loginWithCredential()',
-    }).log();
     let credentialResolved = credentialOrQueryString ?? '';
 
     if (!credentialOrQueryString && SDKEnvironment.platform === 'web') {
@@ -141,21 +131,11 @@ export class AuthModule extends BaseModule {
 
   // Custom Auth
   public setAuthorizationToken(jwt: string) {
-    createDeprecationWarning({
-      method: 'auth.setAuthorizationToken()',
-      removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: '@magic-ext/auth auth.setAuthorizationToken()',
-    }).log();
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.SetAuthorizationToken, [{ jwt }]);
     return this.request<boolean>(requestPayload);
   }
 
   public updateEmailWithUI(configuration: UpdateEmailConfiguration) {
-    createDeprecationWarning({
-      method: 'auth.updateEmailWithUI()',
-      removalVersions: ProductConsolidationMethodRemovalVersions,
-      useInstead: '@magic-ext/auth auth.updateEmailWithUI()',
-    }).log();
     const { email, showUI = true } = configuration;
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.UpdateEmailTestMode : MagicPayloadMethod.UpdateEmail,


### PR DESCRIPTION
### 📦 Pull Request

Removes deprecation warnings from `AuthModule` methods moved to the `@magic-ext/auth` as the extension will be deprecated with the end of support for Universal Wallets. 

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n\a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/aptos@3.0.2-canary.629.6254645033.0
  npm install @magic-ext/auth@3.0.2-canary.629.6254645033.0
  npm install @magic-ext/avalanche@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/bitcoin@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/conflux@13.0.2-canary.629.6254645033.0
  npm install @magic-ext/cosmos@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/ed25519@11.0.2-canary.629.6254645033.0
  npm install @magic-ext/flow@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/gdkms@3.0.2-canary.629.6254645033.0
  npm install @magic-ext/harmony@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/icon@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/near@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/oauth@14.0.2-canary.629.6254645033.0
  npm install @magic-ext/oidc@3.0.2-canary.629.6254645033.0
  npm install @magic-ext/polkadot@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/react-native-bare-oauth@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/react-native-expo-oauth@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/solana@16.0.2-canary.629.6254645033.0
  npm install @magic-ext/taquito@12.0.2-canary.629.6254645033.0
  npm install @magic-ext/terra@12.0.2-canary.629.6254645033.0
  npm install @magic-ext/tezos@15.0.2-canary.629.6254645033.0
  npm install @magic-ext/webauthn@14.0.2-canary.629.6254645033.0
  npm install @magic-ext/zilliqa@15.0.2-canary.629.6254645033.0
  npm install @magic-sdk/commons@16.0.2-canary.629.6254645033.0
  npm install @magic-sdk/pnp@14.0.2-canary.629.6254645033.0
  npm install @magic-sdk/provider@20.0.2-canary.629.6254645033.0
  npm install @magic-sdk/react-native-bare@21.0.2-canary.629.6254645033.0
  npm install @magic-sdk/react-native-expo@21.0.2-canary.629.6254645033.0
  npm install magic-sdk@20.0.2-canary.629.6254645033.0
  # or 
  yarn add @magic-ext/algorand@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/aptos@3.0.2-canary.629.6254645033.0
  yarn add @magic-ext/auth@3.0.2-canary.629.6254645033.0
  yarn add @magic-ext/avalanche@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/bitcoin@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/conflux@13.0.2-canary.629.6254645033.0
  yarn add @magic-ext/cosmos@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/ed25519@11.0.2-canary.629.6254645033.0
  yarn add @magic-ext/flow@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/gdkms@3.0.2-canary.629.6254645033.0
  yarn add @magic-ext/harmony@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/icon@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/near@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/oauth@14.0.2-canary.629.6254645033.0
  yarn add @magic-ext/oidc@3.0.2-canary.629.6254645033.0
  yarn add @magic-ext/polkadot@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/react-native-bare-oauth@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/react-native-expo-oauth@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/solana@16.0.2-canary.629.6254645033.0
  yarn add @magic-ext/taquito@12.0.2-canary.629.6254645033.0
  yarn add @magic-ext/terra@12.0.2-canary.629.6254645033.0
  yarn add @magic-ext/tezos@15.0.2-canary.629.6254645033.0
  yarn add @magic-ext/webauthn@14.0.2-canary.629.6254645033.0
  yarn add @magic-ext/zilliqa@15.0.2-canary.629.6254645033.0
  yarn add @magic-sdk/commons@16.0.2-canary.629.6254645033.0
  yarn add @magic-sdk/pnp@14.0.2-canary.629.6254645033.0
  yarn add @magic-sdk/provider@20.0.2-canary.629.6254645033.0
  yarn add @magic-sdk/react-native-bare@21.0.2-canary.629.6254645033.0
  yarn add @magic-sdk/react-native-expo@21.0.2-canary.629.6254645033.0
  yarn add magic-sdk@20.0.2-canary.629.6254645033.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
