### PR TITLE
adds cdnGlobalName to flow package.json

### DIFF
--- a/packages/@magic-ext/flow/package.json
+++ b/packages/@magic-ext/flow/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "target": "neutral",
+  "cdnGlobalName": "MagicFlowExtension",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2826,8 +2826,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^16.0.1
-    "@magic-sdk/provider": ^20.0.1
+    "@magic-sdk/commons": ^16.0.2
+    "@magic-sdk/provider": ^20.0.2
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2839,7 +2839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2847,7 +2847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2871,7 +2871,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2879,7 +2879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2887,7 +2887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2900,7 +2900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
     "@magic-sdk/types": ^17.0.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2910,7 +2910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2928,7 +2928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2936,15 +2936,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^14.0.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^14.0.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
     "@types/crypto-js": 4.1.2
     crypto-js: 4.1.1
   languageName: unknown
@@ -2954,7 +2954,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2962,7 +2962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -2970,7 +2970,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^21.0.1
+    "@magic-sdk/react-native-bare": ^21.0.2
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2986,7 +2986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^21.0.1
+    "@magic-sdk/react-native-expo": ^21.0.2
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3001,7 +3001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -3009,7 +3009,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -3017,7 +3017,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -3025,7 +3025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
@@ -3041,15 +3041,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^16.0.1
+    "@magic-sdk/commons": ^16.0.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^16.0.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^16.0.2, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^20.0.1
+    "@magic-sdk/provider": ^20.0.2
     "@magic-sdk/types": ^17.0.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -3074,12 +3074,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^14.0.1
-    magic-sdk: ^20.0.1
+    "@magic-ext/oauth": ^14.0.2
+    magic-sdk: ^20.0.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^20.0.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^20.0.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -3096,7 +3096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^21.0.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^21.0.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3104,8 +3104,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.0.1
-    "@magic-sdk/provider": ^20.0.1
+    "@magic-sdk/commons": ^16.0.2
+    "@magic-sdk/provider": ^20.0.2
     "@magic-sdk/types": ^17.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -3132,7 +3132,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^21.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^21.0.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3140,8 +3140,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.0.1
-    "@magic-sdk/provider": ^20.0.1
+    "@magic-sdk/commons": ^16.0.2
+    "@magic-sdk/provider": ^20.0.2
     "@magic-sdk/types": ^17.0.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -12841,15 +12841,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^20.0.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^20.0.2, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^16.0.1
-    "@magic-sdk/provider": ^20.0.1
+    "@magic-sdk/commons": ^16.0.2
+    "@magic-sdk/provider": ^20.0.2
     "@magic-sdk/types": ^17.0.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
### 📦 Pull Request

The flow extension was missing a cdnGlobalName in its package.json, preventing it from being imported via CDN. This fixes that.

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/flow@15.0.3-canary.630.6265151757.0
  # or 
  yarn add @magic-ext/flow@15.0.3-canary.630.6265151757.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
