### PR TITLE
Have the constructor preload iframe assets by default, with optional SDK flag to defer preloading

### DIFF
--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -168,6 +168,9 @@ export class SDKBase {
       locale: options?.locale || 'en_US',
       ...(SDKEnvironment.bundleId ? { bundleId: SDKEnvironment.bundleId } : {}),
     });
+
+    // Force the constructor to preload the iframe.
+    this.preload();
   }
 
   /**

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -95,6 +95,7 @@ export interface MagicSDKAdditionalConfiguration<
   network?: EthNetworkConfiguration;
   extensions?: TExt;
   testMode?: boolean;
+  deferPreload?: boolean;
 }
 
 export class SDKBase {
@@ -168,9 +169,7 @@ export class SDKBase {
       locale: options?.locale || 'en_US',
       ...(SDKEnvironment.bundleId ? { bundleId: SDKEnvironment.bundleId } : {}),
     });
-
-    // Force the constructor to preload the iframe.
-    this.preload();
+    if (!options?.deferPreload) this.preload();
   }
 
   /**

--- a/packages/@magic-sdk/provider/test/spec/core/sdk/overlay.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/sdk/overlay.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 test('`MagicSDK.overlay` is lazy loaded', async () => {
   const Ctor = createMagicSDKCtor();
-  const magic = new Ctor(TEST_API_KEY);
+  const magic = new Ctor(TEST_API_KEY, { deferPreload: true });
 
   expect((SDKBase as any).__overlays__.size).toBe(0);
 


### PR DESCRIPTION
### 📦 Pull Request

Have the SDK constructor run the iframe bootstrap logic by default, and introduce an SDK config flag to defer the preloading for devs who want to control when the Magic Iframe assets get loaded.

### ✅ Fixed Issues

- [CH87853](https://app.shortcut.com/magic-labs/story/87853/productionalize-deferpreload-sdk-flag)

### 🚨 Test instructions

`const m = new Magic(API_KEY)` -> will immediately bootstrap the auth relayer iframe by default

`const m = new Magic(API_KEY, { deferPreload: true })` -> will not bootstrap the auth relayer iframe until the first sdk request is made (existing behavior)

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/aptos@4.0.0-canary.634.6489741908.0
  npm install @magic-ext/auth@4.0.0-canary.634.6489741908.0
  npm install @magic-ext/avalanche@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/bitcoin@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/conflux@14.0.0-canary.634.6489741908.0
  npm install @magic-ext/cosmos@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/ed25519@12.0.0-canary.634.6489741908.0
  npm install @magic-ext/flow@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/gdkms@4.0.0-canary.634.6489741908.0
  npm install @magic-ext/harmony@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/icon@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/near@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/oauth@15.0.0-canary.634.6489741908.0
  npm install @magic-ext/oidc@4.0.0-canary.634.6489741908.0
  npm install @magic-ext/polkadot@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/react-native-bare-oauth@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/react-native-expo-oauth@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/solana@17.0.0-canary.634.6489741908.0
  npm install @magic-ext/taquito@13.0.0-canary.634.6489741908.0
  npm install @magic-ext/terra@13.0.0-canary.634.6489741908.0
  npm install @magic-ext/tezos@16.0.0-canary.634.6489741908.0
  npm install @magic-ext/webauthn@15.0.0-canary.634.6489741908.0
  npm install @magic-ext/zilliqa@16.0.0-canary.634.6489741908.0
  npm install @magic-sdk/commons@17.0.0-canary.634.6489741908.0
  npm install @magic-sdk/pnp@15.0.0-canary.634.6489741908.0
  npm install @magic-sdk/provider@21.0.0-canary.634.6489741908.0
  npm install @magic-sdk/react-native-bare@22.0.0-canary.634.6489741908.0
  npm install @magic-sdk/react-native-expo@22.0.0-canary.634.6489741908.0
  npm install magic-sdk@21.0.0-canary.634.6489741908.0
  # or 
  yarn add @magic-ext/algorand@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/aptos@4.0.0-canary.634.6489741908.0
  yarn add @magic-ext/auth@4.0.0-canary.634.6489741908.0
  yarn add @magic-ext/avalanche@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/bitcoin@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/conflux@14.0.0-canary.634.6489741908.0
  yarn add @magic-ext/cosmos@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/ed25519@12.0.0-canary.634.6489741908.0
  yarn add @magic-ext/flow@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/gdkms@4.0.0-canary.634.6489741908.0
  yarn add @magic-ext/harmony@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/icon@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/near@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/oauth@15.0.0-canary.634.6489741908.0
  yarn add @magic-ext/oidc@4.0.0-canary.634.6489741908.0
  yarn add @magic-ext/polkadot@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/react-native-bare-oauth@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/react-native-expo-oauth@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/solana@17.0.0-canary.634.6489741908.0
  yarn add @magic-ext/taquito@13.0.0-canary.634.6489741908.0
  yarn add @magic-ext/terra@13.0.0-canary.634.6489741908.0
  yarn add @magic-ext/tezos@16.0.0-canary.634.6489741908.0
  yarn add @magic-ext/webauthn@15.0.0-canary.634.6489741908.0
  yarn add @magic-ext/zilliqa@16.0.0-canary.634.6489741908.0
  yarn add @magic-sdk/commons@17.0.0-canary.634.6489741908.0
  yarn add @magic-sdk/pnp@15.0.0-canary.634.6489741908.0
  yarn add @magic-sdk/provider@21.0.0-canary.634.6489741908.0
  yarn add @magic-sdk/react-native-bare@22.0.0-canary.634.6489741908.0
  yarn add @magic-sdk/react-native-expo@22.0.0-canary.634.6489741908.0
  yarn add magic-sdk@21.0.0-canary.634.6489741908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
