### PR TITLE
Removes React Native entrypoint from all extension's package.json

### DIFF
--- a/BUILD_SYSTEM.md
+++ b/BUILD_SYSTEM.md
@@ -73,8 +73,6 @@ We generate multiple outputs in order to maximize backwards compatibility and in
   // Output location for CDN entrypoint
   "jsdelivr": "./dist/my-library.js",
 
-  // Output location for React Native entrypoint
-  "react-native": "./dist/react-native/index.native.js",
 
   // Here, we define a standard NodeJS "exports" field...
   "exports": {

--- a/packages/@magic-ext/algorand/package.json
+++ b/packages/@magic-ext/algorand/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/avalanche/package.json
+++ b/packages/@magic-ext/avalanche/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/conflux/package.json
+++ b/packages/@magic-ext/conflux/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/cosmos/package.json
+++ b/packages/@magic-ext/cosmos/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/ed25519/package.json
+++ b/packages/@magic-ext/ed25519/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/flow/package.json
+++ b/packages/@magic-ext/flow/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/hedera/package.json
+++ b/packages/@magic-ext/hedera/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/icon/package.json
+++ b/packages/@magic-ext/icon/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/near/package.json
+++ b/packages/@magic-ext/near/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/polkadot/package.json
+++ b/packages/@magic-ext/polkadot/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/solana/package.json
+++ b/packages/@magic-ext/solana/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/taquito/package.json
+++ b/packages/@magic-ext/taquito/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/terra/package.json
+++ b/packages/@magic-ext/terra/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/tezos/package.json
+++ b/packages/@magic-ext/tezos/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/webauthn/package.json
+++ b/packages/@magic-ext/webauthn/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/packages/@magic-ext/zilliqa/package.json
+++ b/packages/@magic-ext/zilliqa/package.json
@@ -17,7 +17,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "jsdelivr": "./dist/extension.js",
-  "react-native": "./dist/react-native/index.native.js",
   "exports": {
     "import": "./dist/es/index.mjs",
     "require": "./dist/cjs/index.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,7 +2940,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^14.1.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^14.1.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
@@ -3074,7 +3074,7 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^14.1.1
+    "@magic-ext/oauth": ^14.1.2
     magic-sdk: ^20.1.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

- Removes React Native entrypoint from all extension's package.json

### ✅ Fixed Issues

- Fixes https://github.com/magiclabs/react-native-demo/issues/68

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/avalanche@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/conflux@13.1.2-canary.644.6475639388.0
  npm install @magic-ext/cosmos@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/ed25519@11.1.2-canary.644.6475639388.0
  npm install @magic-ext/flow@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/hedera@1.0.2-canary.644.6475639388.0
  npm install @magic-ext/icon@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/near@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/polkadot@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/solana@16.1.2-canary.644.6475639388.0
  npm install @magic-ext/taquito@12.1.2-canary.644.6475639388.0
  npm install @magic-ext/terra@12.1.2-canary.644.6475639388.0
  npm install @magic-ext/tezos@15.1.2-canary.644.6475639388.0
  npm install @magic-ext/webauthn@14.1.2-canary.644.6475639388.0
  npm install @magic-ext/zilliqa@15.1.2-canary.644.6475639388.0
  # or 
  yarn add @magic-ext/algorand@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/avalanche@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/conflux@13.1.2-canary.644.6475639388.0
  yarn add @magic-ext/cosmos@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/ed25519@11.1.2-canary.644.6475639388.0
  yarn add @magic-ext/flow@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/hedera@1.0.2-canary.644.6475639388.0
  yarn add @magic-ext/icon@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/near@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/polkadot@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/solana@16.1.2-canary.644.6475639388.0
  yarn add @magic-ext/taquito@12.1.2-canary.644.6475639388.0
  yarn add @magic-ext/terra@12.1.2-canary.644.6475639388.0
  yarn add @magic-ext/tezos@15.1.2-canary.644.6475639388.0
  yarn add @magic-ext/webauthn@14.1.2-canary.644.6475639388.0
  yarn add @magic-ext/zilliqa@15.1.2-canary.644.6475639388.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
