### PR TITLE
Email customization sdk updates

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -49,6 +49,7 @@ export class AuthModule extends BaseModule {
       }).log();
     }
 
+    console.log(configuration);
     const { email, showUI = true, redirectURI, variation } = configuration;
 
     const requestPayload = createJsonRpcRequestPayload(

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -49,11 +49,11 @@ export class AuthModule extends BaseModule {
       }).log();
     }
 
-    const { email, showUI = true, redirectURI, customTemplateName } = configuration;
+    const { email, showUI = true, redirectURI, variation } = configuration;
 
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithMagicLinkTestMode : MagicPayloadMethod.LoginWithMagicLink,
-      [{ email, showUI, redirectURI, customTemplateName }],
+      [{ email, showUI, redirectURI, variation }],
     );
     return this.request<string | null, LoginWithMagicLinkEventHandlers>(requestPayload);
   }
@@ -78,10 +78,10 @@ export class AuthModule extends BaseModule {
    * of 15 minutes)
    */
   public loginWithEmailOTP(configuration: LoginWithEmailOTPConfiguration) {
-    const { email, showUI, deviceCheckUI, customTemplateName } = configuration;
+    const { email, showUI, deviceCheckUI, variation } = configuration;
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithEmailOTPTestMode : MagicPayloadMethod.LoginWithEmailOTP,
-      [{ email, showUI, deviceCheckUI, customTemplateName }],
+      [{ email, showUI, deviceCheckUI, variation }],
     );
     const handle = this.request<string | null, LoginWithEmailOTPEventHandlers>(requestPayload);
     if (!deviceCheckUI && handle) {

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -49,11 +49,11 @@ export class AuthModule extends BaseModule {
       }).log();
     }
 
-    const { email, showUI = true, redirectURI } = configuration;
+    const { email, showUI = true, redirectURI, customTemplateName } = configuration;
 
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithMagicLinkTestMode : MagicPayloadMethod.LoginWithMagicLink,
-      [{ email, showUI, redirectURI }],
+      [{ email, showUI, redirectURI, customTemplateName }],
     );
     return this.request<string | null, LoginWithMagicLinkEventHandlers>(requestPayload);
   }
@@ -78,10 +78,10 @@ export class AuthModule extends BaseModule {
    * of 15 minutes)
    */
   public loginWithEmailOTP(configuration: LoginWithEmailOTPConfiguration) {
-    const { email, showUI, deviceCheckUI } = configuration;
+    const { email, showUI, deviceCheckUI, customTemplateName } = configuration;
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithEmailOTPTestMode : MagicPayloadMethod.LoginWithEmailOTP,
-      [{ email, showUI, deviceCheckUI }],
+      [{ email, showUI, deviceCheckUI, customTemplateName }],
     );
     const handle = this.request<string | null, LoginWithEmailOTPEventHandlers>(requestPayload);
     if (!deviceCheckUI && handle) {

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -49,12 +49,11 @@ export class AuthModule extends BaseModule {
       }).log();
     }
 
-    console.log(configuration);
-    const { email, showUI = true, redirectURI, variation } = configuration;
+    const { email, showUI = true, redirectURI, overrides } = configuration;
 
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithMagicLinkTestMode : MagicPayloadMethod.LoginWithMagicLink,
-      [{ email, showUI, redirectURI, variation }],
+      [{ email, showUI, redirectURI, overrides }],
     );
     return this.request<string | null, LoginWithMagicLinkEventHandlers>(requestPayload);
   }
@@ -79,10 +78,10 @@ export class AuthModule extends BaseModule {
    * of 15 minutes)
    */
   public loginWithEmailOTP(configuration: LoginWithEmailOTPConfiguration) {
-    const { email, showUI, deviceCheckUI, variation } = configuration;
+    const { email, showUI, deviceCheckUI, overrides } = configuration;
     const requestPayload = createJsonRpcRequestPayload(
       this.sdk.testMode ? MagicPayloadMethod.LoginWithEmailOTPTestMode : MagicPayloadMethod.LoginWithEmailOTP,
-      [{ email, showUI, deviceCheckUI, variation }],
+      [{ email, showUI, deviceCheckUI, overrides }],
     );
     const handle = this.request<string | null, LoginWithEmailOTPEventHandlers>(requestPayload);
     if (!deviceCheckUI && handle) {

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
@@ -37,6 +37,18 @@ test('Generates JSON RPC request payload with `showUI: false` parameter', async 
   expect(requestPayload.params).toEqual([{ email: expectedEmail, showUI: false }]);
 });
 
+test('Generates JSON RPC request payload with `customTemplateName` parameter', async () => {
+  const magic = createMagicSDK();
+  magic.auth.request = jest.fn();
+
+  await magic.auth.loginWithEmailOTP({ email: expectedEmail, customTemplateName: 'my custom template' });
+
+  const requestPayload = magic.auth.request.mock.calls[0][0];
+  expect(requestPayload.jsonrpc).toBe('2.0');
+  expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithEmailOTP);
+  expect(requestPayload.params).toEqual([{ email: expectedEmail, customTemplateName: 'my custom template' }]);
+});
+
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {
   const magic = createMagicSDKTestMode();
   magic.auth.request = jest.fn();

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
@@ -37,16 +37,16 @@ test('Generates JSON RPC request payload with `showUI: false` parameter', async 
   expect(requestPayload.params).toEqual([{ email: expectedEmail, showUI: false }]);
 });
 
-test('Generates JSON RPC request payload with `variation` parameter', async () => {
+test('Generates JSON RPC request payload with `overrides` parameter', async () => {
   const magic = createMagicSDK();
   magic.auth.request = jest.fn();
 
-  await magic.auth.loginWithEmailOTP({ email: expectedEmail, variation: 'my custom template' });
+  await magic.auth.loginWithEmailOTP({ email: expectedEmail, overrides: { variation: 'my custom template' } });
 
   const requestPayload = magic.auth.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithEmailOTP);
-  expect(requestPayload.params).toEqual([{ email: expectedEmail, variation: 'my custom template' }]);
+  expect(requestPayload.params).toEqual([{ email: expectedEmail, overrides: { variation: 'my custom template' } }]);
 });
 
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTP.spec.ts
@@ -37,16 +37,16 @@ test('Generates JSON RPC request payload with `showUI: false` parameter', async 
   expect(requestPayload.params).toEqual([{ email: expectedEmail, showUI: false }]);
 });
 
-test('Generates JSON RPC request payload with `customTemplateName` parameter', async () => {
+test('Generates JSON RPC request payload with `variation` parameter', async () => {
   const magic = createMagicSDK();
   magic.auth.request = jest.fn();
 
-  await magic.auth.loginWithEmailOTP({ email: expectedEmail, customTemplateName: 'my custom template' });
+  await magic.auth.loginWithEmailOTP({ email: expectedEmail, variation: 'my custom template' });
 
   const requestPayload = magic.auth.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithEmailOTP);
-  expect(requestPayload.params).toEqual([{ email: expectedEmail, customTemplateName: 'my custom template' }]);
+  expect(requestPayload.params).toEqual([{ email: expectedEmail, variation: 'my custom template' }]);
 });
 
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
@@ -48,16 +48,18 @@ test('Generates JSON RPC request payload with `redirectURI` parameter', async ()
   expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, redirectURI: 'helloworld' }]);
 });
 
-test('Generates JSON RPC request payload with `variation` parameter', async () => {
+test('Generates JSON RPC request payload with `overrides` parameter', async () => {
   const magic = createMagicSDK();
   magic.auth.request = jest.fn();
 
-  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, variation: 'my custom template' });
+  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, overrides: { variation: 'my custom template' } });
 
   const requestPayload = magic.auth.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithMagicLink);
-  expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, variation: 'my custom template' }]);
+  expect(requestPayload.params).toEqual([
+    { email: 'test', showUI: true, overrides: { variation: 'my custom template' } },
+  ]);
 });
 
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
@@ -48,6 +48,18 @@ test('Generates JSON RPC request payload with `redirectURI` parameter', async ()
   expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, redirectURI: 'helloworld' }]);
 });
 
+test('Generates JSON RPC request payload with `customTemplateName` parameter', async () => {
+  const magic = createMagicSDK();
+  magic.auth.request = jest.fn();
+
+  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, customTemplateName: 'my custom template' });
+
+  const requestPayload = magic.auth.request.mock.calls[0][0];
+  expect(requestPayload.jsonrpc).toBe('2.0');
+  expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithMagicLink);
+  expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, customTemplateName: 'my custom template' }]);
+});
+
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {
   const magic = createMagicSDKTestMode();
   magic.auth.request = jest.fn();

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithMagicLink.spec.ts
@@ -48,16 +48,16 @@ test('Generates JSON RPC request payload with `redirectURI` parameter', async ()
   expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, redirectURI: 'helloworld' }]);
 });
 
-test('Generates JSON RPC request payload with `customTemplateName` parameter', async () => {
+test('Generates JSON RPC request payload with `variation` parameter', async () => {
   const magic = createMagicSDK();
   magic.auth.request = jest.fn();
 
-  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, customTemplateName: 'my custom template' });
+  await magic.auth.loginWithMagicLink({ email: 'test', showUI: true, variation: 'my custom template' });
 
   const requestPayload = magic.auth.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe(MagicPayloadMethod.LoginWithMagicLink);
-  expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, customTemplateName: 'my custom template' }]);
+  expect(requestPayload.params).toEqual([{ email: 'test', showUI: true, variation: 'my custom template' }]);
 });
 
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -22,9 +22,9 @@ export interface LoginWithMagicLinkConfiguration {
   /**
    * Enterprise users with a custom SMTP can create custom email templates
    * from their dashboard. The default Magic loginWithMagicLink email will be
-   * overriden when a customTemplateName is passed here.
+   * overriden when a variation is passed here.
    */
-  customTemplateName?: string;
+  variation?: string;
 }
 
 export interface LoginWithSmsConfiguration {
@@ -65,9 +65,9 @@ export interface LoginWithEmailOTPConfiguration {
   /**
    * Enterprise users with a custom SMTP can create custom email templates
    * from their dashboard. The default Magic loginWithOTP email will be
-   * overriden when a customTemplateName is passed here.
+   * overriden when a variation is passed here.
    */
-  customTemplateName?: string;
+  variation?: string;
 }
 
 /**

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -18,6 +18,13 @@ export interface LoginWithMagicLinkConfiguration {
    * configure here.
    */
   redirectURI?: string;
+
+  /**
+   * Enterprise users with a custom SMTP can create custom email templates
+   * from their dashboard. The default Magic loginWithMagicLink email will be
+   * overriden when a customTemplateName is passed here.
+   */
+  customTemplateName?: string;
 }
 
 export interface LoginWithSmsConfiguration {
@@ -54,6 +61,13 @@ export interface LoginWithEmailOTPConfiguration {
    * handle device check events, providing a more tailored user experience.
    */
   deviceCheckUI?: boolean;
+
+  /**
+   * Enterprise users with a custom SMTP can create custom email templates
+   * from their dashboard. The default Magic loginWithOTP email will be
+   * overriden when a customTemplateName is passed here.
+   */
+  customTemplateName?: string;
 }
 
 /**

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -24,7 +24,9 @@ export interface LoginWithMagicLinkConfiguration {
    * from their dashboard. The default Magic loginWithMagicLink email will be
    * overriden when a variation is passed here.
    */
-  variation?: string;
+  overrides?: {
+    variation?: string;
+  };
 }
 
 export interface LoginWithSmsConfiguration {
@@ -67,7 +69,9 @@ export interface LoginWithEmailOTPConfiguration {
    * from their dashboard. The default Magic loginWithOTP email will be
    * overriden when a variation is passed here.
    */
-  variation?: string;
+  overrides?: {
+    variation?: string;
+  };
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,7 +2817,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2826,8 +2826,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^16.1.1
-    "@magic-sdk/provider": ^20.1.1
+    "@magic-sdk/commons": ^17.0.0
+    "@magic-sdk/provider": ^21.0.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2839,7 +2839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2847,7 +2847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2855,7 +2855,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2863,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2871,7 +2871,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2879,7 +2879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2887,7 +2887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2900,7 +2900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
     "@magic-sdk/types": ^17.0.2
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2910,7 +2910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2928,7 +2928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2936,15 +2936,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^14.1.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^15.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2954,7 +2954,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2962,7 +2962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -2970,7 +2970,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^21.1.1
+    "@magic-sdk/react-native-bare": ^22.0.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2986,7 +2986,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^21.1.1
+    "@magic-sdk/react-native-expo": ^22.0.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3001,7 +3001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -3009,7 +3009,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -3017,7 +3017,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -3025,7 +3025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -3041,15 +3041,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^16.1.1
+    "@magic-sdk/commons": ^17.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^16.1.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^17.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^20.1.1
+    "@magic-sdk/provider": ^21.0.0
     "@magic-sdk/types": ^17.0.2
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -3074,12 +3074,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^14.1.2
-    magic-sdk: ^20.1.1
+    "@magic-ext/oauth": ^15.0.0
+    magic-sdk: ^21.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^20.1.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^21.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -3096,7 +3096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^21.1.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^22.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3104,8 +3104,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.1.1
-    "@magic-sdk/provider": ^20.1.1
+    "@magic-sdk/commons": ^17.0.0
+    "@magic-sdk/provider": ^21.0.0
     "@magic-sdk/types": ^17.0.2
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -3132,7 +3132,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^21.1.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^22.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3140,8 +3140,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^16.1.1
-    "@magic-sdk/provider": ^20.1.1
+    "@magic-sdk/commons": ^17.0.0
+    "@magic-sdk/provider": ^21.0.0
     "@magic-sdk/types": ^17.0.2
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
@@ -12827,15 +12827,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^20.1.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^21.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^16.1.1
-    "@magic-sdk/provider": ^20.1.1
+    "@magic-sdk/commons": ^17.0.0
+    "@magic-sdk/provider": ^21.0.0
     "@magic-sdk/types": ^17.0.2
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
# Do not merge
### 📦 Pull Request

Attempting to re-publish canary version that is failing in different PR

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/aptos@4.1.0-canary.647.6550944776.0
  npm install @magic-ext/auth@4.1.0-canary.647.6550944776.0
  npm install @magic-ext/avalanche@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/bitcoin@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/conflux@14.1.0-canary.647.6550944776.0
  npm install @magic-ext/cosmos@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/ed25519@12.1.0-canary.647.6550944776.0
  npm install @magic-ext/flow@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/gdkms@4.1.0-canary.647.6550944776.0
  npm install @magic-ext/harmony@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/icon@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/near@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/oauth@15.1.0-canary.647.6550944776.0
  npm install @magic-ext/oidc@4.1.0-canary.647.6550944776.0
  npm install @magic-ext/polkadot@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/react-native-bare-oauth@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/react-native-expo-oauth@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/solana@17.1.0-canary.647.6550944776.0
  npm install @magic-ext/taquito@13.1.0-canary.647.6550944776.0
  npm install @magic-ext/terra@13.1.0-canary.647.6550944776.0
  npm install @magic-ext/tezos@16.1.0-canary.647.6550944776.0
  npm install @magic-ext/webauthn@15.1.0-canary.647.6550944776.0
  npm install @magic-ext/zilliqa@16.1.0-canary.647.6550944776.0
  npm install @magic-sdk/commons@17.1.0-canary.647.6550944776.0
  npm install @magic-sdk/pnp@15.1.0-canary.647.6550944776.0
  npm install @magic-sdk/provider@21.1.0-canary.647.6550944776.0
  npm install @magic-sdk/react-native-bare@22.1.0-canary.647.6550944776.0
  npm install @magic-sdk/react-native-expo@22.1.0-canary.647.6550944776.0
  npm install @magic-sdk/types@17.1.0-canary.647.6550944776.0
  npm install magic-sdk@21.1.0-canary.647.6550944776.0
  # or 
  yarn add @magic-ext/algorand@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/aptos@4.1.0-canary.647.6550944776.0
  yarn add @magic-ext/auth@4.1.0-canary.647.6550944776.0
  yarn add @magic-ext/avalanche@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/bitcoin@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/conflux@14.1.0-canary.647.6550944776.0
  yarn add @magic-ext/cosmos@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/ed25519@12.1.0-canary.647.6550944776.0
  yarn add @magic-ext/flow@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/gdkms@4.1.0-canary.647.6550944776.0
  yarn add @magic-ext/harmony@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/icon@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/near@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/oauth@15.1.0-canary.647.6550944776.0
  yarn add @magic-ext/oidc@4.1.0-canary.647.6550944776.0
  yarn add @magic-ext/polkadot@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/react-native-bare-oauth@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/react-native-expo-oauth@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/solana@17.1.0-canary.647.6550944776.0
  yarn add @magic-ext/taquito@13.1.0-canary.647.6550944776.0
  yarn add @magic-ext/terra@13.1.0-canary.647.6550944776.0
  yarn add @magic-ext/tezos@16.1.0-canary.647.6550944776.0
  yarn add @magic-ext/webauthn@15.1.0-canary.647.6550944776.0
  yarn add @magic-ext/zilliqa@16.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/commons@17.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/pnp@15.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/provider@21.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/react-native-bare@22.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/react-native-expo@22.1.0-canary.647.6550944776.0
  yarn add @magic-sdk/types@17.1.0-canary.647.6550944776.0
  yarn add magic-sdk@21.1.0-canary.647.6550944776.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
