### PR TITLE
[Do Not Merge] override the default /send endpoint to /send-legacy

### DIFF
--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -62,7 +62,7 @@ export class IframeController extends ViewController {
           iframe.classList.add('magic-iframe');
           iframe.dataset.magicIframeLabel = createURL(this.endpoint).host;
           iframe.title = 'Secure Modal';
-          iframe.src = createURL(`/send?params=${encodeURIComponent(this.parameters)}`, this.endpoint).href;
+          iframe.src = createURL(`/send-v1?params=${encodeURIComponent(this.parameters)}`, this.endpoint).href;
           applyOverlayStyles(iframe);
           document.body.appendChild(iframe);
           resolve(iframe);

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -62,7 +62,7 @@ export class IframeController extends ViewController {
           iframe.classList.add('magic-iframe');
           iframe.dataset.magicIframeLabel = createURL(this.endpoint).host;
           iframe.title = 'Secure Modal';
-          iframe.src = createURL(`/send-v1?params=${encodeURIComponent(this.parameters)}`, this.endpoint).href;
+          iframe.src = createURL(`/send-legacy?params=${encodeURIComponent(this.parameters)}`, this.endpoint).href;
           applyOverlayStyles(iframe);
           document.body.appendChild(iframe);
           resolve(iframe);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,7 +2826,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2835,8 +2835,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^17.1.1
-    "@magic-sdk/provider": ^21.1.1
+    "@magic-sdk/commons": ^17.2.0
+    "@magic-sdk/provider": ^21.2.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2848,7 +2848,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2856,7 +2856,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2864,7 +2864,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2872,7 +2872,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2880,7 +2880,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2888,7 +2888,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2896,7 +2896,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2909,8 +2909,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
+    "@magic-sdk/types": ^17.2.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2919,7 +2919,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2937,7 +2937,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2945,15 +2945,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^15.1.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^15.2.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2963,7 +2963,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2971,7 +2971,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -2979,7 +2979,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^22.1.1
+    "@magic-sdk/react-native-bare": ^22.2.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2995,7 +2995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^22.1.1
+    "@magic-sdk/react-native-expo": ^22.2.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3010,7 +3010,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3021,7 +3021,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -3029,7 +3029,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -3037,7 +3037,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -3045,7 +3045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
@@ -3053,16 +3053,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^17.1.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^17.2.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^21.1.1
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/provider": ^21.2.0
+    "@magic-sdk/types": ^17.2.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -3086,17 +3086,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^15.1.1
-    magic-sdk: ^21.1.1
+    "@magic-ext/oauth": ^15.2.0
+    magic-sdk: ^21.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^21.1.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^21.2.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/types": ^17.2.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -3108,7 +3108,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^22.1.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^22.2.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3116,9 +3116,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^17.1.1
-    "@magic-sdk/provider": ^21.1.1
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
+    "@magic-sdk/provider": ^21.2.0
+    "@magic-sdk/types": ^17.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3144,7 +3144,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^22.1.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^22.2.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3152,9 +3152,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^17.1.1
-    "@magic-sdk/provider": ^21.1.1
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
+    "@magic-sdk/provider": ^21.2.0
+    "@magic-sdk/types": ^17.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
@@ -3180,7 +3180,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^17.1.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^17.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12987,16 +12987,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^21.1.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^21.2.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^17.1.1
-    "@magic-sdk/provider": ^21.1.1
-    "@magic-sdk/types": ^17.1.1
+    "@magic-sdk/commons": ^17.2.0
+    "@magic-sdk/provider": ^21.2.0
+    "@magic-sdk/types": ^17.2.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
For internal testing only.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-sdk/pnp@15.2.1-canary.655.6657410675.0
  npm install magic-sdk@21.2.1-canary.655.6657410675.0
  # or 
  yarn add @magic-sdk/pnp@15.2.1-canary.655.6657410675.0
  yarn add magic-sdk@21.2.1-canary.655.6657410675.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
