### PR TITLE
Add types to sign methods to avoid returning 'any' type

### DIFF
--- a/packages/@magic-ext/solana/src/constants.ts
+++ b/packages/@magic-ext/solana/src/constants.ts
@@ -1,0 +1,4 @@
+export const SOLANA_PAYLOAD_METHODS = {
+  SIGN_TRANSACTION: 'sol_signTransaction',
+  SIGN_MESSAGE: 'sol_signMessage',
+} as const;

--- a/packages/@magic-ext/solana/src/index.ts
+++ b/packages/@magic-ext/solana/src/index.ts
@@ -1,8 +1,8 @@
 import { Extension } from '@magic-sdk/commons';
 
-/* eslint-disable no-param-reassign, array-callback-return */
-import { Transaction, VersionedTransaction } from '@solana/web3.js';
-import { SolanaConfig, SolanaPayloadMethod, SerializeConfig } from './type';
+import { SerializeConfig, Transaction, VersionedTransaction } from '@solana/web3.js';
+import { SolanaConfig } from './type';
+import { SOLANA_PAYLOAD_METHODS } from './constants';
 
 export class SolanaExtension extends Extension.Internal<'solana', any> {
   name = 'solana' as const;
@@ -18,10 +18,10 @@ export class SolanaExtension extends Extension.Internal<'solana', any> {
   }
 
   public signTransaction = (transaction: Transaction | VersionedTransaction, serializeConfig?: SerializeConfig) => {
-    return this.request({
+    return this.request<{ rawTransaction: string }>({
       id: 42,
       jsonrpc: '2.0',
-      method: SolanaPayloadMethod.SignTransaction,
+      method: SOLANA_PAYLOAD_METHODS.SIGN_TRANSACTION,
       params: {
         type: transaction instanceof Transaction ? 'legacy' : 0,
         serialized: transaction.serialize(serializeConfig),
@@ -31,10 +31,10 @@ export class SolanaExtension extends Extension.Internal<'solana', any> {
   };
 
   public signMessage = (message: any) => {
-    return this.request({
+    return this.request<{ rawTransaction: string }>({
       id: 42,
       jsonrpc: '2.0',
-      method: SolanaPayloadMethod.SignMessage,
+      method: SOLANA_PAYLOAD_METHODS.SIGN_MESSAGE,
       params: {
         message,
       },

--- a/packages/@magic-ext/solana/src/type.ts
+++ b/packages/@magic-ext/solana/src/type.ts
@@ -1,16 +1,3 @@
 export interface SolanaConfig {
   rpcUrl: string;
 }
-
-export enum SolanaPayloadMethod {
-  SignTransaction = 'sol_signTransaction',
-  SendTransaction = 'sol_sendTransaction',
-  SignMessage = 'sol_signMessage',
-}
-
-export interface SerializeConfig {
-  /** Require all transaction signatures be present (default: true) */
-  requireAllSignatures?: boolean;
-  /** Verify provided signatures (default: true) */
-  verifySignatures?: boolean;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,7 +2979,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^22.2.0
+    "@magic-sdk/react-native-bare": ^22.2.1
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2995,7 +2995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^22.2.0
+    "@magic-sdk/react-native-expo": ^22.2.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3108,7 +3108,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^22.2.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^22.2.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3144,7 +3144,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^22.2.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^22.2.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Add types to sign methods to avoid returning 'any' type

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/solana@17.2.2-canary.662.6807796828.0
  # or 
  yarn add @magic-ext/solana@17.2.2-canary.662.6807796828.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
