### PR TITLE
Revert "Rename: ready -> checkIsReadyForRequest and isReady -> isReadyForRequest"

### DIFF
--- a/packages/@magic-ext/react-native-bare-oauth/src/index.ts
+++ b/packages/@magic-ext/react-native-bare-oauth/src/index.ts
@@ -20,7 +20,7 @@ export class OAuthExtension extends Extension.Internal<'oauth'> {
     '@magic-sdk/react-native': false,
   };
 
-  public loginWithRedirect(configuration: OAuthRedirectConfiguration) {
+  public loginWithPopup(configuration: OAuthRedirectConfiguration) {
     return this.utils.createPromiEvent<OAuthRedirectResult>(async (resolve, reject) => {
       try {
         const { provider, query, redirectURI } = await createURI.call(this, configuration);

--- a/packages/@magic-ext/react-native-expo-oauth/src/index.ts
+++ b/packages/@magic-ext/react-native-expo-oauth/src/index.ts
@@ -20,7 +20,7 @@ export class OAuthExtension extends Extension.Internal<'oauth'> {
     '@magic-sdk/react-native-expo': '>=13.0.0',
   };
 
-  public loginWithRedirect(configuration: OAuthRedirectConfiguration) {
+  public loginWithPopup(configuration: OAuthRedirectConfiguration) {
     return this.utils.createPromiEvent<OAuthRedirectResult>(async (resolve, reject) => {
       try {
         const { provider, query, redirectURI } = await createURI.call(this, configuration);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,7 +2835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2844,8 +2844,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^17.2.1
-    "@magic-sdk/provider": ^21.2.1
+    "@magic-sdk/commons": ^17.3.0
+    "@magic-sdk/provider": ^21.3.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2857,7 +2857,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/auth@workspace:packages/@magic-ext/auth"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2865,7 +2865,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2873,7 +2873,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2881,7 +2881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2889,7 +2889,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2897,7 +2897,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2905,7 +2905,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2918,7 +2918,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
     "@magic-sdk/types": ^17.2.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2928,7 +2928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2946,7 +2946,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2954,15 +2954,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^15.2.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^15.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2972,7 +2972,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2980,7 +2980,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -2988,7 +2988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^22.2.2
+    "@magic-sdk/react-native-bare": ^22.3.0
     "@magic-sdk/types": ^10.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3004,7 +3004,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^22.2.2
+    "@magic-sdk/react-native-expo": ^22.3.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -3019,7 +3019,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3030,7 +3030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -3038,7 +3038,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -3046,7 +3046,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -3054,7 +3054,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
@@ -3062,15 +3062,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^17.2.1
+    "@magic-sdk/commons": ^17.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^17.2.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^17.3.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^21.2.1
+    "@magic-sdk/provider": ^21.3.0
     "@magic-sdk/types": ^17.2.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -3095,12 +3095,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^15.2.1
-    magic-sdk: ^21.2.1
+    "@magic-ext/oauth": ^15.3.0
+    magic-sdk: ^21.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^21.2.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^21.3.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -3117,7 +3117,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^22.2.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^22.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -3125,8 +3125,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^17.2.1
-    "@magic-sdk/provider": ^21.2.1
+    "@magic-sdk/commons": ^17.3.0
+    "@magic-sdk/provider": ^21.3.0
     "@magic-sdk/types": ^17.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -3157,7 +3157,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^22.2.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^22.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -3165,8 +3165,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^17.2.1
-    "@magic-sdk/provider": ^21.2.1
+    "@magic-sdk/commons": ^17.3.0
+    "@magic-sdk/provider": ^21.3.0
     "@magic-sdk/types": ^17.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -13077,15 +13077,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^21.2.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^21.3.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^17.2.1
-    "@magic-sdk/provider": ^21.2.1
+    "@magic-sdk/commons": ^17.3.0
+    "@magic-sdk/provider": ^21.3.0
     "@magic-sdk/types": ^17.2.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
This reverts commit 09ec3931

### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-bare-oauth@18.0.0-canary.668.6937289924.0
  npm install @magic-ext/react-native-expo-oauth@18.0.0-canary.668.6937289924.0
  # or 
  yarn add @magic-ext/react-native-bare-oauth@18.0.0-canary.668.6937289924.0
  yarn add @magic-ext/react-native-expo-oauth@18.0.0-canary.668.6937289924.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
