### PR TITLE
Fix TypeScript resolution for @magic-ext/* packages when using modern module resolution (node16 etc)

### DIFF
--- a/packages/@magic-ext/algorand/package.json
+++ b/packages/@magic-ext/algorand/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/auth/package.json
+++ b/packages/@magic-ext/auth/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/avalanche/package.json
+++ b/packages/@magic-ext/avalanche/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/bitcoin/package.json
+++ b/packages/@magic-ext/bitcoin/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/conflux/package.json
+++ b/packages/@magic-ext/conflux/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/cosmos/package.json
+++ b/packages/@magic-ext/cosmos/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/ed25519/package.json
+++ b/packages/@magic-ext/ed25519/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/flow/package.json
+++ b/packages/@magic-ext/flow/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/gdkms/package.json
+++ b/packages/@magic-ext/gdkms/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/harmony/package.json
+++ b/packages/@magic-ext/harmony/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/hedera/package.json
+++ b/packages/@magic-ext/hedera/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/icon/package.json
+++ b/packages/@magic-ext/icon/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/near/package.json
+++ b/packages/@magic-ext/near/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/oidc/package.json
+++ b/packages/@magic-ext/oidc/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/polkadot/package.json
+++ b/packages/@magic-ext/polkadot/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/react-native-expo-oauth/package.json
+++ b/packages/@magic-ext/react-native-expo-oauth/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/taquito/package.json
+++ b/packages/@magic-ext/taquito/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/terra/package.json
+++ b/packages/@magic-ext/terra/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/tezos/package.json
+++ b/packages/@magic-ext/tezos/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/webauthn/package.json
+++ b/packages/@magic-ext/webauthn/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/packages/@magic-ext/zilliqa/package.json
+++ b/packages/@magic-ext/zilliqa/package.json
@@ -19,6 +19,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {


### PR DESCRIPTION
### 📦 Pull Request

This PR updates the `package.json` files for all of the `@magic-ext` packages (apart from aptos and solana, which already had this change applied).

This is essentially the same change that has already been applied in https://github.com/magiclabs/magic-js/pull/517 by @octave08 (why wasn't this done for all packages?) and proposed in https://github.com/magiclabs/magic-js/pull/626

### ✅ Fixed Issues

Fixes #669 

### 🚨 Test instructions

Create a new TypeScript web app that uses `node16` or `nodenext` module resolution, try to import these packages, TypeScript should be able to perform type checking based on the types of the imported objects.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
