### PR TITLE
add types to scaffolding export

### DIFF
--- a/scripts/bin/scaffold/template/hybrid/package.json
+++ b/scripts/bin/scaffold/template/hybrid/package.json
@@ -17,6 +17,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/scripts/bin/scaffold/template/react-native/package.json
+++ b/scripts/bin/scaffold/template/react-native/package.json
@@ -15,6 +15,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/scripts/bin/scaffold/template/web/package.json
+++ b/scripts/bin/scaffold/template/web/package.json
@@ -17,6 +17,7 @@
   "jsdelivr": "./dist/extension.js",
   "exports": {
     "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.js"
   },
   "externals": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,7 +2958,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^15.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^15.3.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
@@ -3095,7 +3095,7 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^15.3.0
+    "@magic-ext/oauth": ^15.3.1
     magic-sdk: ^21.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

Our scaffolding templates did not have a `types` export. This caused many of our extensions to not have this export in their `package.json`'s.

### ✅ Fixed Issues

- Add `types` export to each template scaffolding

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
