### PR TITLE
Fix: Allow implementers of `view-controller` to set if it's connected to the internet, and reject requests when `isConnectedToInternet` is `false`

### DIFF
--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/react-native-bare",
-  "version": "22.3.0",
+  "version": "22.3.1",
   "description": "Passwordless authentication for React Native (Bare).",
   "author": "Magic Labs <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -6,6 +6,7 @@ import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
 import Global = NodeJS.Global;
+import { useInternetConnection } from './hooks';
 
 const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
 const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
@@ -79,6 +80,11 @@ export class ReactNativeWebViewController extends ViewController {
   /* istanbul ignore next */
   public Relayer: React.FC<{ backgroundColor?: string }> = (backgroundColor) => {
     const [show, setShow] = useState(false);
+    const isConnected = useInternetConnection();
+
+    useEffect(() => {
+      this.isConnectedToInternet = isConnected;
+    }, [isConnected]);
 
     /**
      * Saves a reference to the underlying `<WebView>` node so we can interact

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-sdk/react-native-expo",
-  "version": "22.3.0",
+  "version": "22.3.1",
   "description": "Passwordless authentication for React Native (Expo).",
   "author": "Magic Labs <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -6,6 +6,7 @@ import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
 import Global = NodeJS.Global;
+import { useInternetConnection } from './hooks';
 
 const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
 const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
@@ -79,6 +80,11 @@ export class ReactNativeWebViewController extends ViewController {
   /* istanbul ignore next */
   public Relayer: React.FC<{ backgroundColor?: string }> = ({ backgroundColor }) => {
     const [show, setShow] = useState(false);
+    const isConnected = useInternetConnection();
+
+    useEffect(() => {
+      this.isConnectedToInternet = isConnected;
+    }, [isConnected]);
 
     /**
      * Saves a reference to the underlying `<WebView>` node so we can interact


### PR DESCRIPTION
### 📦 Pull Request
Fix: Allow classes that extend `view-controller` to set if it's connected to the internet, and reject requests when `isConnectedToInternet` is `false`.

On mobile, it takes a while for the connectivity to the overlay to be established. If a method like `isLoggedIn` is called before that (i.e. on app start-up), it would reject it, which is not ideal. This fix allows you to call methods like `isLoggedIn` even before the connection is established, and wait for a response.


### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]
Fixes https://github.com/magiclabs/magic-js/issues/672
### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/aptos@4.3.1-canary.673.7023773085.0
  npm install @magic-ext/auth@4.3.2-canary.673.7023773085.0
  npm install @magic-ext/avalanche@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/bitcoin@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/conflux@14.3.2-canary.673.7023773085.0
  npm install @magic-ext/cosmos@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/ed25519@12.3.2-canary.673.7023773085.0
  npm install @magic-ext/flow@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/gdkms@4.3.2-canary.673.7023773085.0
  npm install @magic-ext/harmony@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/icon@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/near@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/oauth@15.3.2-canary.673.7023773085.0
  npm install @magic-ext/oidc@4.3.2-canary.673.7023773085.0
  npm install @magic-ext/polkadot@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/react-native-bare-oauth@18.0.2-canary.673.7023773085.0
  npm install @magic-ext/react-native-expo-oauth@18.0.2-canary.673.7023773085.0
  npm install @magic-ext/solana@18.1.1-canary.673.7023773085.0
  npm install @magic-ext/taquito@13.3.2-canary.673.7023773085.0
  npm install @magic-ext/terra@13.3.2-canary.673.7023773085.0
  npm install @magic-ext/tezos@16.3.2-canary.673.7023773085.0
  npm install @magic-ext/webauthn@15.3.2-canary.673.7023773085.0
  npm install @magic-ext/zilliqa@16.3.2-canary.673.7023773085.0
  npm install @magic-sdk/commons@17.3.1-canary.673.7023773085.0
  npm install @magic-sdk/pnp@15.3.2-canary.673.7023773085.0
  npm install @magic-sdk/provider@21.3.1-canary.673.7023773085.0
  npm install @magic-sdk/react-native-bare@22.3.2-canary.673.7023773085.0
  npm install @magic-sdk/react-native-expo@22.3.2-canary.673.7023773085.0
  npm install magic-sdk@21.3.1-canary.673.7023773085.0
  # or 
  yarn add @magic-ext/algorand@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/aptos@4.3.1-canary.673.7023773085.0
  yarn add @magic-ext/auth@4.3.2-canary.673.7023773085.0
  yarn add @magic-ext/avalanche@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/bitcoin@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/conflux@14.3.2-canary.673.7023773085.0
  yarn add @magic-ext/cosmos@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/ed25519@12.3.2-canary.673.7023773085.0
  yarn add @magic-ext/flow@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/gdkms@4.3.2-canary.673.7023773085.0
  yarn add @magic-ext/harmony@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/icon@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/near@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/oauth@15.3.2-canary.673.7023773085.0
  yarn add @magic-ext/oidc@4.3.2-canary.673.7023773085.0
  yarn add @magic-ext/polkadot@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/react-native-bare-oauth@18.0.2-canary.673.7023773085.0
  yarn add @magic-ext/react-native-expo-oauth@18.0.2-canary.673.7023773085.0
  yarn add @magic-ext/solana@18.1.1-canary.673.7023773085.0
  yarn add @magic-ext/taquito@13.3.2-canary.673.7023773085.0
  yarn add @magic-ext/terra@13.3.2-canary.673.7023773085.0
  yarn add @magic-ext/tezos@16.3.2-canary.673.7023773085.0
  yarn add @magic-ext/webauthn@15.3.2-canary.673.7023773085.0
  yarn add @magic-ext/zilliqa@16.3.2-canary.673.7023773085.0
  yarn add @magic-sdk/commons@17.3.1-canary.673.7023773085.0
  yarn add @magic-sdk/pnp@15.3.2-canary.673.7023773085.0
  yarn add @magic-sdk/provider@21.3.1-canary.673.7023773085.0
  yarn add @magic-sdk/react-native-bare@22.3.2-canary.673.7023773085.0
  yarn add @magic-sdk/react-native-expo@22.3.2-canary.673.7023773085.0
  yarn add magic-sdk@21.3.1-canary.673.7023773085.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
