### PR TITLE
added getter for request status

### DIFF
--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -198,4 +198,8 @@ export class SDKBase {
   public async preload() {
     await this.overlay.checkIsReadyForRequest;
   }
+
+  public get readyForRequest() {
+    return this.overlay.readyForRequest;
+  }
 }

--- a/packages/@magic-sdk/provider/src/core/view-controller.ts
+++ b/packages/@magic-sdk/provider/src/core/view-controller.ts
@@ -105,6 +105,10 @@ export abstract class ViewController {
     this.listen();
   }
 
+  public get readyForRequest() {
+    return this.isReadyForRequest;
+  }
+
   protected abstract init(): void;
   protected abstract _post(data: MagicMessageRequest): Promise<void>;
   protected abstract hideOverlay(): void;


### PR DESCRIPTION
### 📦 Pull Request

Adding new getter to Magic to be able to get current request status, so the app can start making requests to Magic only after it is ready. This is important when switching multiple networks and the whole view controller is reinitiated, if switching multiple times within short period it can make requests unavailable since it didn't load it all correctly. With this getter flag we know when Magic is ready to receive requests. This is already done internally and it is raising errors right now but with this approach we know to back off more correctly until it is ready. 

### ✅ Fixed Issues

- [https://github.com/magiclabs/magic-js/issues/610](https://github.com/magiclabs/magic-js/issues/610)

### 🚨 Test instructions

When you instantiate magic you have available new getter readyForRequest on magic object.

```
const magic = new Magic(....)

magic.readyForRequest // returns boolean if Magic can do requests
```


- `patch`: Bug Fix?
- `minor`: New Feature?