### PR TITLE
Fix type mismatch for signMessage in solana-ext

### DIFF
--- a/packages/@magic-ext/solana/src/index.ts
+++ b/packages/@magic-ext/solana/src/index.ts
@@ -30,8 +30,8 @@ export class SolanaExtension extends Extension.Internal<'solana', any> {
     });
   };
 
-  public signMessage = (message: any) => {
-    return this.request<{ rawTransaction: string }>({
+  public signMessage = (message: string | Uint8Array) => {
+    return this.request<Uint8Array>({
       id: 42,
       jsonrpc: '2.0',
       method: SOLANA_PAYLOAD_METHODS.SIGN_MESSAGE,


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/solana@18.3.0-canary.691.7291625982.0
  # or 
  yarn add @magic-ext/solana@18.3.0-canary.691.7291625982.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
