### PR TITLE
move crypto-js to dependencies

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -28,9 +28,11 @@
       "@magic-sdk/provider"
     ]
   },
+  "dependencies": {
+    "crypto-js": "^3.3.0"
+  },
   "devDependencies": {
     "@magic-sdk/commons": "^17.4.1",
-    "@types/crypto-js": "~3.1.47",
-    "crypto-js": "^3.3.0"
+    "@types/crypto-js": "~3.1.47"
   }
 }


### PR DESCRIPTION
### 📦 Pull Request

Fix webpack 5 build fail for magic-ext/oauth

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions
![image](https://github.com/magiclabs/magic-js/assets/33166884/60377e0d-622b-4ed9-add2-12ff6b077cb1)

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/oauth@15.4.2-canary.692.7296356209.0
  npm install @magic-ext/solana@18.2.2-canary.692.7296356209.0
  npm install @magic-sdk/pnp@15.4.2-canary.692.7296356209.0
  # or 
  yarn add @magic-ext/oauth@15.4.2-canary.692.7296356209.0
  yarn add @magic-ext/solana@18.2.2-canary.692.7296356209.0
  yarn add @magic-sdk/pnp@15.4.2-canary.692.7296356209.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
