### PR TITLE
Fix: use default import of crypto-js to fix unresolved imports after build

### DIFF
--- a/packages/@magic-ext/oauth/src/crypto.ts
+++ b/packages/@magic-ext/oauth/src/crypto.ts
@@ -1,6 +1,4 @@
-import { WordArray } from 'crypto-js';
-import SHA256 from 'crypto-js/sha256';
-import Base64 from 'crypto-js/enc-base64';
+import Crypto from 'crypto-js';
 
 const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
 const HAS_CRYPTO = typeof window !== 'undefined' && !!(window.crypto as any);
@@ -19,9 +17,9 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: WordArray): string;
+function base64URLEncodeFromByteArray(wordArray: Crypto.WordArray): string;
 function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
-function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
+function base64URLEncodeFromByteArray(arg: Crypto.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   };
@@ -36,7 +34,7 @@ function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
     return makeURLSafe(base64);
   }
 
-  return makeURLSafe(Base64.stringify(arg));
+  return makeURLSafe(Crypto.enc.Base64.stringify(arg));
 }
 
 /**
@@ -50,7 +48,7 @@ async function sha256(message: string) {
     return crypto.subtle.digest('SHA-256', bytes).then(base64URLEncodeFromByteArray);
   }
 
-  return base64URLEncodeFromByteArray(SHA256(message));
+  return base64URLEncodeFromByteArray(Crypto.SHA256(message));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,7 +2950,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^15.4.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^15.5.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
@@ -3087,7 +3087,7 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^15.4.1
+    "@magic-ext/oauth": ^15.5.0
     magic-sdk: ^21.4.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION

### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/oauth@15.5.1-canary.694.7332577917.0
  npm install @magic-sdk/pnp@15.5.1-canary.694.7332577917.0
  # or 
  yarn add @magic-ext/oauth@15.5.1-canary.694.7332577917.0
  yarn add @magic-sdk/pnp@15.5.1-canary.694.7332577917.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
