### PR TITLE
Fix type mismatch for signTransaction in solana-ext.

### DIFF
--- a/packages/@magic-ext/solana/src/index.ts
+++ b/packages/@magic-ext/solana/src/index.ts
@@ -18,7 +18,7 @@ export class SolanaExtension extends Extension.Internal<'solana', any> {
   }
 
   public signTransaction = (transaction: Transaction | VersionedTransaction, serializeConfig?: SerializeConfig) => {
-    return this.request<{ rawTransaction: string }>({
+    return this.request<{ rawTransaction: Uint8Array }>({
       id: 42,
       jsonrpc: '2.0',
       method: SOLANA_PAYLOAD_METHODS.SIGN_TRANSACTION,


### PR DESCRIPTION
### 📦 Pull Request

The response type of `magic.solana.signTransaction()` should be `Promise<{rawTransaction: Uint8Array}>` instead of `Promise<{rawTransaction: string}>`