### PR TITLE
[FEAT]: adding meta field to @magic-sdk magic constructor

### DIFF
--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -118,6 +118,7 @@ export interface MagicSDKAdditionalConfiguration<
   testMode?: boolean;
   deferPreload?: boolean;
   useStorageCache?: boolean;
+  meta?: any; // Generic field for clients to add metadata
 }
 
 export class SDKBase {
@@ -193,6 +194,7 @@ export class SDKBase {
       ext: isEmpty(extConfig) ? undefined : extConfig,
       locale: options?.locale || 'en_US',
       ...(SDKEnvironment.bundleId ? { bundleId: SDKEnvironment.bundleId } : {}),
+      meta: options?.meta,
     });
     this.networkHash = getNetworkHash(this.apiKey, options?.network, isEmpty(extConfig) ? undefined : extConfig);
     if (!options?.deferPreload) this.preload();

--- a/packages/@magic-sdk/types/src/core/query-types.ts
+++ b/packages/@magic-sdk/types/src/core/query-types.ts
@@ -13,4 +13,5 @@ export interface QueryParameters {
   ext?: any;
   locale?: string;
   bundleId?: string;
+  meta?: any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2043,7 +2043,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2052,8 +2052,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^18.0.0
-    "@magic-sdk/provider": ^22.0.0
+    "@magic-sdk/commons": ^18.0.1
+    "@magic-sdk/provider": ^22.0.1
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2065,7 +2065,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2073,7 +2073,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2081,7 +2081,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2089,7 +2089,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2097,7 +2097,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2105,7 +2105,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2118,8 +2118,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
+    "@magic-sdk/types": ^18.0.1
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2128,7 +2128,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2146,7 +2146,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2154,15 +2154,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^16.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^16.0.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2172,7 +2172,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2180,7 +2180,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2188,8 +2188,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^23.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/react-native-bare": ^23.0.1
+    "@magic-sdk/types": ^18.0.1
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2204,7 +2204,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^23.0.0
+    "@magic-sdk/react-native-expo": ^23.0.1
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2219,7 +2219,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2230,7 +2230,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2238,7 +2238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2246,7 +2246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2254,7 +2254,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
@@ -2262,16 +2262,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^18.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^18.0.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^22.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/provider": ^22.0.1
+    "@magic-sdk/types": ^18.0.1
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2295,17 +2295,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^16.0.0
-    magic-sdk: ^22.0.0
+    "@magic-ext/oauth": ^16.0.1
+    magic-sdk: ^22.0.1
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^22.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^22.0.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/types": ^18.0.1
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2317,7 +2317,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^23.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^23.0.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2325,9 +2325,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^18.0.0
-    "@magic-sdk/provider": ^22.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
+    "@magic-sdk/provider": ^22.0.1
+    "@magic-sdk/types": ^18.0.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2357,7 +2357,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^23.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^23.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2365,9 +2365,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^18.0.0
-    "@magic-sdk/provider": ^22.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
+    "@magic-sdk/provider": ^22.0.1
+    "@magic-sdk/types": ^18.0.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2397,7 +2397,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^18.0.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^18.0.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12742,16 +12742,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^22.0.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^22.0.1, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^18.0.0
-    "@magic-sdk/provider": ^22.0.0
-    "@magic-sdk/types": ^18.0.0
+    "@magic-sdk/commons": ^18.0.1
+    "@magic-sdk/provider": ^22.0.1
+    "@magic-sdk/types": ^18.0.1
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

Adding a meta field to the Magic constructor in the @magic-sdk package to allow arbitrary data to be sent to the Magic backend. Ping @bengriffin1 for more details.

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

No test needed as of now

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please only add **one** label:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/aptos@5.1.0-canary.708.7845477243.0
  npm install @magic-ext/avalanche@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/bitcoin@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/conflux@15.1.0-canary.708.7845477243.0
  npm install @magic-ext/cosmos@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/ed25519@13.1.0-canary.708.7845477243.0
  npm install @magic-ext/flow@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/gdkms@5.1.0-canary.708.7845477243.0
  npm install @magic-ext/harmony@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/icon@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/near@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/oauth@16.1.0-canary.708.7845477243.0
  npm install @magic-ext/oidc@5.1.0-canary.708.7845477243.0
  npm install @magic-ext/polkadot@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/react-native-bare-oauth@19.1.0-canary.708.7845477243.0
  npm install @magic-ext/react-native-expo-oauth@19.1.0-canary.708.7845477243.0
  npm install @magic-ext/solana@19.1.0-canary.708.7845477243.0
  npm install @magic-ext/taquito@14.1.0-canary.708.7845477243.0
  npm install @magic-ext/terra@14.1.0-canary.708.7845477243.0
  npm install @magic-ext/tezos@17.1.0-canary.708.7845477243.0
  npm install @magic-ext/webauthn@16.1.0-canary.708.7845477243.0
  npm install @magic-ext/zilliqa@17.1.0-canary.708.7845477243.0
  npm install @magic-sdk/commons@18.1.0-canary.708.7845477243.0
  npm install @magic-sdk/pnp@16.1.0-canary.708.7845477243.0
  npm install @magic-sdk/provider@22.1.0-canary.708.7845477243.0
  npm install @magic-sdk/react-native-bare@23.1.0-canary.708.7845477243.0
  npm install @magic-sdk/react-native-expo@23.1.0-canary.708.7845477243.0
  npm install @magic-sdk/types@18.1.0-canary.708.7845477243.0
  npm install magic-sdk@22.1.0-canary.708.7845477243.0
  # or 
  yarn add @magic-ext/algorand@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/aptos@5.1.0-canary.708.7845477243.0
  yarn add @magic-ext/avalanche@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/bitcoin@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/conflux@15.1.0-canary.708.7845477243.0
  yarn add @magic-ext/cosmos@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/ed25519@13.1.0-canary.708.7845477243.0
  yarn add @magic-ext/flow@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/gdkms@5.1.0-canary.708.7845477243.0
  yarn add @magic-ext/harmony@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/icon@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/near@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/oauth@16.1.0-canary.708.7845477243.0
  yarn add @magic-ext/oidc@5.1.0-canary.708.7845477243.0
  yarn add @magic-ext/polkadot@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/react-native-bare-oauth@19.1.0-canary.708.7845477243.0
  yarn add @magic-ext/react-native-expo-oauth@19.1.0-canary.708.7845477243.0
  yarn add @magic-ext/solana@19.1.0-canary.708.7845477243.0
  yarn add @magic-ext/taquito@14.1.0-canary.708.7845477243.0
  yarn add @magic-ext/terra@14.1.0-canary.708.7845477243.0
  yarn add @magic-ext/tezos@17.1.0-canary.708.7845477243.0
  yarn add @magic-ext/webauthn@16.1.0-canary.708.7845477243.0
  yarn add @magic-ext/zilliqa@17.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/commons@18.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/pnp@16.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/provider@22.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/react-native-bare@23.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/react-native-expo@23.1.0-canary.708.7845477243.0
  yarn add @magic-sdk/types@18.1.0-canary.708.7845477243.0
  yarn add magic-sdk@22.1.0-canary.708.7845477243.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
