### PR TITLE
Removes `product_announcement` from JsonRpcResponsePayload

### DIFF
--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -32,7 +32,6 @@ export interface JsonRpcResponsePayload<ResultType = any> {
   id: string | number | null;
   result?: ResultType | null;
   error?: JsonRpcError | null;
-  product_announcement?: string | null;
 }
 
 export interface UserInfo {


### PR DESCRIPTION
### 📦 Pull Request

Removes `product_announcement` from JsonRpcResponsePayload

### ✅ Fixed Issues

n/a

### 🚨 Test instructions

n/a

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️
