### PR TITLE
Add an option for crypto-checkout

### DIFF
--- a/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/nft/checkout.spec.ts
@@ -5,15 +5,14 @@ beforeEach(() => {
   browserEnv.restore();
 });
 
-test('checkout method should return a PromiEvent', () => {
+test('checkout method should return a PromiEvent', async () => {
   const magic = createMagicSDK();
 
   magic.nft.request = jest.fn().mockReturnValue({
-    status: 'complete',
-    viewInWallet: true,
+    status: 'processed',
   });
 
-  magic.nft.checkout({
+  const response = await magic.nft.checkout({
     contractId: '1cd4cfe8-b997-466e-8b0d-ff1177222ba4',
     contractAddress: '0x375625833431b22623ce222e55b1cd15a459ba49',
     tokenId: '1',
@@ -22,8 +21,10 @@ test('checkout method should return a PromiEvent', () => {
     quantity: 1,
   });
 
+  expect(response.status).toBe('processed');
+
   const requestPayload = magic.nft.request.mock.calls[0][0];
-  console.log(requestPayload.params);
+
   expect(requestPayload.method).toBe('magic_nft_checkout');
   expect(requestPayload.params).toMatchObject([
     {
@@ -33,6 +34,41 @@ test('checkout method should return a PromiEvent', () => {
       name: 'NFT Checkout Test',
       imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
       quantity: 1,
+    },
+  ]);
+});
+
+test('checkout method can add isCryptoCheckoutEnabled to request payload', async () => {
+  const magic = createMagicSDK();
+
+  magic.nft.request = jest.fn().mockReturnValue({
+    status: 'processed',
+  });
+
+  const response = await magic.nft.checkout({
+    contractId: '1cd4cfe8-b997-466e-8b0d-ff1177222ba4',
+    contractAddress: '0x375625833431b22623ce222e55b1cd15a459ba49',
+    tokenId: '1',
+    name: 'NFT Checkout Test',
+    imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
+    quantity: 1,
+    isCryptoCheckoutEnabled: true,
+  });
+
+  expect(response.status).toBe('processed');
+
+  const requestPayload = magic.nft.request.mock.calls[0][0];
+
+  expect(requestPayload.method).toBe('magic_nft_checkout');
+  expect(requestPayload.params).toMatchObject([
+    {
+      contractId: '1cd4cfe8-b997-466e-8b0d-ff1177222ba4',
+      contractAddress: '0x375625833431b22623ce222e55b1cd15a459ba49',
+      tokenId: '1',
+      name: 'NFT Checkout Test',
+      imageUrl: 'https://nft-cdn.alchemy.com/matic-mumbai/382ceb42f28fb4df0d12897d5d433084',
+      quantity: 1,
+      isCryptoCheckoutEnabled: true,
     },
   ]);
 });

--- a/packages/@magic-sdk/types/src/modules/nft-types.ts
+++ b/packages/@magic-sdk/types/src/modules/nft-types.ts
@@ -1,4 +1,4 @@
-export type NFTResponseStatus = 'cancelled' | 'processed' | 'declined' | 'expired';
+export type NFTResponseStatus = 'cancelled' | 'pending' | 'processed' | 'declined' | 'expired';
 
 export type NFTResponse = {
   status: NFTResponseStatus;

--- a/packages/@magic-sdk/types/src/modules/nft-types.ts
+++ b/packages/@magic-sdk/types/src/modules/nft-types.ts
@@ -44,6 +44,8 @@ export interface NFTCheckoutRequest {
   imageUrl: string;
   quantity?: number; // default is 1
   walletAddress?: string; // default is user's wallet address
+  // If enabled, the user will be able to pay with crypto. the default is false
+  isCryptoCheckoutEnabled?: boolean;
 }
 
 export type NFTCheckoutResponse = NFTResponse;


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

- Added an option for crypto-checkout
- Updated nft-response status

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/aptos@10.0.1-canary.727.8366702038.0
  npm install @magic-ext/avalanche@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/bitcoin@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/conflux@20.0.1-canary.727.8366702038.0
  npm install @magic-ext/cosmos@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/ed25519@18.0.1-canary.727.8366702038.0
  npm install @magic-ext/flow@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/gdkms@10.0.1-canary.727.8366702038.0
  npm install @magic-ext/harmony@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/icon@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/near@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/oauth@21.0.1-canary.727.8366702038.0
  npm install @magic-ext/oauth2@8.0.1-canary.727.8366702038.0
  npm install @magic-ext/oidc@10.0.1-canary.727.8366702038.0
  npm install @magic-ext/polkadot@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/react-native-bare-oauth@24.0.1-canary.727.8366702038.0
  npm install @magic-ext/react-native-expo-oauth@24.0.1-canary.727.8366702038.0
  npm install @magic-ext/solana@24.0.1-canary.727.8366702038.0
  npm install @magic-ext/taquito@19.0.1-canary.727.8366702038.0
  npm install @magic-ext/terra@19.0.1-canary.727.8366702038.0
  npm install @magic-ext/tezos@22.0.1-canary.727.8366702038.0
  npm install @magic-ext/webauthn@21.0.1-canary.727.8366702038.0
  npm install @magic-ext/zilliqa@22.0.1-canary.727.8366702038.0
  npm install @magic-sdk/commons@23.0.1-canary.727.8366702038.0
  npm install @magic-sdk/pnp@21.0.1-canary.727.8366702038.0
  npm install @magic-sdk/provider@27.0.1-canary.727.8366702038.0
  npm install @magic-sdk/react-native-bare@28.0.1-canary.727.8366702038.0
  npm install @magic-sdk/react-native-expo@28.0.1-canary.727.8366702038.0
  npm install @magic-sdk/types@23.0.1-canary.727.8366702038.0
  npm install magic-sdk@27.0.1-canary.727.8366702038.0
  # or 
  yarn add @magic-ext/algorand@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/aptos@10.0.1-canary.727.8366702038.0
  yarn add @magic-ext/avalanche@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/bitcoin@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/conflux@20.0.1-canary.727.8366702038.0
  yarn add @magic-ext/cosmos@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/ed25519@18.0.1-canary.727.8366702038.0
  yarn add @magic-ext/flow@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/gdkms@10.0.1-canary.727.8366702038.0
  yarn add @magic-ext/harmony@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/icon@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/near@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/oauth@21.0.1-canary.727.8366702038.0
  yarn add @magic-ext/oauth2@8.0.1-canary.727.8366702038.0
  yarn add @magic-ext/oidc@10.0.1-canary.727.8366702038.0
  yarn add @magic-ext/polkadot@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/react-native-bare-oauth@24.0.1-canary.727.8366702038.0
  yarn add @magic-ext/react-native-expo-oauth@24.0.1-canary.727.8366702038.0
  yarn add @magic-ext/solana@24.0.1-canary.727.8366702038.0
  yarn add @magic-ext/taquito@19.0.1-canary.727.8366702038.0
  yarn add @magic-ext/terra@19.0.1-canary.727.8366702038.0
  yarn add @magic-ext/tezos@22.0.1-canary.727.8366702038.0
  yarn add @magic-ext/webauthn@21.0.1-canary.727.8366702038.0
  yarn add @magic-ext/zilliqa@22.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/commons@23.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/pnp@21.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/provider@27.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/react-native-bare@28.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/react-native-expo@28.0.1-canary.727.8366702038.0
  yarn add @magic-sdk/types@23.0.1-canary.727.8366702038.0
  yarn add magic-sdk@27.0.1-canary.727.8366702038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
