### PR TITLE
Add two more events for EmailOTP

### DIFF
--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -77,42 +77,6 @@ export interface LoginWithEmailOTPConfiguration {
 }
 
 /**
- * EventHandlers
- */
-export type LoginWithMagicLinkEventHandlers = {
-  // Event Received
-  [LoginWithMagicLinkEventOnReceived.EmailSent]: () => void;
-  [LoginWithMagicLinkEventOnReceived.EmailNotDeliverable]: () => void;
-
-  // Event sent
-  [LoginWithMagicLinkEventEmit.Retry]: () => void;
-} & DeviceVerificationEventHandlers;
-
-export type LoginWithEmailOTPEventHandlers = {
-  // Event Received
-  [LoginWithEmailOTPEventOnReceived.EmailOTPSent]: () => void;
-  [LoginWithEmailOTPEventOnReceived.InvalidEmailOtp]: () => void;
-  [LoginWithEmailOTPEventOnReceived.ExpiredEmailOtp]: () => void;
-  [AuthEventOnReceived.IDTokenCreated]: (idToken: string) => void;
-  [WalletEventOnReceived.WalletInfoFetched]: () => void;
-
-  // Event sent
-  [LoginWithEmailOTPEventEmit.VerifyEmailOtp]: (otp: string) => void;
-  [LoginWithEmailOTPEventEmit.Cancel]: () => void;
-} & DeviceVerificationEventHandlers;
-
-type DeviceVerificationEventHandlers = {
-  // Event Received
-  [DeviceVerificationEventOnReceived.DeviceNeedsApproval]: () => void;
-  [DeviceVerificationEventOnReceived.DeviceVerificationEmailSent]: () => void;
-  [DeviceVerificationEventOnReceived.DeviceVerificationLinkExpired]: () => void;
-  [DeviceVerificationEventOnReceived.DeviceApproved]: () => void;
-
-  // Event sent
-  [DeviceVerificationEventEmit.Retry]: () => void;
-};
-
-/**
  * Auth Events Enum
  */
 export enum LoginWithMagicLinkEventEmit {
@@ -145,38 +109,6 @@ export enum DeviceVerificationEventOnReceived {
   DeviceVerificationLinkExpired = 'device-verification-link-expired',
   DeviceVerificationEmailSent = 'device-verification-email-sent',
 }
-
-/**
- * Update Email
- */
-
-type RecencyCheckEventHandlers = {
-  [RecencyCheckEventOnReceived.PrimaryAuthFactorNeedsVerification]: () => void;
-  [RecencyCheckEventOnReceived.PrimaryAuthFactorVerified]: () => void;
-  [RecencyCheckEventOnReceived.InvalidEmailOtp]: () => void;
-  [RecencyCheckEventOnReceived.EmailNotDeliverable]: () => void;
-  [RecencyCheckEventOnReceived.EmailExpired]: () => void;
-  [RecencyCheckEventOnReceived.EmailSent]: () => void;
-
-  [RecencyCheckEventEmit.Cancel]: () => void;
-  [RecencyCheckEventEmit.Retry]: () => void;
-  [RecencyCheckEventEmit.VerifyEmailOtp]: (otp: string) => void;
-};
-
-export type UpdateEmailEventHandlers = {
-  [UpdateEmailEventOnReceived.NewAuthFactorNeedsVerification]: () => void;
-  [UpdateEmailEventOnReceived.EmailUpdated]: () => void;
-  [UpdateEmailEventOnReceived.InvalidEmailOtp]: () => void;
-  [UpdateEmailEventOnReceived.EmailNotDeliverable]: () => void;
-  [UpdateEmailEventOnReceived.EmailExpired]: () => void;
-  [UpdateEmailEventOnReceived.EmailSent]: () => void;
-  [UpdateEmailEventOnReceived.InvalidEmail]: () => void;
-  [UpdateEmailEventOnReceived.EmailAlreadyExists]: () => void;
-
-  [UpdateEmailEventEmit.Cancel]: () => void;
-  [UpdateEmailEventEmit.RetryWithNewEmail]: (email?: string) => void;
-  [UpdateEmailEventEmit.VerifyEmailOtp]: (otp: string) => void;
-} & RecencyCheckEventHandlers;
 
 export enum RecencyCheckEventEmit {
   Retry = 'Recency/auth-factor-retry',
@@ -213,3 +145,71 @@ export enum UpdateEmailEventOnReceived {
 export enum AuthEventOnReceived {
   IDTokenCreated = 'Auth/id-token-created',
 }
+
+/**
+ * EventHandlers
+ */
+export type LoginWithMagicLinkEventHandlers = {
+  // Event Received
+  [LoginWithMagicLinkEventOnReceived.EmailSent]: () => void;
+  [LoginWithMagicLinkEventOnReceived.EmailNotDeliverable]: () => void;
+
+  // Event sent
+  [LoginWithMagicLinkEventEmit.Retry]: () => void;
+} & DeviceVerificationEventHandlers;
+
+export type LoginWithEmailOTPEventHandlers = {
+  // Event Received
+  [LoginWithEmailOTPEventOnReceived.EmailOTPSent]: () => void;
+  [LoginWithEmailOTPEventOnReceived.InvalidEmailOtp]: () => void;
+  [LoginWithEmailOTPEventOnReceived.ExpiredEmailOtp]: () => void;
+  [AuthEventOnReceived.IDTokenCreated]: (idToken: string) => void;
+  [WalletEventOnReceived.WalletInfoFetched]: () => void;
+
+  // Event sent
+  [LoginWithEmailOTPEventEmit.VerifyEmailOtp]: (otp: string) => void;
+  [LoginWithEmailOTPEventEmit.Cancel]: () => void;
+} & DeviceVerificationEventHandlers;
+
+type DeviceVerificationEventHandlers = {
+  // Event Received
+  [DeviceVerificationEventOnReceived.DeviceNeedsApproval]: () => void;
+  [DeviceVerificationEventOnReceived.DeviceVerificationEmailSent]: () => void;
+  [DeviceVerificationEventOnReceived.DeviceVerificationLinkExpired]: () => void;
+  [DeviceVerificationEventOnReceived.DeviceApproved]: () => void;
+
+  // Event sent
+  [DeviceVerificationEventEmit.Retry]: () => void;
+};
+
+/**
+ * Update Email
+ */
+
+type RecencyCheckEventHandlers = {
+  [RecencyCheckEventOnReceived.PrimaryAuthFactorNeedsVerification]: () => void;
+  [RecencyCheckEventOnReceived.PrimaryAuthFactorVerified]: () => void;
+  [RecencyCheckEventOnReceived.InvalidEmailOtp]: () => void;
+  [RecencyCheckEventOnReceived.EmailNotDeliverable]: () => void;
+  [RecencyCheckEventOnReceived.EmailExpired]: () => void;
+  [RecencyCheckEventOnReceived.EmailSent]: () => void;
+
+  [RecencyCheckEventEmit.Cancel]: () => void;
+  [RecencyCheckEventEmit.Retry]: () => void;
+  [RecencyCheckEventEmit.VerifyEmailOtp]: (otp: string) => void;
+};
+
+export type UpdateEmailEventHandlers = {
+  [UpdateEmailEventOnReceived.NewAuthFactorNeedsVerification]: () => void;
+  [UpdateEmailEventOnReceived.EmailUpdated]: () => void;
+  [UpdateEmailEventOnReceived.InvalidEmailOtp]: () => void;
+  [UpdateEmailEventOnReceived.EmailNotDeliverable]: () => void;
+  [UpdateEmailEventOnReceived.EmailExpired]: () => void;
+  [UpdateEmailEventOnReceived.EmailSent]: () => void;
+  [UpdateEmailEventOnReceived.InvalidEmail]: () => void;
+  [UpdateEmailEventOnReceived.EmailAlreadyExists]: () => void;
+
+  [UpdateEmailEventEmit.Cancel]: () => void;
+  [UpdateEmailEventEmit.RetryWithNewEmail]: (email?: string) => void;
+  [UpdateEmailEventEmit.VerifyEmailOtp]: (otp: string) => void;
+} & RecencyCheckEventHandlers;

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -1,4 +1,4 @@
-import { WalletEventOnReceived } from '@magic-sdk/types';
+import { WalletEventOnReceived } from './wallet-types';
 
 export interface LoginWithMagicLinkConfiguration {
   /**

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -1,3 +1,5 @@
+import { WalletEventOnReceived } from '@magic-sdk/types';
+
 export interface LoginWithMagicLinkConfiguration {
   /**
    * The email address of the user attempting to login.
@@ -91,6 +93,8 @@ export type LoginWithEmailOTPEventHandlers = {
   [LoginWithEmailOTPEventOnReceived.EmailOTPSent]: () => void;
   [LoginWithEmailOTPEventOnReceived.InvalidEmailOtp]: () => void;
   [LoginWithEmailOTPEventOnReceived.ExpiredEmailOtp]: () => void;
+  [AuthEventOnReceived.IDTokenCreated]: (idToken: string) => void;
+  [WalletEventOnReceived.WalletInfoFetched]: () => void;
 
   // Event sent
   [LoginWithEmailOTPEventEmit.VerifyEmailOtp]: (otp: string) => void;
@@ -204,4 +208,8 @@ export enum UpdateEmailEventOnReceived {
   EmailNotDeliverable = 'UpdateEmail/new-email-verification-email-not-deliverable',
   InvalidEmail = 'UpdateEmail/new-email-invalid',
   EmailAlreadyExists = 'UpdateEmail/new-email-already-exists',
+}
+
+export enum AuthEventOnReceived {
+  IDTokenCreated = 'Auth/id-token-created',
 }

--- a/packages/@magic-sdk/types/src/modules/wallet-types.ts
+++ b/packages/@magic-sdk/types/src/modules/wallet-types.ts
@@ -85,3 +85,7 @@ export interface GaslessTransactionRequest {
    */
   customData?: any;
 }
+
+export enum WalletEventOnReceived {
+  WalletInfoFetched = 'Wallet/wallet-info-fetched',
+}


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Add two more events for better UX

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/aptos@11.0.3-canary.746.9405081585.0
  npm install @magic-ext/avalanche@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/bitcoin@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/conflux@21.0.3-canary.746.9405081585.0
  npm install @magic-ext/cosmos@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/ed25519@19.0.3-canary.746.9405081585.0
  npm install @magic-ext/flow@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/gdkms@11.0.3-canary.746.9405081585.0
  npm install @magic-ext/harmony@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/icon@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/near@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/oauth@22.0.4-canary.746.9405081585.0
  npm install @magic-ext/oauth2@9.0.3-canary.746.9405081585.0
  npm install @magic-ext/oidc@11.0.3-canary.746.9405081585.0
  npm install @magic-ext/polkadot@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/react-native-bare-oauth@25.0.3-canary.746.9405081585.0
  npm install @magic-ext/react-native-expo-oauth@25.0.3-canary.746.9405081585.0
  npm install @magic-ext/solana@25.1.1-canary.746.9405081585.0
  npm install @magic-ext/sui@0.1.2-canary.746.9405081585.0
  npm install @magic-ext/taquito@20.0.3-canary.746.9405081585.0
  npm install @magic-ext/terra@20.0.3-canary.746.9405081585.0
  npm install @magic-ext/tezos@23.0.3-canary.746.9405081585.0
  npm install @magic-ext/webauthn@22.0.3-canary.746.9405081585.0
  npm install @magic-ext/zilliqa@23.0.3-canary.746.9405081585.0
  npm install @magic-sdk/commons@24.0.3-canary.746.9405081585.0
  npm install @magic-sdk/pnp@22.0.5-canary.746.9405081585.0
  npm install @magic-sdk/provider@28.0.3-canary.746.9405081585.0
  npm install @magic-sdk/react-native-bare@29.0.3-canary.746.9405081585.0
  npm install @magic-sdk/react-native-expo@29.0.3-canary.746.9405081585.0
  npm install @magic-sdk/types@24.0.2-canary.746.9405081585.0
  npm install magic-sdk@28.0.4-canary.746.9405081585.0
  # or 
  yarn add @magic-ext/algorand@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/aptos@11.0.3-canary.746.9405081585.0
  yarn add @magic-ext/avalanche@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/bitcoin@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/conflux@21.0.3-canary.746.9405081585.0
  yarn add @magic-ext/cosmos@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/ed25519@19.0.3-canary.746.9405081585.0
  yarn add @magic-ext/flow@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/gdkms@11.0.3-canary.746.9405081585.0
  yarn add @magic-ext/harmony@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/icon@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/near@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/oauth@22.0.4-canary.746.9405081585.0
  yarn add @magic-ext/oauth2@9.0.3-canary.746.9405081585.0
  yarn add @magic-ext/oidc@11.0.3-canary.746.9405081585.0
  yarn add @magic-ext/polkadot@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/react-native-bare-oauth@25.0.3-canary.746.9405081585.0
  yarn add @magic-ext/react-native-expo-oauth@25.0.3-canary.746.9405081585.0
  yarn add @magic-ext/solana@25.1.1-canary.746.9405081585.0
  yarn add @magic-ext/sui@0.1.2-canary.746.9405081585.0
  yarn add @magic-ext/taquito@20.0.3-canary.746.9405081585.0
  yarn add @magic-ext/terra@20.0.3-canary.746.9405081585.0
  yarn add @magic-ext/tezos@23.0.3-canary.746.9405081585.0
  yarn add @magic-ext/webauthn@22.0.3-canary.746.9405081585.0
  yarn add @magic-ext/zilliqa@23.0.3-canary.746.9405081585.0
  yarn add @magic-sdk/commons@24.0.3-canary.746.9405081585.0
  yarn add @magic-sdk/pnp@22.0.5-canary.746.9405081585.0
  yarn add @magic-sdk/provider@28.0.3-canary.746.9405081585.0
  yarn add @magic-sdk/react-native-bare@29.0.3-canary.746.9405081585.0
  yarn add @magic-sdk/react-native-expo@29.0.3-canary.746.9405081585.0
  yarn add @magic-sdk/types@24.0.2-canary.746.9405081585.0
  yarn add magic-sdk@28.0.4-canary.746.9405081585.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
