### PR TITLE
Add farcaster event types

### DIFF
--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -146,6 +146,10 @@ export enum AuthEventOnReceived {
   IDTokenCreated = 'Auth/id-token-created',
 }
 
+export enum FarcasterLoginEventEmit {
+  SuccessSignIn = 'Farcaster/success_sign_in',
+}
+
 /**
  * EventHandlers
  */

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -2,6 +2,7 @@ import {
   AuthEventOnReceived,
   DeviceVerificationEventEmit,
   DeviceVerificationEventOnReceived,
+  FarcasterLoginEventEmit,
   LoginWithEmailOTPEventEmit,
   LoginWithEmailOTPEventOnReceived,
   LoginWithMagicLinkEventEmit,
@@ -35,4 +36,6 @@ export type IntermediaryEvents =
   | `${AuthEventOnReceived}`
   | `${WalletEventOnReceived}`
   // Nft Checkout Events
-  | `${NftCheckoutIntermediaryEvents}`;
+  | `${NftCheckoutIntermediaryEvents}`
+  // Farcaster Login Events
+  | `${FarcasterLoginEventEmit}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.0.4
-    "@magic-sdk/provider": ^28.0.4
+    "@magic-sdk/commons": ^24.0.5
+    "@magic-sdk/provider": ^28.0.5
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2120,8 +2120,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/commons": ^24.0.5
+    "@magic-sdk/types": ^24.0.4
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2130,7 +2130,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2148,7 +2148,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2164,17 +2164,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.0.5, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.0.6, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2184,7 +2184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2200,8 +2200,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/react-native-bare": ^29.0.5
+    "@magic-sdk/types": ^24.0.4
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2216,7 +2216,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.0.4
+    "@magic-sdk/react-native-expo": ^29.0.5
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2231,7 +2231,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2242,7 +2242,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
@@ -2282,16 +2282,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.0.4
+    "@magic-sdk/commons": ^24.0.5
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.0.4, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.0.5, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/provider": ^28.0.5
+    "@magic-sdk/types": ^24.0.4
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2315,17 +2315,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.0.5
-    magic-sdk: ^28.0.5
+    "@magic-ext/oauth": ^22.0.6
+    magic-sdk: ^28.0.6
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.0.4, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.0.5, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/types": ^24.0.4
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2337,7 +2337,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.0.4, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.0.5, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2345,9 +2345,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.0.4
-    "@magic-sdk/provider": ^28.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/commons": ^24.0.5
+    "@magic-sdk/provider": ^28.0.5
+    "@magic-sdk/types": ^24.0.4
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2377,7 +2377,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.0.4, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.0.5, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2385,9 +2385,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.0.4
-    "@magic-sdk/provider": ^28.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/commons": ^24.0.5
+    "@magic-sdk/provider": ^28.0.5
+    "@magic-sdk/types": ^24.0.4
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2417,7 +2417,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.0.3, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.0.4, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12762,16 +12762,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.0.5, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.0.6, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.0.4
-    "@magic-sdk/provider": ^28.0.4
-    "@magic-sdk/types": ^24.0.3
+    "@magic-sdk/commons": ^24.0.5
+    "@magic-sdk/provider": ^28.0.5
+    "@magic-sdk/types": ^24.0.4
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/aptos@11.0.6-canary.751.9562340473.0
  npm install @magic-ext/avalanche@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/bitcoin@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/conflux@21.0.6-canary.751.9562340473.0
  npm install @magic-ext/cosmos@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/ed25519@19.0.6-canary.751.9562340473.0
  npm install @magic-ext/flow@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/gdkms@11.0.6-canary.751.9562340473.0
  npm install @magic-ext/harmony@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/icon@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/near@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/oauth@22.0.7-canary.751.9562340473.0
  npm install @magic-ext/oauth2@9.0.6-canary.751.9562340473.0
  npm install @magic-ext/oidc@11.0.6-canary.751.9562340473.0
  npm install @magic-ext/polkadot@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/react-native-bare-oauth@25.0.6-canary.751.9562340473.0
  npm install @magic-ext/react-native-expo-oauth@25.0.6-canary.751.9562340473.0
  npm install @magic-ext/solana@25.1.4-canary.751.9562340473.0
  npm install @magic-ext/sui@0.1.5-canary.751.9562340473.0
  npm install @magic-ext/taquito@20.0.6-canary.751.9562340473.0
  npm install @magic-ext/terra@20.0.6-canary.751.9562340473.0
  npm install @magic-ext/tezos@23.0.6-canary.751.9562340473.0
  npm install @magic-ext/webauthn@22.0.6-canary.751.9562340473.0
  npm install @magic-ext/zilliqa@23.0.6-canary.751.9562340473.0
  npm install @magic-sdk/commons@24.0.6-canary.751.9562340473.0
  npm install @magic-sdk/pnp@22.0.8-canary.751.9562340473.0
  npm install @magic-sdk/provider@28.0.6-canary.751.9562340473.0
  npm install @magic-sdk/react-native-bare@29.0.6-canary.751.9562340473.0
  npm install @magic-sdk/react-native-expo@29.0.6-canary.751.9562340473.0
  npm install @magic-sdk/types@24.0.5-canary.751.9562340473.0
  npm install magic-sdk@28.0.7-canary.751.9562340473.0
  # or 
  yarn add @magic-ext/algorand@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/aptos@11.0.6-canary.751.9562340473.0
  yarn add @magic-ext/avalanche@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/bitcoin@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/conflux@21.0.6-canary.751.9562340473.0
  yarn add @magic-ext/cosmos@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/ed25519@19.0.6-canary.751.9562340473.0
  yarn add @magic-ext/flow@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/gdkms@11.0.6-canary.751.9562340473.0
  yarn add @magic-ext/harmony@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/icon@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/near@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/oauth@22.0.7-canary.751.9562340473.0
  yarn add @magic-ext/oauth2@9.0.6-canary.751.9562340473.0
  yarn add @magic-ext/oidc@11.0.6-canary.751.9562340473.0
  yarn add @magic-ext/polkadot@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/react-native-bare-oauth@25.0.6-canary.751.9562340473.0
  yarn add @magic-ext/react-native-expo-oauth@25.0.6-canary.751.9562340473.0
  yarn add @magic-ext/solana@25.1.4-canary.751.9562340473.0
  yarn add @magic-ext/sui@0.1.5-canary.751.9562340473.0
  yarn add @magic-ext/taquito@20.0.6-canary.751.9562340473.0
  yarn add @magic-ext/terra@20.0.6-canary.751.9562340473.0
  yarn add @magic-ext/tezos@23.0.6-canary.751.9562340473.0
  yarn add @magic-ext/webauthn@22.0.6-canary.751.9562340473.0
  yarn add @magic-ext/zilliqa@23.0.6-canary.751.9562340473.0
  yarn add @magic-sdk/commons@24.0.6-canary.751.9562340473.0
  yarn add @magic-sdk/pnp@22.0.8-canary.751.9562340473.0
  yarn add @magic-sdk/provider@28.0.6-canary.751.9562340473.0
  yarn add @magic-sdk/react-native-bare@29.0.6-canary.751.9562340473.0
  yarn add @magic-sdk/react-native-expo@29.0.6-canary.751.9562340473.0
  yarn add @magic-sdk/types@24.0.5-canary.751.9562340473.0
  yarn add magic-sdk@28.0.7-canary.751.9562340473.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
