### PR TITLE
fix: iOS async popup

### DIFF
--- a/packages/@magic-ext/farcaster/src/index.ts
+++ b/packages/@magic-ext/farcaster/src/index.ts
@@ -68,8 +68,14 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
         });
     });
 
+    let popup: Window | null = null;
     let requestPayload: JsonRpcRequestPayload;
     let channel_token: string;
+
+    if (isMobile()) {
+      console.info('Info: showUI parameter is ignored on mobile, open URL directly');
+      popup = window.open();
+    }
 
     const handle: Handle = {
       on: (event, callback) => {
@@ -84,8 +90,7 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
             channel_token = data.channelToken;
 
             if (isMobile()) {
-              console.info('Info: showUI parameter is ignored on mobile, open URL directly');
-              window.open(data.url, '_blank');
+              popup?.location.assign(data.url);
             }
 
             requestPayload = this.utils.createJsonRpcRequestPayload(FarcasterPayloadMethod.FarcasterShowQR, [
@@ -114,11 +119,14 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
 
             if (!isDoneCallback(callback)) return;
 
+            popup?.close();
+
             callback(data);
           })();
         }
         if (event === EVENT.ERROR) {
           statusPromise.catch((e) => {
+            popup?.close();
             callback(e);
           });
         }


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Fix iOS Async popup (ref: https://www.lexo.ch/blog/2021/08/fix-how-to-use-window-open-in-safari-inside-async-call/#:~:text=Safari%20blocks%20any%20window.,that%20a%20popup%20gets%20blocked.)

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️
