### PR TITLE
Fix: consider the provider ready after 15s even if the message hasn't arrived

### DIFF
--- a/packages/@magic-sdk/provider/src/core/view-controller.ts
+++ b/packages/@magic-sdk/provider/src/core/view-controller.ts
@@ -246,6 +246,16 @@ export abstract class ViewController {
         resolve();
         unsubscribe();
       });
+
+      // We expect the overlay to be ready within 15 seconds.
+      // Sometimes the message is not properly processed due to
+      // webview issues. In that case, after 15 seconds we consider
+      // the overlay ready, to avoid requests hanging forever.
+      setTimeout(() => {
+        this.isReadyForRequest = true;
+        resolve();
+        unsubscribe();
+      }, 15000);
     });
   }
 

--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/waitForReady.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/waitForReady.spec.ts
@@ -16,3 +16,17 @@ test('Receive MAGIC_OVERLAY_READY, resolve `waitForReady` promise', (done) => {
 
   window.postMessage({ msgType: MSG_TYPES().MAGIC_OVERLAY_READY }, '*');
 });
+
+test('Resolve `waitForReady` promise after timeout', (done) => {
+  jest.useFakeTimers();
+  const overlay = createViewController('');
+  const waitForReady = (overlay as any).waitForReady();
+
+  waitForReady.then(() => {
+    done();
+  });
+
+  // Fast forward time to 15 seconds
+  jest.advanceTimersByTime(15000);
+  jest.useRealTimers();
+});


### PR DESCRIPTION
### 📦 Pull Request

We expect the overlay to be ready within 15 seconds. Sometimes the message is not properly processed due to webview issues. In that case, after 15 seconds we consider the overlay ready, to avoid requests hanging forever.

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/aptos@11.1.0-canary.760.9898019531.0
  npm install @magic-ext/avalanche@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/bitcoin@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/conflux@21.1.0-canary.760.9898019531.0
  npm install @magic-ext/cosmos@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/ed25519@19.1.0-canary.760.9898019531.0
  npm install @magic-ext/farcaster@0.1.0-canary.760.9898019531.0
  npm install @magic-ext/flow@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/gdkms@11.1.0-canary.760.9898019531.0
  npm install @magic-ext/harmony@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/icon@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/near@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/oauth@22.1.0-canary.760.9898019531.0
  npm install @magic-ext/oauth2@9.1.0-canary.760.9898019531.0
  npm install @magic-ext/oidc@11.1.0-canary.760.9898019531.0
  npm install @magic-ext/polkadot@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/react-native-bare-oauth@25.1.0-canary.760.9898019531.0
  npm install @magic-ext/react-native-expo-oauth@25.1.0-canary.760.9898019531.0
  npm install @magic-ext/solana@25.2.0-canary.760.9898019531.0
  npm install @magic-ext/sui@0.2.0-canary.760.9898019531.0
  npm install @magic-ext/taquito@20.1.0-canary.760.9898019531.0
  npm install @magic-ext/terra@20.1.0-canary.760.9898019531.0
  npm install @magic-ext/tezos@23.1.0-canary.760.9898019531.0
  npm install @magic-ext/webauthn@22.1.0-canary.760.9898019531.0
  npm install @magic-ext/zilliqa@23.1.0-canary.760.9898019531.0
  npm install @magic-sdk/commons@24.1.0-canary.760.9898019531.0
  npm install @magic-sdk/pnp@22.1.0-canary.760.9898019531.0
  npm install @magic-sdk/provider@28.1.0-canary.760.9898019531.0
  npm install @magic-sdk/react-native-bare@29.1.0-canary.760.9898019531.0
  npm install @magic-sdk/react-native-expo@29.1.0-canary.760.9898019531.0
  npm install magic-sdk@28.1.0-canary.760.9898019531.0
  # or 
  yarn add @magic-ext/algorand@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/aptos@11.1.0-canary.760.9898019531.0
  yarn add @magic-ext/avalanche@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/bitcoin@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/conflux@21.1.0-canary.760.9898019531.0
  yarn add @magic-ext/cosmos@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/ed25519@19.1.0-canary.760.9898019531.0
  yarn add @magic-ext/farcaster@0.1.0-canary.760.9898019531.0
  yarn add @magic-ext/flow@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/gdkms@11.1.0-canary.760.9898019531.0
  yarn add @magic-ext/harmony@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/icon@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/near@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/oauth@22.1.0-canary.760.9898019531.0
  yarn add @magic-ext/oauth2@9.1.0-canary.760.9898019531.0
  yarn add @magic-ext/oidc@11.1.0-canary.760.9898019531.0
  yarn add @magic-ext/polkadot@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/react-native-bare-oauth@25.1.0-canary.760.9898019531.0
  yarn add @magic-ext/react-native-expo-oauth@25.1.0-canary.760.9898019531.0
  yarn add @magic-ext/solana@25.2.0-canary.760.9898019531.0
  yarn add @magic-ext/sui@0.2.0-canary.760.9898019531.0
  yarn add @magic-ext/taquito@20.1.0-canary.760.9898019531.0
  yarn add @magic-ext/terra@20.1.0-canary.760.9898019531.0
  yarn add @magic-ext/tezos@23.1.0-canary.760.9898019531.0
  yarn add @magic-ext/webauthn@22.1.0-canary.760.9898019531.0
  yarn add @magic-ext/zilliqa@23.1.0-canary.760.9898019531.0
  yarn add @magic-sdk/commons@24.1.0-canary.760.9898019531.0
  yarn add @magic-sdk/pnp@22.1.0-canary.760.9898019531.0
  yarn add @magic-sdk/provider@28.1.0-canary.760.9898019531.0
  yarn add @magic-sdk/react-native-bare@29.1.0-canary.760.9898019531.0
  yarn add @magic-sdk/react-native-expo@29.1.0-canary.760.9898019531.0
  yarn add magic-sdk@28.1.0-canary.760.9898019531.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
