### PR TITLE
fix: partialSignTransaction return type is Uint8Array

### DIFF
--- a/packages/@magic-ext/solana/src/index.ts
+++ b/packages/@magic-ext/solana/src/index.ts
@@ -45,7 +45,7 @@ export class SolanaExtension extends Extension.Internal<'solana', any> {
     transaction: Transaction | VersionedTransaction,
     serializeConfig?: SerializeConfig,
   ) => {
-    return this.request<{ rawTransaction: string }>({
+    return this.request<{ rawTransaction: Uint8Array }>({
       id: 42,
       jsonrpc: '2.0',
       method: SOLANA_PAYLOAD_METHODS.PARTIAL_SIGN_TRANSACTION,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/solana@25.2.1-canary.765.9948183993.0
  # or 
  yarn add @magic-ext/solana@25.2.1-canary.765.9948183993.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
