### PR TITLE
feat: add onramperParams arg to showUI

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/wallet.ts
+++ b/packages/@magic-sdk/provider/src/modules/wallet.ts
@@ -23,6 +23,10 @@ export type ConnectWithUiEvents = {
   wallet_selected: (params: { wallet: Wallets }) => any;
 };
 
+type ShowUiConfig = {
+  onramperParams?: { [key: string]: string };
+};
+
 export class WalletModule extends BaseModule {
   /* Prompt Magic's Login Form */
   public connectWithUI() {
@@ -60,8 +64,8 @@ export class WalletModule extends BaseModule {
   }
 
   /* Prompt Magic's Wallet UI (not available for users logged in with third party wallets) */
-  public showUI() {
-    return this.request<boolean>(createJsonRpcRequestPayload(MagicPayloadMethod.ShowUI));
+  public showUI(config?: ShowUiConfig) {
+    return this.request<boolean>(createJsonRpcRequestPayload(MagicPayloadMethod.ShowUI, [config]));
   }
 
   public showAddress() {

--- a/packages/@magic-sdk/provider/test/spec/modules/wallet/showUI.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/wallet/showUI.spec.ts
@@ -14,7 +14,18 @@ test('Generate JSON RPC request payload with method `magic_wallet`', async () =>
 
   const requestPayload = magic.wallet.request.mock.calls[0][0];
   expect(requestPayload.method).toBe('magic_wallet');
-  expect(requestPayload.params).toEqual([]);
+  expect(requestPayload.params).toEqual([undefined]);
+});
+
+test('Generate JSON RPC request payload with method `magic_wallet` with onramperParams', async () => {
+  const magic = createMagicSDK();
+  magic.wallet.request = jest.fn();
+
+  magic.wallet.showUI({ onramperParams: { onlyCryptos: 'matic_polygon' } });
+
+  const requestPayload = magic.wallet.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_wallet');
+  expect(requestPayload.params).toEqual([{ onramperParams: { onlyCryptos: 'matic_polygon' } }]);
 });
 
 test('method should return a PromiEvent', () => {


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/aptos@11.2.0-canary.766.9964959341.0
  npm install @magic-ext/avalanche@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/bitcoin@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/conflux@21.2.0-canary.766.9964959341.0
  npm install @magic-ext/cosmos@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/ed25519@19.2.0-canary.766.9964959341.0
  npm install @magic-ext/farcaster@0.2.0-canary.766.9964959341.0
  npm install @magic-ext/flow@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/gdkms@11.2.0-canary.766.9964959341.0
  npm install @magic-ext/harmony@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/icon@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/near@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/oauth@22.2.0-canary.766.9964959341.0
  npm install @magic-ext/oauth2@9.2.0-canary.766.9964959341.0
  npm install @magic-ext/oidc@11.2.0-canary.766.9964959341.0
  npm install @magic-ext/polkadot@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/react-native-bare-oauth@25.2.0-canary.766.9964959341.0
  npm install @magic-ext/react-native-expo-oauth@25.2.0-canary.766.9964959341.0
  npm install @magic-ext/solana@25.3.0-canary.766.9964959341.0
  npm install @magic-ext/sui@0.3.0-canary.766.9964959341.0
  npm install @magic-ext/taquito@20.2.0-canary.766.9964959341.0
  npm install @magic-ext/terra@20.2.0-canary.766.9964959341.0
  npm install @magic-ext/tezos@23.2.0-canary.766.9964959341.0
  npm install @magic-ext/webauthn@22.2.0-canary.766.9964959341.0
  npm install @magic-ext/zilliqa@23.2.0-canary.766.9964959341.0
  npm install @magic-sdk/commons@24.2.0-canary.766.9964959341.0
  npm install @magic-sdk/pnp@22.2.0-canary.766.9964959341.0
  npm install @magic-sdk/provider@28.2.0-canary.766.9964959341.0
  npm install @magic-sdk/react-native-bare@29.2.0-canary.766.9964959341.0
  npm install @magic-sdk/react-native-expo@29.2.0-canary.766.9964959341.0
  npm install magic-sdk@28.2.0-canary.766.9964959341.0
  # or 
  yarn add @magic-ext/algorand@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/aptos@11.2.0-canary.766.9964959341.0
  yarn add @magic-ext/avalanche@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/bitcoin@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/conflux@21.2.0-canary.766.9964959341.0
  yarn add @magic-ext/cosmos@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/ed25519@19.2.0-canary.766.9964959341.0
  yarn add @magic-ext/farcaster@0.2.0-canary.766.9964959341.0
  yarn add @magic-ext/flow@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/gdkms@11.2.0-canary.766.9964959341.0
  yarn add @magic-ext/harmony@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/icon@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/near@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/oauth@22.2.0-canary.766.9964959341.0
  yarn add @magic-ext/oauth2@9.2.0-canary.766.9964959341.0
  yarn add @magic-ext/oidc@11.2.0-canary.766.9964959341.0
  yarn add @magic-ext/polkadot@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/react-native-bare-oauth@25.2.0-canary.766.9964959341.0
  yarn add @magic-ext/react-native-expo-oauth@25.2.0-canary.766.9964959341.0
  yarn add @magic-ext/solana@25.3.0-canary.766.9964959341.0
  yarn add @magic-ext/sui@0.3.0-canary.766.9964959341.0
  yarn add @magic-ext/taquito@20.2.0-canary.766.9964959341.0
  yarn add @magic-ext/terra@20.2.0-canary.766.9964959341.0
  yarn add @magic-ext/tezos@23.2.0-canary.766.9964959341.0
  yarn add @magic-ext/webauthn@22.2.0-canary.766.9964959341.0
  yarn add @magic-ext/zilliqa@23.2.0-canary.766.9964959341.0
  yarn add @magic-sdk/commons@24.2.0-canary.766.9964959341.0
  yarn add @magic-sdk/pnp@22.2.0-canary.766.9964959341.0
  yarn add @magic-sdk/provider@28.2.0-canary.766.9964959341.0
  yarn add @magic-sdk/react-native-bare@29.2.0-canary.766.9964959341.0
  yarn add @magic-sdk/react-native-expo@29.2.0-canary.766.9964959341.0
  yarn add magic-sdk@28.2.0-canary.766.9964959341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
