### PR TITLE
feat: Added new event type in order to prevent typescript error

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/wallet.ts
+++ b/packages/@magic-sdk/provider/src/modules/wallet.ts
@@ -16,7 +16,7 @@ import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
 import { setItem, getItem, removeItem } from '../util/storage';
 import { ProductConsolidationMethodRemovalVersions } from './auth';
-import { createPromiEvent, EventsDefinition } from '../util';
+import { createPromiEvent } from '../util';
 import { clearDeviceShares } from '../util/device-share-web-crypto';
 
 export type ConnectWithUiEvents = {

--- a/packages/@magic-sdk/provider/src/modules/wallet.ts
+++ b/packages/@magic-sdk/provider/src/modules/wallet.ts
@@ -8,6 +8,7 @@ import {
   UserInfo,
   WalletInfo,
   Wallets,
+  ShowUIPromiEvents,
 } from '@magic-sdk/types';
 
 import { BaseModule } from './base-module';
@@ -15,7 +16,7 @@ import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
 import { setItem, getItem, removeItem } from '../util/storage';
 import { ProductConsolidationMethodRemovalVersions } from './auth';
-import { createPromiEvent } from '../util';
+import { createPromiEvent, EventsDefinition } from '../util';
 import { clearDeviceShares } from '../util/device-share-web-crypto';
 
 export type ConnectWithUiEvents = {
@@ -65,7 +66,7 @@ export class WalletModule extends BaseModule {
 
   /* Prompt Magic's Wallet UI (not available for users logged in with third party wallets) */
   public showUI(config?: ShowUiConfig) {
-    return this.request<boolean>(createJsonRpcRequestPayload(MagicPayloadMethod.ShowUI, [config]));
+    return this.request<boolean, ShowUIPromiEvents>(createJsonRpcRequestPayload(MagicPayloadMethod.ShowUI, [config]));
   }
 
   public showAddress() {

--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -30,6 +30,7 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
+  disconnect: () => void;
 };
 
 /**

--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -30,7 +30,6 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
-  disconnect: () => void;
 };
 
 /**

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -38,6 +38,10 @@ export interface UserInfo {
   email?: string;
 }
 
+export type ShowUIPromiEvents = {
+  disconnect: () => void;
+};
+
 export interface WalletInfo {
   walletType: 'magic' | 'metamask' | 'coinbase_wallet';
 }


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/aptos@11.2.1-canary.773.10246759191.0
  npm install @magic-ext/avalanche@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/bitcoin@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/conflux@21.2.1-canary.773.10246759191.0
  npm install @magic-ext/cosmos@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/ed25519@19.2.1-canary.773.10246759191.0
  npm install @magic-ext/farcaster@0.2.2-canary.773.10246759191.0
  npm install @magic-ext/flow@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/gdkms@11.2.1-canary.773.10246759191.0
  npm install @magic-ext/harmony@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/icon@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/near@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/oauth@22.2.1-canary.773.10246759191.0
  npm install @magic-ext/oauth2@9.2.1-canary.773.10246759191.0
  npm install @magic-ext/oidc@11.2.1-canary.773.10246759191.0
  npm install @magic-ext/polkadot@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/react-native-bare-oauth@25.2.1-canary.773.10246759191.0
  npm install @magic-ext/react-native-expo-oauth@25.2.1-canary.773.10246759191.0
  npm install @magic-ext/solana@25.3.1-canary.773.10246759191.0
  npm install @magic-ext/sui@0.3.1-canary.773.10246759191.0
  npm install @magic-ext/taquito@20.2.1-canary.773.10246759191.0
  npm install @magic-ext/terra@20.2.1-canary.773.10246759191.0
  npm install @magic-ext/tezos@23.2.1-canary.773.10246759191.0
  npm install @magic-ext/webauthn@22.2.1-canary.773.10246759191.0
  npm install @magic-ext/zilliqa@23.2.1-canary.773.10246759191.0
  npm install @magic-sdk/commons@24.2.1-canary.773.10246759191.0
  npm install @magic-sdk/pnp@22.2.1-canary.773.10246759191.0
  npm install @magic-sdk/provider@28.2.1-canary.773.10246759191.0
  npm install @magic-sdk/react-native-bare@29.2.1-canary.773.10246759191.0
  npm install @magic-sdk/react-native-expo@29.2.1-canary.773.10246759191.0
  npm install @magic-sdk/types@24.0.6-canary.773.10246759191.0
  npm install magic-sdk@28.2.1-canary.773.10246759191.0
  # or 
  yarn add @magic-ext/algorand@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/aptos@11.2.1-canary.773.10246759191.0
  yarn add @magic-ext/avalanche@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/bitcoin@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/conflux@21.2.1-canary.773.10246759191.0
  yarn add @magic-ext/cosmos@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/ed25519@19.2.1-canary.773.10246759191.0
  yarn add @magic-ext/farcaster@0.2.2-canary.773.10246759191.0
  yarn add @magic-ext/flow@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/gdkms@11.2.1-canary.773.10246759191.0
  yarn add @magic-ext/harmony@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/icon@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/near@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/oauth@22.2.1-canary.773.10246759191.0
  yarn add @magic-ext/oauth2@9.2.1-canary.773.10246759191.0
  yarn add @magic-ext/oidc@11.2.1-canary.773.10246759191.0
  yarn add @magic-ext/polkadot@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/react-native-bare-oauth@25.2.1-canary.773.10246759191.0
  yarn add @magic-ext/react-native-expo-oauth@25.2.1-canary.773.10246759191.0
  yarn add @magic-ext/solana@25.3.1-canary.773.10246759191.0
  yarn add @magic-ext/sui@0.3.1-canary.773.10246759191.0
  yarn add @magic-ext/taquito@20.2.1-canary.773.10246759191.0
  yarn add @magic-ext/terra@20.2.1-canary.773.10246759191.0
  yarn add @magic-ext/tezos@23.2.1-canary.773.10246759191.0
  yarn add @magic-ext/webauthn@22.2.1-canary.773.10246759191.0
  yarn add @magic-ext/zilliqa@23.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/commons@24.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/pnp@22.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/provider@28.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/react-native-bare@29.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/react-native-expo@29.2.1-canary.773.10246759191.0
  yarn add @magic-sdk/types@24.0.6-canary.773.10246759191.0
  yarn add magic-sdk@28.2.1-canary.773.10246759191.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
