### PR TITLE
chore: adds try catch to preload

### DIFF
--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign  */
 
-import { EthNetworkConfiguration, QueryParameters, SupportedLocale } from '@magic-sdk/types';
+import { EthNetworkConfiguration, QueryParameters, SDKErrorCode, SupportedLocale } from '@magic-sdk/types';
 import type { AbstractProvider } from 'web3-core';
 import { coerce, satisfies } from '../util/semver';
 import { encodeJSON } from '../util/base64-json';
@@ -8,6 +8,8 @@ import {
   createMissingApiKeyError,
   createReactNativeEndpointConfigurationWarning,
   createIncompatibleExtensionsError,
+  MagicSDKError,
+  createModalNotReadyError,
 } from './sdk-exceptions';
 import { AuthModule } from '../modules/auth';
 import { UserModule } from '../modules/user';
@@ -224,6 +226,10 @@ export class SDKBase {
    * has completed loading and is ready for requests.
    */
   public async preload() {
-    await this.overlay.checkIsReadyForRequest;
+    try {
+      await this.overlay.checkIsReadyForRequest;
+    } catch (err) {
+      createModalNotReadyError();
+    }
   }
 }

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -9,7 +9,6 @@ import {
   createReactNativeEndpointConfigurationWarning,
   createIncompatibleExtensionsError,
   MagicSDKError,
-  createModalNotReadyError,
 } from './sdk-exceptions';
 import { AuthModule } from '../modules/auth';
 import { UserModule } from '../modules/user';
@@ -228,8 +227,12 @@ export class SDKBase {
   public async preload() {
     try {
       await this.overlay.checkIsReadyForRequest;
-    } catch (err) {
-      createModalNotReadyError();
+    } catch {
+      const error = new MagicSDKError(
+        SDKErrorCode.ModalNotReady,
+        'Something went wrong. Please refresh the page and try again.',
+      );
+      console.error(error);
     }
   }
 }

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -66,8 +66,23 @@ export class IframeController extends ViewController {
           iframe.allow = 'clipboard-read; clipboard-write';
           applyOverlayStyles(iframe);
           document.body.appendChild(iframe);
+          iframe.addEventListener('error', (event) => {
+            console.error('Event listener error: ', event);
+          });
+          iframe.onload = () => {
+            try {
+              const iframeDocument = iframe.contentDocument || iframe?.contentWindow?.document;
+              const pre = iframeDocument?.querySelector('pre');
+              if (pre) {
+                console.log('Error from iframe: ', pre.textContent);
+              }
+            } catch (error) {
+              console.error('Error accessing iframe content: ', error);
+            }
+          };
+
           iframe.onerror = (event) => {
-            console.error('Magic Overlay Error:', event);
+            console.error('Magic Overlay Error: ', event);
           };
           resolve(iframe);
         } else {

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -66,6 +66,9 @@ export class IframeController extends ViewController {
           iframe.allow = 'clipboard-read; clipboard-write';
           applyOverlayStyles(iframe);
           document.body.appendChild(iframe);
+          iframe.onerror = (event) => {
+            console.error('Magic Overlay Error:', event);
+          };
           resolve(iframe);
         } else {
           createDuplicateIframeWarning().log();

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -66,6 +66,12 @@ export class IframeController extends ViewController {
           iframe.allow = 'clipboard-read; clipboard-write';
           applyOverlayStyles(iframe);
           document.body.appendChild(iframe);
+          console.log('ENDPOINT: ', this.endpoint);
+          window.addEventListener('message', (event: MessageEvent) => {
+            if (event.data && event.data.error) {
+              console.error('RECEIVED ERROR: ', event.data.error);
+            }
+          });
           iframe.addEventListener('error', (event) => {
             console.error('Event listener error: ', event);
           });


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/aptos@11.2.1-canary.776.10274248297.0
  npm install @magic-ext/avalanche@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/bitcoin@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/conflux@21.2.1-canary.776.10274248297.0
  npm install @magic-ext/cosmos@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/ed25519@19.2.1-canary.776.10274248297.0
  npm install @magic-ext/farcaster@0.2.2-canary.776.10274248297.0
  npm install @magic-ext/flow@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/gdkms@11.2.1-canary.776.10274248297.0
  npm install @magic-ext/harmony@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/icon@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/near@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/oauth@22.2.1-canary.776.10274248297.0
  npm install @magic-ext/oauth2@9.2.1-canary.776.10274248297.0
  npm install @magic-ext/oidc@11.2.1-canary.776.10274248297.0
  npm install @magic-ext/polkadot@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/react-native-bare-oauth@25.2.1-canary.776.10274248297.0
  npm install @magic-ext/react-native-expo-oauth@25.2.1-canary.776.10274248297.0
  npm install @magic-ext/solana@25.3.1-canary.776.10274248297.0
  npm install @magic-ext/sui@0.3.1-canary.776.10274248297.0
  npm install @magic-ext/taquito@20.2.1-canary.776.10274248297.0
  npm install @magic-ext/terra@20.2.1-canary.776.10274248297.0
  npm install @magic-ext/tezos@23.2.1-canary.776.10274248297.0
  npm install @magic-ext/webauthn@22.2.1-canary.776.10274248297.0
  npm install @magic-ext/zilliqa@23.2.1-canary.776.10274248297.0
  npm install @magic-sdk/commons@24.2.1-canary.776.10274248297.0
  npm install @magic-sdk/pnp@22.2.1-canary.776.10274248297.0
  npm install @magic-sdk/provider@28.2.1-canary.776.10274248297.0
  npm install @magic-sdk/react-native-bare@29.2.1-canary.776.10274248297.0
  npm install @magic-sdk/react-native-expo@29.2.1-canary.776.10274248297.0
  npm install @magic-sdk/types@24.0.6-canary.776.10274248297.0
  npm install magic-sdk@28.2.1-canary.776.10274248297.0
  # or 
  yarn add @magic-ext/algorand@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/aptos@11.2.1-canary.776.10274248297.0
  yarn add @magic-ext/avalanche@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/bitcoin@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/conflux@21.2.1-canary.776.10274248297.0
  yarn add @magic-ext/cosmos@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/ed25519@19.2.1-canary.776.10274248297.0
  yarn add @magic-ext/farcaster@0.2.2-canary.776.10274248297.0
  yarn add @magic-ext/flow@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/gdkms@11.2.1-canary.776.10274248297.0
  yarn add @magic-ext/harmony@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/icon@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/near@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/oauth@22.2.1-canary.776.10274248297.0
  yarn add @magic-ext/oauth2@9.2.1-canary.776.10274248297.0
  yarn add @magic-ext/oidc@11.2.1-canary.776.10274248297.0
  yarn add @magic-ext/polkadot@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/react-native-bare-oauth@25.2.1-canary.776.10274248297.0
  yarn add @magic-ext/react-native-expo-oauth@25.2.1-canary.776.10274248297.0
  yarn add @magic-ext/solana@25.3.1-canary.776.10274248297.0
  yarn add @magic-ext/sui@0.3.1-canary.776.10274248297.0
  yarn add @magic-ext/taquito@20.2.1-canary.776.10274248297.0
  yarn add @magic-ext/terra@20.2.1-canary.776.10274248297.0
  yarn add @magic-ext/tezos@23.2.1-canary.776.10274248297.0
  yarn add @magic-ext/webauthn@22.2.1-canary.776.10274248297.0
  yarn add @magic-ext/zilliqa@23.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/commons@24.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/pnp@22.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/provider@28.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/react-native-bare@29.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/react-native-expo@29.2.1-canary.776.10274248297.0
  yarn add @magic-sdk/types@24.0.6-canary.776.10274248297.0
  yarn add magic-sdk@28.2.1-canary.776.10274248297.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
