### PR TITLE
Add new types for whitelabel sms 

### DIFF
--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -43,6 +43,29 @@ export interface LoginWithSmsConfiguration {
   phoneNumber: string;
 
   /**
+   * When `true`, a pre-built modal interface will show to the user, directing
+   * them to check their SMS for the one time passcode (OTP) to complete their
+   * authentication.
+   *
+   * When `false`, developers will be able to implement their own custom UI to
+   * continue the SMS OTP flow.
+   */
+  showUI?: boolean;
+
+  /**
+   * Device Unrecognized UI will enforce showing up to secure user's login
+   *
+   * When set to true (default), an improved device recognition UI will be displayed to the user,
+   * prompting them to verify their login by checking their email for device approval. This feature
+   * enhances authentication security.
+   *
+   * This param will only be affect if showUI is false. When set to false,
+   * developers have the flexibility to implement their own customized UI to
+   * handle device check events, providing a more tailored user experience.
+   */
+  deviceCheckUI?: boolean;
+
+  /*
    * The number of seconds until the generated Decenteralized ID token will expire.
    */
   lifespan?: number;
@@ -120,6 +143,18 @@ export enum LoginWithEmailOTPEventEmit {
   Cancel = 'cancel',
 }
 
+export enum LoginWithSmsOTPEventEmit {
+  VerifySmsOtp = 'verify-sms-otp',
+  Cancel = 'cancel',
+  Retry = 'retry',
+}
+
+export enum LoginWithSmsOTPEventOnReceived {
+  SmsOTPSent = 'sms-otp-sent',
+  InvalidSmsOtp = 'invalid-sms-otp',
+  ExpiredSmsOtp = 'expired-sms-otp',
+}
+
 export enum LoginWithEmailOTPEventOnReceived {
   EmailOTPSent = 'email-otp-sent',
   InvalidEmailOtp = 'invalid-email-otp',
@@ -187,6 +222,18 @@ export type LoginWithMagicLinkEventHandlers = {
 
   // Event sent
   [LoginWithMagicLinkEventEmit.Retry]: () => void;
+} & DeviceVerificationEventHandlers;
+
+export type LoginWithSmsOTPEventHandlers = {
+  // Event sent
+  [LoginWithSmsOTPEventEmit.VerifySmsOtp]: (otp: string) => void;
+  [LoginWithSmsOTPEventEmit.Cancel]: () => void;
+  [LoginWithSmsOTPEventEmit.Retry]: () => void;
+
+  // Event received
+  [LoginWithSmsOTPEventOnReceived.SmsOTPSent]: () => void;
+  [LoginWithSmsOTPEventOnReceived.InvalidSmsOtp]: () => void;
+  [LoginWithSmsOTPEventOnReceived.ExpiredSmsOtp]: () => void;
 } & DeviceVerificationEventHandlers;
 
 export type LoginWithEmailOTPEventHandlers = {

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -52,19 +52,6 @@ export interface LoginWithSmsConfiguration {
    */
   showUI?: boolean;
 
-  /**
-   * Device Unrecognized UI will enforce showing up to secure user's login
-   *
-   * When set to true (default), an improved device recognition UI will be displayed to the user,
-   * prompting them to verify their login by checking their email for device approval. This feature
-   * enhances authentication security.
-   *
-   * This param will only be affect if showUI is false. When set to false,
-   * developers have the flexibility to implement their own customized UI to
-   * handle device check events, providing a more tailored user experience.
-   */
-  deviceCheckUI?: boolean;
-
   /*
    * The number of seconds until the generated Decenteralized ID token will expire.
    */

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -4,6 +4,8 @@ import {
   DeviceVerificationEventOnReceived,
   FarcasterLoginEventEmit,
   LoginWithEmailOTPEventEmit,
+  LoginWithSmsOTPEventEmit,
+  LoginWithSmsOTPEventOnReceived,
   LoginWithEmailOTPEventOnReceived,
   LoginWithMagicLinkEventEmit,
   LoginWithMagicLinkEventOnReceived,
@@ -20,6 +22,9 @@ export type IntermediaryEvents =
   // EmailOTP
   | `${LoginWithEmailOTPEventEmit}`
   | `${LoginWithEmailOTPEventOnReceived}`
+  // SmsOTP
+  | `${LoginWithSmsOTPEventEmit}`
+  | `${LoginWithSmsOTPEventOnReceived}`
   // MagicLink
   | `${LoginWithMagicLinkEventEmit}`
   | `${LoginWithMagicLinkEventOnReceived}`


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/aptos@11.3.0-canary.777.10283995228.0
  npm install @magic-ext/avalanche@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/bitcoin@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/conflux@21.3.0-canary.777.10283995228.0
  npm install @magic-ext/cosmos@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/ed25519@19.3.0-canary.777.10283995228.0
  npm install @magic-ext/farcaster@0.3.0-canary.777.10283995228.0
  npm install @magic-ext/flow@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/gdkms@11.3.0-canary.777.10283995228.0
  npm install @magic-ext/harmony@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/icon@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/near@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/oauth@22.3.0-canary.777.10283995228.0
  npm install @magic-ext/oauth2@9.3.0-canary.777.10283995228.0
  npm install @magic-ext/oidc@11.3.0-canary.777.10283995228.0
  npm install @magic-ext/polkadot@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/react-native-bare-oauth@25.3.0-canary.777.10283995228.0
  npm install @magic-ext/react-native-expo-oauth@25.3.0-canary.777.10283995228.0
  npm install @magic-ext/solana@25.4.0-canary.777.10283995228.0
  npm install @magic-ext/sui@0.4.0-canary.777.10283995228.0
  npm install @magic-ext/taquito@20.3.0-canary.777.10283995228.0
  npm install @magic-ext/terra@20.3.0-canary.777.10283995228.0
  npm install @magic-ext/tezos@23.3.0-canary.777.10283995228.0
  npm install @magic-ext/webauthn@22.3.0-canary.777.10283995228.0
  npm install @magic-ext/zilliqa@23.3.0-canary.777.10283995228.0
  npm install @magic-sdk/commons@24.3.0-canary.777.10283995228.0
  npm install @magic-sdk/pnp@22.3.0-canary.777.10283995228.0
  npm install @magic-sdk/provider@28.3.0-canary.777.10283995228.0
  npm install @magic-sdk/react-native-bare@29.3.0-canary.777.10283995228.0
  npm install @magic-sdk/react-native-expo@29.3.0-canary.777.10283995228.0
  npm install @magic-sdk/types@24.1.0-canary.777.10283995228.0
  npm install magic-sdk@28.3.0-canary.777.10283995228.0
  # or 
  yarn add @magic-ext/algorand@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/aptos@11.3.0-canary.777.10283995228.0
  yarn add @magic-ext/avalanche@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/bitcoin@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/conflux@21.3.0-canary.777.10283995228.0
  yarn add @magic-ext/cosmos@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/ed25519@19.3.0-canary.777.10283995228.0
  yarn add @magic-ext/farcaster@0.3.0-canary.777.10283995228.0
  yarn add @magic-ext/flow@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/gdkms@11.3.0-canary.777.10283995228.0
  yarn add @magic-ext/harmony@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/icon@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/near@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/oauth@22.3.0-canary.777.10283995228.0
  yarn add @magic-ext/oauth2@9.3.0-canary.777.10283995228.0
  yarn add @magic-ext/oidc@11.3.0-canary.777.10283995228.0
  yarn add @magic-ext/polkadot@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/react-native-bare-oauth@25.3.0-canary.777.10283995228.0
  yarn add @magic-ext/react-native-expo-oauth@25.3.0-canary.777.10283995228.0
  yarn add @magic-ext/solana@25.4.0-canary.777.10283995228.0
  yarn add @magic-ext/sui@0.4.0-canary.777.10283995228.0
  yarn add @magic-ext/taquito@20.3.0-canary.777.10283995228.0
  yarn add @magic-ext/terra@20.3.0-canary.777.10283995228.0
  yarn add @magic-ext/tezos@23.3.0-canary.777.10283995228.0
  yarn add @magic-ext/webauthn@22.3.0-canary.777.10283995228.0
  yarn add @magic-ext/zilliqa@23.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/commons@24.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/pnp@22.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/provider@28.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/react-native-bare@29.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/react-native-expo@29.3.0-canary.777.10283995228.0
  yarn add @magic-sdk/types@24.1.0-canary.777.10283995228.0
  yarn add magic-sdk@28.3.0-canary.777.10283995228.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
