### PR TITLE
feat: added new event for controlling close by user

### DIFF
--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -30,7 +30,7 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
-  'closed-by-user': () => void;
+  'closed-by-user-handle': () => void;
 };
 
 /**
@@ -128,6 +128,9 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = voi
     ),
   );
 
+  result.on('closed-by-user', () => {
+    result.emit('closed-by-user-handle');
+  });
   return result;
 }
 

--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -30,7 +30,7 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
-  'closed-by-user-handle': () => void;
+  'closed-by-user-emit': () => void;
 };
 
 /**
@@ -128,8 +128,8 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = voi
     ),
   );
 
-  result.on('closed-by-user', () => {
-    result.emit('closed-by-user-handle');
+  result.on('closed-by-user-on-recieved', () => {
+    result.emit('closed-by-user-emit');
   });
   return result;
 }

--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -1,3 +1,4 @@
+import { UserEventsEmit, UserEventsOnReceived } from '@magic-sdk/types';
 import { TypedEmitter, EventsDefinition, createTypedEmitter } from './events';
 
 /**
@@ -30,7 +31,7 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
-  'closed-by-user-emit': () => void;
+  [UserEventsOnReceived.ClosedByUser]: () => void;
 };
 
 /**
@@ -128,8 +129,8 @@ export function createPromiEvent<TResult, TEvents extends EventsDefinition = voi
     ),
   );
 
-  result.on('closed-by-user-on-recieved', () => {
-    result.emit('closed-by-user-emit');
+  result.on(UserEventsEmit.ClosedByUser, () => {
+    result.emit(UserEventsOnReceived.ClosedByUser);
   });
   return result;
 }

--- a/packages/@magic-sdk/provider/src/util/promise-tools.ts
+++ b/packages/@magic-sdk/provider/src/util/promise-tools.ts
@@ -30,6 +30,7 @@ type DefaultEvents<TResult> = {
   done: (result: TResult) => void;
   error: (reason: any) => void;
   settled: () => void;
+  'closed-by-user': () => void;
 };
 
 /**

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -16,7 +16,7 @@ export interface GenerateIdTokenConfiguration extends GetIdTokenConfiguration {
   attachment?: string;
 }
 
-export enum AllowAllEvents {
+export enum UserEvents {
   ClosedByUser = 'closed-by-user',
   ClosedByUserHandle = 'closed-by-user-handle',
 }

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -16,6 +16,10 @@ export interface GenerateIdTokenConfiguration extends GetIdTokenConfiguration {
   attachment?: string;
 }
 
+export enum AllowAllEvents {
+  ClosedByUser = 'closed-by-user',
+}
+
 export interface MagicUserMetadata {
   issuer: string | null;
   publicAddress: string | null;

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -17,8 +17,8 @@ export interface GenerateIdTokenConfiguration extends GetIdTokenConfiguration {
 }
 
 export enum UserEvents {
-  ClosedByUser = 'closed-by-user',
-  ClosedByUserHandle = 'closed-by-user-handle',
+  ClosedByUserOnReceived = 'closed-by-user-on-recieved',
+  ClosedByUserEmit = 'closed-by-user-emit',
 }
 
 export interface MagicUserMetadata {

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -16,9 +16,12 @@ export interface GenerateIdTokenConfiguration extends GetIdTokenConfiguration {
   attachment?: string;
 }
 
-export enum UserEvents {
-  ClosedByUserOnReceived = 'closed-by-user-on-recieved',
-  ClosedByUserEmit = 'closed-by-user-emit',
+export enum UserEventsEmit {
+  ClosedByUser = 'closed-by-user-emit',
+}
+
+export enum UserEventsOnReceived {
+  ClosedByUser = 'closed-by-user',
 }
 
 export interface MagicUserMetadata {

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -18,6 +18,7 @@ export interface GenerateIdTokenConfiguration extends GetIdTokenConfiguration {
 
 export enum AllowAllEvents {
   ClosedByUser = 'closed-by-user',
+  ClosedByUserHandle = 'closed-by-user-handle',
 }
 
 export interface MagicUserMetadata {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.3.0
-    "@magic-sdk/provider": ^28.3.0
+    "@magic-sdk/commons": ^24.4.0
+    "@magic-sdk/provider": ^28.4.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/commons": ^24.4.0
+    "@magic-sdk/types": ^24.2.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2172,17 +2172,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.4.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2208,8 +2208,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/react-native-bare": ^29.4.0
+    "@magic-sdk/types": ^24.2.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2224,7 +2224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.3.0
+    "@magic-sdk/react-native-expo": ^29.4.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2239,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
@@ -2290,16 +2290,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.3.0
+    "@magic-sdk/commons": ^24.4.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.3.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.4.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/provider": ^28.4.0
+    "@magic-sdk/types": ^24.2.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2323,17 +2323,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.3.0
-    magic-sdk: ^28.3.1
+    "@magic-ext/oauth": ^22.4.0
+    magic-sdk: ^28.4.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.3.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.4.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/types": ^24.2.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2345,7 +2345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.4.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2353,9 +2353,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.3.0
-    "@magic-sdk/provider": ^28.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/commons": ^24.4.0
+    "@magic-sdk/provider": ^28.4.0
+    "@magic-sdk/types": ^24.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2385,7 +2385,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.4.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2393,9 +2393,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.3.0
-    "@magic-sdk/provider": ^28.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/commons": ^24.4.0
+    "@magic-sdk/provider": ^28.4.0
+    "@magic-sdk/types": ^24.2.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2425,7 +2425,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.1.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.2.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12770,16 +12770,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.3.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.4.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.3.0
-    "@magic-sdk/provider": ^28.3.0
-    "@magic-sdk/types": ^24.1.0
+    "@magic-sdk/commons": ^24.4.0
+    "@magic-sdk/provider": ^28.4.0
+    "@magic-sdk/types": ^24.2.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/aptos@11.5.0-canary.781.10422812712.0
  npm install @magic-ext/avalanche@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/bitcoin@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/conflux@21.5.0-canary.781.10422812712.0
  npm install @magic-ext/cosmos@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/ed25519@19.5.0-canary.781.10422812712.0
  npm install @magic-ext/farcaster@0.5.0-canary.781.10422812712.0
  npm install @magic-ext/flow@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/gdkms@11.5.0-canary.781.10422812712.0
  npm install @magic-ext/harmony@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/icon@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/near@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/oauth@22.5.0-canary.781.10422812712.0
  npm install @magic-ext/oauth2@9.5.0-canary.781.10422812712.0
  npm install @magic-ext/oidc@11.5.0-canary.781.10422812712.0
  npm install @magic-ext/polkadot@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/react-native-bare-oauth@25.5.0-canary.781.10422812712.0
  npm install @magic-ext/react-native-expo-oauth@25.5.0-canary.781.10422812712.0
  npm install @magic-ext/solana@25.6.0-canary.781.10422812712.0
  npm install @magic-ext/sui@0.6.0-canary.781.10422812712.0
  npm install @magic-ext/taquito@20.5.0-canary.781.10422812712.0
  npm install @magic-ext/terra@20.5.0-canary.781.10422812712.0
  npm install @magic-ext/tezos@23.5.0-canary.781.10422812712.0
  npm install @magic-ext/webauthn@22.5.0-canary.781.10422812712.0
  npm install @magic-ext/zilliqa@23.5.0-canary.781.10422812712.0
  npm install @magic-sdk/commons@24.5.0-canary.781.10422812712.0
  npm install @magic-sdk/pnp@22.5.0-canary.781.10422812712.0
  npm install @magic-sdk/provider@28.5.0-canary.781.10422812712.0
  npm install @magic-sdk/react-native-bare@29.5.0-canary.781.10422812712.0
  npm install @magic-sdk/react-native-expo@29.5.0-canary.781.10422812712.0
  npm install @magic-sdk/types@24.3.0-canary.781.10422812712.0
  npm install magic-sdk@28.5.0-canary.781.10422812712.0
  # or 
  yarn add @magic-ext/algorand@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/aptos@11.5.0-canary.781.10422812712.0
  yarn add @magic-ext/avalanche@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/bitcoin@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/conflux@21.5.0-canary.781.10422812712.0
  yarn add @magic-ext/cosmos@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/ed25519@19.5.0-canary.781.10422812712.0
  yarn add @magic-ext/farcaster@0.5.0-canary.781.10422812712.0
  yarn add @magic-ext/flow@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/gdkms@11.5.0-canary.781.10422812712.0
  yarn add @magic-ext/harmony@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/icon@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/near@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/oauth@22.5.0-canary.781.10422812712.0
  yarn add @magic-ext/oauth2@9.5.0-canary.781.10422812712.0
  yarn add @magic-ext/oidc@11.5.0-canary.781.10422812712.0
  yarn add @magic-ext/polkadot@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/react-native-bare-oauth@25.5.0-canary.781.10422812712.0
  yarn add @magic-ext/react-native-expo-oauth@25.5.0-canary.781.10422812712.0
  yarn add @magic-ext/solana@25.6.0-canary.781.10422812712.0
  yarn add @magic-ext/sui@0.6.0-canary.781.10422812712.0
  yarn add @magic-ext/taquito@20.5.0-canary.781.10422812712.0
  yarn add @magic-ext/terra@20.5.0-canary.781.10422812712.0
  yarn add @magic-ext/tezos@23.5.0-canary.781.10422812712.0
  yarn add @magic-ext/webauthn@22.5.0-canary.781.10422812712.0
  yarn add @magic-ext/zilliqa@23.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/commons@24.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/pnp@22.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/provider@28.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/react-native-bare@29.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/react-native-expo@29.5.0-canary.781.10422812712.0
  yarn add @magic-sdk/types@24.3.0-canary.781.10422812712.0
  yarn add magic-sdk@28.5.0-canary.781.10422812712.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
