### PR TITLE
fix: on iOS Safari it shows a white screen when using display: 'block', visibility: 'hidden'

### DIFF
--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -18,6 +18,8 @@ const overlayStyles: Partial<CSSStyleDeclaration> = {
   borderRadius: '0',
   border: 'none',
   zIndex: '2147483647',
+  // necessary for iOS Safari
+  opacity: '0',
 };
 
 /**
@@ -100,6 +102,7 @@ export class IframeController extends ViewController {
   protected async showOverlay() {
     const iframe = await this.iframe;
     iframe.style.visibility = 'visible';
+    iframe.style.opacity = '1';
     this.activeElement = document.activeElement;
     iframe.focus();
   }
@@ -107,6 +110,7 @@ export class IframeController extends ViewController {
   protected async hideOverlay() {
     const iframe = await this.iframe;
     iframe.style.visibility = 'hidden';
+    iframe.style.opacity = '0';
     if (this.activeElement?.focus) this.activeElement.focus();
     this.activeElement = null;
   }

--- a/packages/magic-sdk/test/spec/iframe-controller/hideOverlay.spec.ts
+++ b/packages/magic-sdk/test/spec/iframe-controller/hideOverlay.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
   browserEnv.stub('console.log', jest.fn());
 });
 
-test('Change visibility style to `hidden`', async () => {
+test('Change visibility style to `hidden` and opacity to 0', async () => {
   (IframeController.prototype as any).init = function () {
     this.iframe = {
       style: { visibility: 'hidden' },
@@ -23,7 +23,7 @@ test('Change visibility style to `hidden`', async () => {
 
   await (overlay as any).hideOverlay();
 
-  expect((overlay as any).iframe).toEqual({ style: { visibility: 'hidden' } });
+  expect((overlay as any).iframe).toEqual({ style: { visibility: 'hidden', opacity: '0' } });
 });
 
 test('If `activeElement` exists and can be focused, calls `activeElement.focus()`', async () => {

--- a/packages/magic-sdk/test/spec/iframe-controller/hideOverlay.spec.ts
+++ b/packages/magic-sdk/test/spec/iframe-controller/hideOverlay.spec.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 test('Change visibility style to `hidden` and opacity to 0', async () => {
   (IframeController.prototype as any).init = function () {
     this.iframe = {
-      style: { visibility: 'hidden' },
+      style: { visibility: 'hidden', opacity: '0' },
     };
 
     return Promise.resolve();


### PR DESCRIPTION
### 📦 Pull Request

fix: on iOS Safari it shows a white screen when using display: 'block', visibility: 'hidden'

### ✅ Fixed Issues
https://github.com/magiclabs/magic-js/issues/787


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/aptos@11.5.1-canary.788.10682754855.0
  npm install @magic-ext/avalanche@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/bitcoin@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/conflux@21.5.1-canary.788.10682754855.0
  npm install @magic-ext/cosmos@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/ed25519@19.5.1-canary.788.10682754855.0
  npm install @magic-ext/farcaster@0.5.1-canary.788.10682754855.0
  npm install @magic-ext/flow@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/gdkms@11.5.1-canary.788.10682754855.0
  npm install @magic-ext/harmony@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/icon@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/near@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/oauth@22.5.1-canary.788.10682754855.0
  npm install @magic-ext/oauth2@9.5.1-canary.788.10682754855.0
  npm install @magic-ext/oidc@11.5.1-canary.788.10682754855.0
  npm install @magic-ext/polkadot@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/react-native-bare-oauth@25.5.1-canary.788.10682754855.0
  npm install @magic-ext/react-native-expo-oauth@25.5.1-canary.788.10682754855.0
  npm install @magic-ext/solana@25.6.1-canary.788.10682754855.0
  npm install @magic-ext/sui@0.6.1-canary.788.10682754855.0
  npm install @magic-ext/taquito@20.5.1-canary.788.10682754855.0
  npm install @magic-ext/terra@20.5.1-canary.788.10682754855.0
  npm install @magic-ext/tezos@23.5.1-canary.788.10682754855.0
  npm install @magic-ext/webauthn@22.5.1-canary.788.10682754855.0
  npm install @magic-ext/zilliqa@23.5.1-canary.788.10682754855.0
  npm install @magic-sdk/commons@24.5.1-canary.788.10682754855.0
  npm install @magic-sdk/pnp@22.5.1-canary.788.10682754855.0
  npm install @magic-sdk/provider@28.5.1-canary.788.10682754855.0
  npm install @magic-sdk/react-native-bare@29.5.1-canary.788.10682754855.0
  npm install @magic-sdk/react-native-expo@29.5.1-canary.788.10682754855.0
  npm install @magic-sdk/types@24.3.1-canary.788.10682754855.0
  npm install magic-sdk@28.5.1-canary.788.10682754855.0
  # or 
  yarn add @magic-ext/algorand@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/aptos@11.5.1-canary.788.10682754855.0
  yarn add @magic-ext/avalanche@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/bitcoin@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/conflux@21.5.1-canary.788.10682754855.0
  yarn add @magic-ext/cosmos@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/ed25519@19.5.1-canary.788.10682754855.0
  yarn add @magic-ext/farcaster@0.5.1-canary.788.10682754855.0
  yarn add @magic-ext/flow@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/gdkms@11.5.1-canary.788.10682754855.0
  yarn add @magic-ext/harmony@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/icon@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/near@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/oauth@22.5.1-canary.788.10682754855.0
  yarn add @magic-ext/oauth2@9.5.1-canary.788.10682754855.0
  yarn add @magic-ext/oidc@11.5.1-canary.788.10682754855.0
  yarn add @magic-ext/polkadot@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/react-native-bare-oauth@25.5.1-canary.788.10682754855.0
  yarn add @magic-ext/react-native-expo-oauth@25.5.1-canary.788.10682754855.0
  yarn add @magic-ext/solana@25.6.1-canary.788.10682754855.0
  yarn add @magic-ext/sui@0.6.1-canary.788.10682754855.0
  yarn add @magic-ext/taquito@20.5.1-canary.788.10682754855.0
  yarn add @magic-ext/terra@20.5.1-canary.788.10682754855.0
  yarn add @magic-ext/tezos@23.5.1-canary.788.10682754855.0
  yarn add @magic-ext/webauthn@22.5.1-canary.788.10682754855.0
  yarn add @magic-ext/zilliqa@23.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/commons@24.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/pnp@22.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/provider@28.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/react-native-bare@29.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/react-native-expo@29.5.1-canary.788.10682754855.0
  yarn add @magic-sdk/types@24.3.1-canary.788.10682754855.0
  yarn add magic-sdk@28.5.1-canary.788.10682754855.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
