### PR TITLE
fix: remount the webview after inactivity before posting a message to avoid timeouts

### DIFF
--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -24,12 +24,12 @@
     "@react-native-async-storage/async-storage": "^1.15.5",
     "@types/lodash": "^4.14.158",
     "buffer": "~5.6.0",
-    "events": "^3.3.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",
     "process": "~0.11.10",
     "react-native-device-info": "^10.3.0",
+    "react-native-event-listeners": "^1.0.7",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },

--- a/packages/@magic-sdk/react-native-bare/package.json
+++ b/packages/@magic-sdk/react-native-bare/package.json
@@ -24,6 +24,7 @@
     "@react-native-async-storage/async-storage": "^1.15.5",
     "@types/lodash": "^4.14.158",
     "buffer": "~5.6.0",
+    "events": "^3.3.0",
     "localforage": "^1.7.4",
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -14,6 +14,7 @@ const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
 const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
 const DEFAULT_BACKGROUND_COLOR = '#FFFFFF';
 const MSG_POSTED_AFTER_INACTIVITY_EVENT = 'msg_posted_after_inactivity_event';
+const LAST_MESSAGE_TIME = 'lastMessageTime';
 /**
  * Builds the Magic `<WebView>` overlay styles. These base styles enable
  * `<WebView>` UI to render above all other DOM content.
@@ -92,7 +93,7 @@ export class ReactNativeWebViewController extends ViewController {
 
     useEffect(() => {
       // reset lastMessage when webview is first mounted
-      AsyncStorage.setItem('lastMessageTime', '');
+      AsyncStorage.setItem(LAST_MESSAGE_TIME, '');
       return () => {
         this.isReadyForRequest = false;
       };
@@ -107,7 +108,7 @@ export class ReactNativeWebViewController extends ViewController {
         this.isReadyForRequest = false;
         setMountOverlay(false);
         this.post(message.msgType, message.payload);
-        await AsyncStorage.setItem('lastMessageTime', new Date().toISOString());
+        await AsyncStorage.setItem(LAST_MESSAGE_TIME, new Date().toISOString());
       });
     }, []);
 
@@ -238,7 +239,7 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   private async msgPostedAfterInactivity() {
-    const lastPostTimestamp: string | null = await AsyncStorage.getItem('lastMessageTime');
+    const lastPostTimestamp: string | null = await AsyncStorage.getItem(LAST_MESSAGE_TIME);
     if (lastPostTimestamp) {
       const lastPostDate = new Date(lastPostTimestamp).getTime();
       const now = new Date().getTime();
@@ -279,7 +280,7 @@ export class ReactNativeWebViewController extends ViewController {
         }),
         this.endpoint,
       );
-      AsyncStorage.setItem('lastMessageTime', new Date().toISOString());
+      AsyncStorage.setItem(LAST_MESSAGE_TIME, new Date().toISOString());
     } else {
       throw createModalNotReadyError();
     }

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -5,13 +5,15 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { EventEmitter } from 'events';
 import Global = NodeJS.Global;
 import { useInternetConnection } from './hooks';
 
 const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
 const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
 const DEFAULT_BACKGROUND_COLOR = '#FFFFFF';
-
+const MSG_POSTED_AFTER_INACTIVITY_EVENT = 'msg_posted_after_inactivity_event';
 /**
  * Builds the Magic `<WebView>` overlay styles. These base styles enable
  * `<WebView>` UI to render above all other DOM content.
@@ -62,6 +64,7 @@ export class ReactNativeWebViewController extends ViewController {
   private webView!: WebView | null;
   private container!: ViewWrapper | null;
   private styles: any;
+  private eventEmitter = new EventEmitter();
 
   protected init() {
     this.webView = null;
@@ -80,6 +83,7 @@ export class ReactNativeWebViewController extends ViewController {
   /* istanbul ignore next */
   public Relayer: React.FC<{ backgroundColor?: string }> = (backgroundColor) => {
     const [show, setShow] = useState(false);
+    const [mountOverlay, setMountOverlay] = useState(true);
     const isConnected = useInternetConnection();
 
     useEffect(() => {
@@ -87,10 +91,32 @@ export class ReactNativeWebViewController extends ViewController {
     }, [isConnected]);
 
     useEffect(() => {
+      // reset lastMessage when webview is first mounted
+      AsyncStorage.setItem('lastMessageTime', '');
       return () => {
         this.isReadyForRequest = false;
       };
     }, []);
+
+    useEffect(() => {
+      this.eventEmitter.addListener(MSG_POSTED_AFTER_INACTIVITY_EVENT, async (message) => {
+        // If inactivity has been determined, the message is posted only after a brief
+        // unmount and re-mount of the webview. This is to ensure the webview is accepting messages.
+        // iOS kills webview processes after a certain period of inactivity, like when the app is
+        // on background for long periods of time.
+        this.isReadyForRequest = false;
+        setMountOverlay(false);
+        this.post(message.msgType, message.payload);
+        await AsyncStorage.setItem('lastMessageTime', new Date().toISOString());
+      });
+    }, []);
+
+    useEffect(() => {
+      if (!mountOverlay) {
+        // Briefly unmount and re-mount the webview to ensure it's ready to accept messages.
+        setTimeout(() => setMountOverlay(true), 10);
+      }
+    }, [mountOverlay]);
 
     /**
      * Saves a reference to the underlying `<WebView>` node so we can interact
@@ -138,9 +164,13 @@ export class ReactNativeWebViewController extends ViewController {
       ];
     }, [show]);
 
-    const handleWebViewMessage = useCallback((event: any) => {
+    const handleWebViewMessage = useCallback((event: unknown) => {
       this.handleReactNativeWebViewMessage(event);
     }, []);
+
+    if (!mountOverlay) {
+      return null;
+    }
 
     return (
       <SafeAreaView ref={containerRef} style={containerStyles}>
@@ -207,6 +237,20 @@ export class ReactNativeWebViewController extends ViewController {
     }
   }
 
+  private async msgPostedAfterInactivity() {
+    const lastPostTimestamp: string | null = await AsyncStorage.getItem('lastMessageTime');
+    if (lastPostTimestamp) {
+      const lastPostDate = new Date(lastPostTimestamp).getTime();
+      const now = new Date().getTime();
+      const fiveMinutes = 5 * 60 * 1000;
+
+      // there's been inactivity if the new message is posted
+      // 5 min or more after the last message.
+      return now - lastPostDate > fiveMinutes;
+    }
+    return false;
+  }
+
   protected hideOverlay() {
     if (this.container) this.container.hideOverlay();
   }
@@ -216,6 +260,10 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   protected async _post(data: any) {
+    if (await this.msgPostedAfterInactivity()) {
+      this.eventEmitter.emit(MSG_POSTED_AFTER_INACTIVITY_EVENT, data);
+      return;
+    }
     if (this.webView && (this.webView as any).postMessage) {
       (this.webView as any).postMessage(
         JSON.stringify(data, (key, value) => {
@@ -231,6 +279,7 @@ export class ReactNativeWebViewController extends ViewController {
         }),
         this.endpoint,
       );
+      AsyncStorage.setItem('lastMessageTime', new Date().toISOString());
     } else {
       throw createModalNotReadyError();
     }

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -6,7 +6,7 @@ import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { EventEmitter } from 'events';
+import { EventRegister } from 'react-native-event-listeners';
 import Global = NodeJS.Global;
 import { useInternetConnection } from './hooks';
 
@@ -65,7 +65,6 @@ export class ReactNativeWebViewController extends ViewController {
   private webView!: WebView | null;
   private container!: ViewWrapper | null;
   private styles: any;
-  private eventEmitter = new EventEmitter();
 
   protected init() {
     this.webView = null;
@@ -100,7 +99,7 @@ export class ReactNativeWebViewController extends ViewController {
     }, []);
 
     useEffect(() => {
-      this.eventEmitter.addListener(MSG_POSTED_AFTER_INACTIVITY_EVENT, async (message) => {
+      EventRegister.addEventListener(MSG_POSTED_AFTER_INACTIVITY_EVENT, async (message) => {
         // If inactivity has been determined, the message is posted only after a brief
         // unmount and re-mount of the webview. This is to ensure the webview is accepting messages.
         // iOS kills webview processes after a certain period of inactivity, like when the app is
@@ -262,7 +261,7 @@ export class ReactNativeWebViewController extends ViewController {
 
   protected async _post(data: any) {
     if (await this.msgPostedAfterInactivity()) {
-      this.eventEmitter.emit(MSG_POSTED_AFTER_INACTIVITY_EVENT, data);
+      EventRegister.emit(MSG_POSTED_AFTER_INACTIVITY_EVENT, data);
       return;
     }
     if (this.webView && (this.webView as any).postMessage) {

--- a/packages/@magic-sdk/react-native-bare/test/setup.ts
+++ b/packages/@magic-sdk/react-native-bare/test/setup.ts
@@ -3,8 +3,11 @@
 import 'regenerator-runtime/runtime';
 
 import browserEnv from '@ikscodes/browser-env';
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 import { removeReactDependencies } from './mocks';
 import { mockConsole } from '../../../../scripts/utils/mock-console';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 browserEnv([
   'setTimeout',

--- a/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/_post.spec.ts
+++ b/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/_post.spec.ts
@@ -8,6 +8,17 @@ beforeEach(() => {
   reactNativeStyleSheetStub();
 });
 
+const emitStub = jest.fn();
+
+jest.mock('react-native-event-listeners', () => {
+  return {
+    EventRegister: {
+      emit: emitStub,
+      addEventListener: jest.fn(),
+    },
+  };
+});
+
 test('Calls webView._post with the expected arguments', async () => {
   const overlay = createReactNativeWebViewController('http://example.com');
 
@@ -54,8 +65,6 @@ test('Process Typed Array in a Solana Request', async () => {
 test('Emits msg_posted_after_inactivity_event when msgPostedAfterInactivity returns true', async () => {
   const overlay = createReactNativeWebViewController('http://example.com');
 
-  const emitStub = jest.fn();
-  overlay.eventEmitter.emit = emitStub;
   overlay.msgPostedAfterInactivity = () => true;
   await overlay._post({ thisIsData: 'hello world' });
 

--- a/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/_post.spec.ts
+++ b/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/_post.spec.ts
@@ -50,3 +50,15 @@ test('Process Typed Array in a Solana Request', async () => {
     'http://example.com',
   ]);
 });
+
+test('Emits msg_posted_after_inactivity_event when msgPostedAfterInactivity returns true', async () => {
+  const overlay = createReactNativeWebViewController('http://example.com');
+
+  const emitStub = jest.fn();
+  overlay.eventEmitter.emit = emitStub;
+  overlay.msgPostedAfterInactivity = () => true;
+  await overlay._post({ thisIsData: 'hello world' });
+
+  expect(emitStub).toBeCalledTimes(1);
+  expect(emitStub).toHaveBeenCalledWith('msg_posted_after_inactivity_event', { thisIsData: 'hello world' });
+});

--- a/packages/@magic-sdk/react-native-expo/package.json
+++ b/packages/@magic-sdk/react-native-expo/package.json
@@ -29,6 +29,7 @@
     "localforage-driver-memory": "^1.0.5",
     "lodash": "^4.17.19",
     "process": "~0.11.10",
+    "react-native-event-listeners": "^1.0.7",
     "tslib": "^2.0.3",
     "whatwg-url": "~8.1.0"
   },

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -5,13 +5,16 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ViewController, createModalNotReadyError } from '@magic-sdk/provider';
 import { MagicMessageEvent } from '@magic-sdk/types';
 import { isTypedArray } from 'lodash';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { EventRegister } from 'react-native-event-listeners';
 import Global = NodeJS.Global;
 import { useInternetConnection } from './hooks';
 
 const MAGIC_PAYLOAD_FLAG_TYPED_ARRAY = 'MAGIC_PAYLOAD_FLAG_TYPED_ARRAY';
 const OPEN_IN_DEVICE_BROWSER = 'open_in_device_browser';
 const DEFAULT_BACKGROUND_COLOR = '#FFFFFF';
-
+const MSG_POSTED_AFTER_INACTIVITY_EVENT = 'msg_posted_after_inactivity_event';
+const LAST_MESSAGE_TIME = 'lastMessageTime';
 /**
  * Builds the Magic `<WebView>` overlay styles. These base styles enable
  * `<WebView>` UI to render above all other DOM content.
@@ -78,8 +81,9 @@ export class ReactNativeWebViewController extends ViewController {
   // is sufficient (this logic is stable right now and not expected to change in
   // the forseeable future).
   /* istanbul ignore next */
-  public Relayer: React.FC<{ backgroundColor?: string }> = ({ backgroundColor }) => {
+  public Relayer: React.FC<{ backgroundColor?: string }> = (backgroundColor) => {
     const [show, setShow] = useState(false);
+    const [mountOverlay, setMountOverlay] = useState(true);
     const isConnected = useInternetConnection();
 
     useEffect(() => {
@@ -87,10 +91,32 @@ export class ReactNativeWebViewController extends ViewController {
     }, [isConnected]);
 
     useEffect(() => {
+      // reset lastMessage when webview is first mounted
+      AsyncStorage.setItem(LAST_MESSAGE_TIME, '');
       return () => {
         this.isReadyForRequest = false;
       };
     }, []);
+
+    useEffect(() => {
+      EventRegister.addEventListener(MSG_POSTED_AFTER_INACTIVITY_EVENT, async (message) => {
+        // If inactivity has been determined, the message is posted only after a brief
+        // unmount and re-mount of the webview. This is to ensure the webview is accepting messages.
+        // iOS kills webview processes after a certain period of inactivity, like when the app is
+        // on background for long periods of time.
+        this.isReadyForRequest = false;
+        setMountOverlay(false);
+        this.post(message.msgType, message.payload);
+        await AsyncStorage.setItem(LAST_MESSAGE_TIME, new Date().toISOString());
+      });
+    }, []);
+
+    useEffect(() => {
+      if (!mountOverlay) {
+        // Briefly unmount and re-mount the webview to ensure it's ready to accept messages.
+        setTimeout(() => setMountOverlay(true), 10);
+      }
+    }, [mountOverlay]);
 
     /**
      * Saves a reference to the underlying `<WebView>` node so we can interact
@@ -141,6 +167,10 @@ export class ReactNativeWebViewController extends ViewController {
     const handleWebViewMessage = useCallback((event: any) => {
       this.handleReactNativeWebViewMessage(event);
     }, []);
+
+    if (!mountOverlay) {
+      return null;
+    }
 
     return (
       <SafeAreaView ref={containerRef} style={containerStyles}>
@@ -207,6 +237,20 @@ export class ReactNativeWebViewController extends ViewController {
     }
   }
 
+  private async msgPostedAfterInactivity() {
+    const lastPostTimestamp: string | null = await AsyncStorage.getItem(LAST_MESSAGE_TIME);
+    if (lastPostTimestamp) {
+      const lastPostDate = new Date(lastPostTimestamp).getTime();
+      const now = new Date().getTime();
+      const fiveMinutes = 5 * 60 * 1000;
+
+      // there's been inactivity if the new message is posted
+      // 5 min or more after the last message.
+      return now - lastPostDate > fiveMinutes;
+    }
+    return false;
+  }
+
   protected hideOverlay() {
     if (this.container) this.container.hideOverlay();
   }
@@ -216,6 +260,10 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   protected async _post(data: any) {
+    if (await this.msgPostedAfterInactivity()) {
+      EventRegister.emit(MSG_POSTED_AFTER_INACTIVITY_EVENT, data);
+      return;
+    }
     if (this.webView && (this.webView as any).postMessage) {
       (this.webView as any).postMessage(
         JSON.stringify(data, (key, value) => {
@@ -231,6 +279,7 @@ export class ReactNativeWebViewController extends ViewController {
         }),
         this.endpoint,
       );
+      AsyncStorage.setItem(LAST_MESSAGE_TIME, new Date().toISOString());
     } else {
       throw createModalNotReadyError();
     }

--- a/packages/@magic-sdk/react-native-expo/test/setup.ts
+++ b/packages/@magic-sdk/react-native-expo/test/setup.ts
@@ -3,8 +3,11 @@
 import 'regenerator-runtime/runtime';
 
 import browserEnv from '@ikscodes/browser-env';
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 import { removeReactDependencies } from './mocks';
 import { mockConsole } from '../../../../scripts/utils/mock-console';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 browserEnv([
   'setTimeout',

--- a/packages/@magic-sdk/react-native-expo/test/spec/react-native-webview-controller/_post.spec.ts
+++ b/packages/@magic-sdk/react-native-expo/test/spec/react-native-webview-controller/_post.spec.ts
@@ -8,6 +8,17 @@ beforeEach(() => {
   reactNativeStyleSheetStub();
 });
 
+const emitStub = jest.fn();
+
+jest.mock('react-native-event-listeners', () => {
+  return {
+    EventRegister: {
+      emit: emitStub,
+      addEventListener: jest.fn(),
+    },
+  };
+});
+
 test('Calls webView._post with the expected arguments', async () => {
   const overlay = createReactNativeWebViewController('http://example.com');
 
@@ -49,4 +60,14 @@ test('Process Typed Array in a Solana Request', async () => {
     '{"msgType":"MAGIC_HANDLE_REQUEST-troll","payload":{"id":3,"jsonrpc":"2.0","method":"sol_signMessage","params":{"message":{"constructor":"Uint8Array","data":"72,101,108,108,111","flag":"MAGIC_PAYLOAD_FLAG_TYPED_ARRAY"}}}}',
     'http://example.com',
   ]);
+});
+
+test('Emits msg_posted_after_inactivity_event when msgPostedAfterInactivity returns true', async () => {
+  const overlay = createReactNativeWebViewController('http://example.com');
+
+  overlay.msgPostedAfterInactivity = () => true;
+  await overlay._post({ thisIsData: 'hello world' });
+
+  expect(emitStub).toBeCalledTimes(1);
+  expect(emitStub).toHaveBeenCalledWith('msg_posted_after_inactivity_event', { thisIsData: 'hello world' });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,7 +2361,6 @@ __metadata:
     "@testing-library/react-native": ^12.4.0
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
-    events: ^3.3.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
     lodash: ^4.17.19
@@ -2370,6 +2369,7 @@ __metadata:
     react: ^16.13.1
     react-native: ^0.62.2
     react-native-device-info: ^10.3.0
+    react-native-event-listeners: ^1.0.7
     react-native-safe-area-context: ^4.4.1
     react-native-webview: ^12.4.0
     react-test-renderer: ^16.13.1
@@ -2411,6 +2411,7 @@ __metadata:
     process: ~0.11.10
     react: ^16.13.1
     react-native: ^0.62.2
+    react-native-event-listeners: ^1.0.7
     react-native-safe-area-context: ^4.4.1
     react-native-webview: ">=12.4.0"
     react-test-renderer: ^16.13.1
@@ -8345,13 +8346,6 @@ __metadata:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -15847,6 +15841,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"react-native-event-listeners@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "react-native-event-listeners@npm:1.0.7"
+  dependencies:
+    type-detect: ^4.0.8
+  checksum: 107bab3a09d58c0e93c93245e6affac6937cf0e48c0af699adb259b65048f3a11315d70b5fd0fbaeffe9312567ab93c48dc74b594967d8d102aff96017950265
+  languageName: node
+  linkType: hard
+
 "react-native-inappbrowser-reborn@npm:^3.7.0":
   version: 3.7.0
   resolution: "react-native-inappbrowser-reborn@npm:3.7.0"
@@ -18459,6 +18462,13 @@ resolve@~1.7.1:
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
+  languageName: node
+  linkType: hard
+
+"type-detect@npm:^4.0.8":
+  version: 4.1.0
+  resolution: "type-detect@npm:4.1.0"
+  checksum: 3b32f873cd02bc7001b00a61502b7ddc4b49278aabe68d652f732e1b5d768c072de0bc734b427abf59d0520a5f19a2e07309ab921ef02018fa1cb4af155cdb37
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.5.0
-    "@magic-sdk/provider": ^28.5.0
+    "@magic-sdk/commons": ^24.6.0
+    "@magic-sdk/provider": ^28.6.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/commons": ^24.6.0
+    "@magic-sdk/types": ^24.4.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2172,17 +2172,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.5.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.6.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2208,8 +2208,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/react-native-bare": ^29.6.0
+    "@magic-sdk/types": ^24.4.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2224,7 +2224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.5.0
+    "@magic-sdk/react-native-expo": ^29.6.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2239,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
@@ -2290,16 +2290,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.5.0
+    "@magic-sdk/commons": ^24.6.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.5.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.6.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/provider": ^28.6.0
+    "@magic-sdk/types": ^24.4.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2323,17 +2323,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.5.0
-    magic-sdk: ^28.5.0
+    "@magic-ext/oauth": ^22.6.0
+    magic-sdk: ^28.6.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.5.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.6.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/types": ^24.4.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2345,7 +2345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.5.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.6.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2353,14 +2353,15 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.5.0
-    "@magic-sdk/provider": ^28.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/commons": ^24.6.0
+    "@magic-sdk/provider": ^28.6.0
+    "@magic-sdk/types": ^24.4.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
     "@types/lodash": ^4.14.158
     buffer: ~5.6.0
+    events: ^3.3.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
     lodash: ^4.17.19
@@ -2385,7 +2386,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.5.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.6.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2393,9 +2394,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.5.0
-    "@magic-sdk/provider": ^28.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/commons": ^24.6.0
+    "@magic-sdk/provider": ^28.6.0
+    "@magic-sdk/types": ^24.4.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2425,7 +2426,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.3.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.4.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -8347,6 +8348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
+  languageName: node
+  linkType: hard
+
 "evp_bytestokey@npm:^1.0.3":
   version: 1.0.3
   resolution: "evp_bytestokey@npm:1.0.3"
@@ -12770,16 +12778,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.5.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.6.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.5.0
-    "@magic-sdk/provider": ^28.5.0
-    "@magic-sdk/types": ^24.3.0
+    "@magic-sdk/commons": ^24.6.0
+    "@magic-sdk/provider": ^28.6.0
+    "@magic-sdk/types": ^24.4.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
After a period of inactivity, especially when the app goes to the background, iOS will randomly decide to kill the webview process without letting us know in any way. When the user comes back to the app and a magic method is called like `isLoggedIn`, we call `webview.postMessage` but even though the webview process is killed, no error is thrown here.

As a result, the message is never sent to mgbox/mandrake, and the user is left hanging for the response forever. They would need to restart the app for magic to work again.

In this PR, we're checking before posting any message if there's been inactivity. Inactivity is determined when a message is being sent 5 minutes or more after the last sent message.

If inactivity is determined, we briefly unmount and re-mount the webview to force a restart of the webview process and  reload the webview content. Only after this hard reload we post the message, avoiding a "forever hanging" situation.

First I tried with `webview.reload()`, but it seems like even the ref is lost when the webview process is killed, so calling this function did nothing. That's why I went with the re-mount approach.

This was tested by the Nova Labs dev who could reproduce the problem previously, and he confirmed that this fix works. He even waited a full night with the app in background, and the next day he opened the app and it still worked, when before it would hang and the app would need a restart.

Ticket: https://magiclink.atlassian.net/browse/PDEEXP-1611
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/react-native-bare-oauth@25.7.0-canary.798.10727977103.0
  npm install @magic-ext/react-native-expo-oauth@25.7.0-canary.798.10727977103.0
  npm install @magic-sdk/react-native-bare@29.7.0-canary.798.10727977103.0
  npm install @magic-sdk/react-native-expo@29.7.0-canary.798.10727977103.0
  # or 
  yarn add @magic-ext/react-native-bare-oauth@25.7.0-canary.798.10727977103.0
  yarn add @magic-ext/react-native-expo-oauth@25.7.0-canary.798.10727977103.0
  yarn add @magic-sdk/react-native-bare@29.7.0-canary.798.10727977103.0
  yarn add @magic-sdk/react-native-expo@29.7.0-canary.798.10727977103.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
