### PR TITLE
White label support for MFA | Should not be merged before Mandrake

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -7,7 +7,7 @@ import {
   RequestUserInfoScope,
   RecoverAccountConfiguration,
   ShowSettingsConfiguration,
-  EnableMfaConfiguration,
+  EnableMFAConfiguration,
   EnableMFAEventEmit,
   EnableMFAEventHandlers,
 } from '@magic-sdk/types';
@@ -144,7 +144,7 @@ export class UserModule extends BaseModule {
     this.userLoggedOutCallbacks.push(callback);
   }
 
-  public enableMFA(configuration: EnableMfaConfiguration) {
+  public enableMFA(configuration: EnableMFAConfiguration) {
     // const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA, [{showUI}]);
     // const handle = this.request<string | null, EnableMFAEventHandlers>(requestPayload);
     const { showUI = true } = configuration;

--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -151,11 +151,11 @@ export class UserModule extends BaseModule {
 
     if (!showUI) {
       handle.on(EnableMFAEventEmit.VerifyMFACode, (totp: string) => {
-        this.createIntermediaryEvent(EnableMFAEventEmit.VerifyMFACode, requestPayload.id as any)(totp);
+        this.createIntermediaryEvent(EnableMFAEventEmit.VerifyMFACode, requestPayload.id as string)(totp);
       });
 
       handle.on(EnableMFAEventEmit.Cancel, () => {
-        this.createIntermediaryEvent(EnableMFAEventEmit.Cancel, requestPayload.id as any)();
+        this.createIntermediaryEvent(EnableMFAEventEmit.Cancel, requestPayload.id as string)();
       });
     }
     return handle;

--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -145,11 +145,13 @@ export class UserModule extends BaseModule {
   }
 
   public enableMFA(configuration: EnableMfaConfiguration) {
-    const { showUI } = configuration;
-    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA);
+    // const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA, [{showUI}]);
+    // const handle = this.request<string | null, EnableMFAEventHandlers>(requestPayload);
+    const { showUI = true } = configuration;
+    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA, [{ showUI }]);
     const handle = this.request<string | null, EnableMFAEventHandlers>(requestPayload);
 
-    if (!showUI) {
+    if (!showUI && handle) {
       handle.on(EnableMFAEventEmit.VerifyMFACode, (totp: string) => {
         this.createIntermediaryEvent(EnableMFAEventEmit.VerifyMFACode, requestPayload.id as string)(totp);
       });

--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -7,6 +7,9 @@ import {
   RequestUserInfoScope,
   RecoverAccountConfiguration,
   ShowSettingsConfiguration,
+  EnableMfaConfiguration,
+  EnableMFAEventEmit,
+  EnableMFAEventHandlers,
 } from '@magic-sdk/types';
 import { getItem, setItem, removeItem } from '../util/storage';
 import { BaseModule } from './base-module';
@@ -141,9 +144,21 @@ export class UserModule extends BaseModule {
     this.userLoggedOutCallbacks.push(callback);
   }
 
-  public enableMFA() {
+  public enableMFA(configuration: EnableMfaConfiguration) {
+    const { showUI } = configuration;
     const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA);
-    return this.request<boolean>(requestPayload);
+    const handle = this.request<string | null, EnableMFAEventHandlers>(requestPayload);
+
+    if (!showUI) {
+      handle.on(EnableMFAEventEmit.VerifyMFACode, (totp: string) => {
+        this.createIntermediaryEvent(EnableMFAEventEmit.VerifyMFACode, requestPayload.id as any)(totp);
+      });
+
+      handle.on(EnableMFAEventEmit.Cancel, () => {
+        this.createIntermediaryEvent(EnableMFAEventEmit.Cancel, requestPayload.id as any)();
+      });
+    }
+    return handle;
   }
 
   public disableMFA() {

--- a/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
@@ -1,14 +1,36 @@
 import { createMagicSDK } from '../../../factories';
 
-test('Resolves immediately when cached magic.user.enableMFA.spec is true', () => {
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', async () => {
   const magic = createMagicSDK();
   magic.user.request = jest.fn();
 
-  magic.user.enableMFA();
+  await magic.user.enableMFA({ showUI: true });
 
   const requestPayload = magic.user.request.mock.calls[0][0];
   expect(requestPayload.method).toBe('magic_auth_enable_mfa_flow');
-  expect(requestPayload.params).toEqual([]);
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
+});
+
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: false', async () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  await magic.user.enableMFA({ showUI: false });
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_enable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: false }]);
+});
+
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with empty param', async () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  await magic.user.enableMFA({});
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_enable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
 });
 
 test('Resolves immediately when cached magic.user.enableMFA.spec is true', () => {

--- a/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
@@ -1,3 +1,5 @@
+import { DisableMFAEventEmit, DisableMFAEventOnReceived } from '@magic-sdk/types/dist/types';
+import { EnableMFAEventEmit } from 'magic-sdk';
 import { createMagicSDK } from '../../../factories';
 
 test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', async () => {
@@ -33,15 +35,24 @@ test('Resolves immediately when cached magic.user.enableMFA.spec is true with em
   expect(requestPayload.params).toEqual([{ showUI: true }]);
 });
 
-test('Resolves immediately when cached magic.user.enableMFA.spec is true without any params', async () => {
+test('Enable MFA flow returns invalid mfa event', () => {
   const magic = createMagicSDK();
-  magic.user.request = jest.fn();
+  magic.user.overlay.post = jest.fn().mockImplementation(() => new Promise(() => {}));
+  const createIntermediaryEventFn = jest.fn();
+  magic.user.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
 
-  await magic.user.enableMFA();
+  const handle = magic.user.enableMFA({ showUI: false });
 
-  const requestPayload = magic.user.request.mock.calls[0][0];
-  expect(requestPayload.method).toBe('magic_auth_enable_mfa_flow');
-  expect(requestPayload.params).toEqual([{ showUI: true }]);
+  const troll_otp = '123456';
+  handle.emit('verify-mfa-code', troll_otp);
+  handle.emit('cancel-mfa-setup');
+
+  const verifyEvent = magic.user.createIntermediaryEvent.mock.calls[0];
+  expect(verifyEvent[0]).toBe('verify-mfa-code');
+  expect(createIntermediaryEventFn.mock.calls[0][0]).toBe(troll_otp);
+
+  const intermediaryEventSecondMethod = magic.user.createIntermediaryEvent.mock.calls[1][0];
+  expect(intermediaryEventSecondMethod).toBe('cancel-mfa-setup');
 });
 
 test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', () => {
@@ -77,13 +88,28 @@ test('Resolves immediately when cached magic.user.enableMFA.spec is true with em
   expect(requestPayload.params).toEqual([{ showUI: true }]);
 });
 
-test('Resolves immediately when cached magic.user.enableMFA.spec is true without any params', () => {
+test('Disable MFA flow returns invalid mfa event', () => {
   const magic = createMagicSDK();
-  magic.user.request = jest.fn();
+  magic.user.overlay.post = jest.fn().mockImplementation(() => new Promise(() => {}));
+  const createIntermediaryEventFn = jest.fn();
+  magic.user.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
 
-  magic.user.disableMFA();
+  const handle = magic.user.disableMFA({ showUI: false });
 
-  const requestPayload = magic.user.request.mock.calls[0][0];
-  expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');
-  expect(requestPayload.params).toEqual([{ showUI: true }]);
+  const troll_otp = '123456';
+  handle.emit('verify-mfa-code', troll_otp);
+  handle.emit('cancel-mfa-disable');
+  handle.emit('lost-device', troll_otp);
+
+  const events = magic.user.createIntermediaryEvent.mock.calls;
+
+  const verifyEvent = events[0][0];
+  expect(verifyEvent).toBe('verify-mfa-code');
+  expect(createIntermediaryEventFn.mock.calls[0][0]).toBe(troll_otp);
+
+  const cancelEvent = events[1][0];
+  expect(cancelEvent).toBe('cancel-mfa-disable');
+
+  const lostDeviceEvent = events[2][0];
+  expect(lostDeviceEvent).toBe('lost-device');
 });

--- a/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
@@ -33,13 +33,35 @@ test('Resolves immediately when cached magic.user.enableMFA.spec is true with em
   expect(requestPayload.params).toEqual([{ showUI: true }]);
 });
 
-test('Resolves immediately when cached magic.user.enableMFA.spec is true', () => {
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', () => {
   const magic = createMagicSDK();
   magic.user.request = jest.fn();
 
-  magic.user.disableMFA();
+  magic.user.disableMFA({ showUI: true });
 
   const requestPayload = magic.user.request.mock.calls[0][0];
   expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');
-  expect(requestPayload.params).toEqual([]);
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
+});
+
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: false', () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  magic.user.disableMFA({ showUI: false });
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: false }]);
+});
+
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with empty param', () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  magic.user.disableMFA({});
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
 });

--- a/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
@@ -1,5 +1,3 @@
-import { DisableMFAEventEmit, DisableMFAEventOnReceived } from '@magic-sdk/types/dist/types';
-import { EnableMFAEventEmit } from 'magic-sdk';
 import { createMagicSDK } from '../../../factories';
 
 test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', async () => {

--- a/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/mfa.spec.ts
@@ -33,6 +33,17 @@ test('Resolves immediately when cached magic.user.enableMFA.spec is true with em
   expect(requestPayload.params).toEqual([{ showUI: true }]);
 });
 
+test('Resolves immediately when cached magic.user.enableMFA.spec is true without any params', async () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  await magic.user.enableMFA();
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_enable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
+});
+
 test('Resolves immediately when cached magic.user.enableMFA.spec is true with ShowUI: true', () => {
   const magic = createMagicSDK();
   magic.user.request = jest.fn();
@@ -55,11 +66,22 @@ test('Resolves immediately when cached magic.user.enableMFA.spec is true with Sh
   expect(requestPayload.params).toEqual([{ showUI: false }]);
 });
 
-test('Resolves immediately when cached magic.user.enableMFA.spec is true with empty param', () => {
+test('Resolves immediately when cached magic.user.enableMFA.spec is true with empty object', () => {
   const magic = createMagicSDK();
   magic.user.request = jest.fn();
 
   magic.user.disableMFA({});
+
+  const requestPayload = magic.user.request.mock.calls[0][0];
+  expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');
+  expect(requestPayload.params).toEqual([{ showUI: true }]);
+});
+
+test('Resolves immediately when cached magic.user.enableMFA.spec is true without any params', () => {
+  const magic = createMagicSDK();
+  magic.user.request = jest.fn();
+
+  magic.user.disableMFA();
 
   const requestPayload = magic.user.request.mock.calls[0][0];
   expect(requestPayload.method).toBe('magic_auth_disable_mfa_flow');

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -119,7 +119,7 @@ export interface EnableMfaConfiguration {
    * them to enable MFA usign Google Authenticator app.
    *
    * When `false`, developers will be able to implement their own custom UI to
-   * continue the SMS OTP flow.
+   * continue the enable MFA flow.
    */
   showUI?: boolean;
 }

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -114,14 +114,14 @@ export interface LoginWithCredentialConfiguration {
 }
 
 export interface EnableMfaConfiguration {
-    /**
+  /**
    * When `true`, a pre-built modal interface will show to the user, directing
    * them to enable MFA usign Google Authenticator app.
    *
    * When `false`, developers will be able to implement their own custom UI to
    * continue the SMS OTP flow.
    */
-    showUI?: boolean;
+  showUI?: boolean;
 }
 
 /**
@@ -217,11 +217,11 @@ export enum FarcasterLoginEventEmit {
 export enum EnableMFAEventOnReceived {
   MFASecretGenerated = 'mfa-secret-generated',
   InvalidMFAOtp = 'invalid-mfa-otp',
-  MFARecoveryCodes = 'mfa-recovery-codes'
+  MFARecoveryCodes = 'mfa-recovery-codes',
 }
 export enum EnableMFAEventEmit {
   VerifyMFACode = 'verify-mfa-code',
-  FinishMFASetup = 'finish-mfa-setup',
+  Cancel = 'cancel-mfa-setup',
 }
 
 /**
@@ -320,5 +320,5 @@ export type EnableMFAEventHandlers = {
 
   // Event sent
   [EnableMFAEventEmit.VerifyMFACode]: (totp: string) => void;
-  [EnableMFAEventEmit.FinishMFASetup]: () => void;
-}
+  [EnableMFAEventEmit.Cancel]: () => void;
+};

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -337,9 +337,9 @@ export type UpdateEmailEventHandlers = {
 
 export type EnableMFAEventHandlers = {
   // Event Received
-  [EnableMFAEventOnReceived.MFASecretGenerated]: (QRCode: string, key: string) => void;
-  [EnableMFAEventOnReceived.InvalidMFAOtp]: (error: string) => void;
-  [EnableMFAEventOnReceived.MFARecoveryCodes]: (recoveryCodes: string) => void;
+  [EnableMFAEventOnReceived.MFASecretGenerated]: ({ QRCode, key }: { QRCode: string; key: string }) => void;
+  [EnableMFAEventOnReceived.InvalidMFAOtp]: ({ errorCode }: { errorCode: string }) => void;
+  [EnableMFAEventOnReceived.MFARecoveryCodes]: ({ recoveryCode }: { recoveryCode: string }) => void;
 
   // Event sent
   [EnableMFAEventEmit.VerifyMFACode]: (totp: string) => void;
@@ -353,7 +353,7 @@ export type EnableMFAEventHandlers = {
 export type DisableMFAEventHandlers = {
   // Event Received
   [DisableMFAEventOnReceived.MFACodeRequested]: () => void;
-  [DisableMFAEventOnReceived.InvalidMFAOtp]: (error: string) => void;
+  [DisableMFAEventOnReceived.InvalidMFAOtp]: ({ errorCode }: { errorCode: string }) => void;
   [DisableMFAEventOnReceived.InvalidRecoveryCode]: () => void;
 
   // Event sent

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -351,7 +351,13 @@ export type EnableMFAEventHandlers = {
  */
 
 export type DisableMFAEventHandlers = {
+  // Event Received
   [DisableMFAEventOnReceived.MFACodeRequested]: () => void;
   [DisableMFAEventOnReceived.InvalidMFAOtp]: (error: string) => void;
   [DisableMFAEventOnReceived.InvalidRecoveryCode]: () => void;
+
+  // Event sent
+  [DisableMFAEventEmit.VerifyMFACode]: (totp: string) => void;
+  [DisableMFAEventEmit.LostDevice]: (recoveryCode: string) => void;
+  [DisableMFAEventEmit.Cancel]: () => void;
 };

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -13,6 +13,8 @@ import {
   UpdateEmailEventEmit,
   UpdateEmailEventOnReceived,
   LoginWithSmsOTPEventOnReceived,
+  EnableMFAEventEmit,
+  EnableMFAEventOnReceived,
 } from './auth-types';
 import { NftCheckoutIntermediaryEvents } from './nft-types';
 
@@ -46,4 +48,7 @@ export type IntermediaryEvents =
   // Farcaster Login Events
   | `${FarcasterLoginEventEmit}`
   // Ui Events
-  | `${UiEventsEmit}`;
+  | `${UiEventsEmit}`
+  // Enable MFA Events
+  | `${EnableMFAEventOnReceived}`
+  | `${EnableMFAEventEmit}`;

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -15,6 +15,8 @@ import {
   LoginWithSmsOTPEventOnReceived,
   EnableMFAEventEmit,
   EnableMFAEventOnReceived,
+  DisableMFAEventOnReceived,
+  DisableMFAEventEmit,
 } from './auth-types';
 import { NftCheckoutIntermediaryEvents } from './nft-types';
 
@@ -51,4 +53,7 @@ export type IntermediaryEvents =
   | `${UiEventsEmit}`
   // Enable MFA Events
   | `${EnableMFAEventOnReceived}`
-  | `${EnableMFAEventEmit}`;
+  | `${EnableMFAEventEmit}`
+  // Disable MFA Events
+  | `${DisableMFAEventOnReceived}`
+  | `${DisableMFAEventEmit}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.7.0
-    "@magic-sdk/provider": ^28.7.0
+    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/provider": ^28.8.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/types": ^24.6.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2172,17 +2172,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.7.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.8.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2208,8 +2208,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.8.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/react-native-bare": ^29.9.0
+    "@magic-sdk/types": ^24.6.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2224,7 +2224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.8.0
+    "@magic-sdk/react-native-expo": ^29.9.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2239,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
@@ -2290,16 +2290,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.7.0
+    "@magic-sdk/commons": ^24.8.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.7.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.8.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.7.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/provider": ^28.8.0
+    "@magic-sdk/types": ^24.6.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2323,17 +2323,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.7.0
-    magic-sdk: ^28.7.0
+    "@magic-ext/oauth": ^22.8.0
+    magic-sdk: ^28.8.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.7.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.8.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/types": ^24.6.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2345,7 +2345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.8.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.9.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2353,9 +2353,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.7.0
-    "@magic-sdk/provider": ^28.7.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/provider": ^28.8.0
+    "@magic-sdk/types": ^24.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2386,7 +2386,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.8.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.9.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2394,9 +2394,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.7.0
-    "@magic-sdk/provider": ^28.7.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/provider": ^28.8.0
+    "@magic-sdk/types": ^24.6.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2427,7 +2427,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.5.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.6.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12772,16 +12772,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.7.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.8.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.7.0
-    "@magic-sdk/provider": ^28.7.0
-    "@magic-sdk/types": ^24.5.0
+    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/provider": ^28.8.0
+    "@magic-sdk/types": ^24.6.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.8.0
-    "@magic-sdk/provider": ^28.8.0
+    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/provider": ^28.9.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/types": ^24.7.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2172,17 +2172,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.8.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.9.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2208,8 +2208,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.9.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/react-native-bare": ^29.10.0
+    "@magic-sdk/types": ^24.7.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2224,7 +2224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.9.0
+    "@magic-sdk/react-native-expo": ^29.10.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2239,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
@@ -2290,16 +2290,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.8.0
+    "@magic-sdk/commons": ^24.9.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.8.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.9.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.8.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/provider": ^28.9.0
+    "@magic-sdk/types": ^24.7.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2323,17 +2323,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.8.0
-    magic-sdk: ^28.8.0
+    "@magic-ext/oauth": ^22.9.0
+    magic-sdk: ^28.9.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.8.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.9.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/types": ^24.7.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2345,7 +2345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.9.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.10.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2353,9 +2353,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.8.0
-    "@magic-sdk/provider": ^28.8.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/provider": ^28.9.0
+    "@magic-sdk/types": ^24.7.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2386,7 +2386,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.9.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.10.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2394,9 +2394,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.8.0
-    "@magic-sdk/provider": ^28.8.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/provider": ^28.9.0
+    "@magic-sdk/types": ^24.7.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2427,7 +2427,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.6.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.7.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12772,16 +12772,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.8.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.9.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.8.0
-    "@magic-sdk/provider": ^28.8.0
-    "@magic-sdk/types": ^24.6.0
+    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/provider": ^28.9.0
+    "@magic-sdk/types": ^24.7.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.9.0
-    "@magic-sdk/provider": ^28.9.0
+    "@magic-sdk/commons": ^24.10.0
+    "@magic-sdk/provider": ^28.10.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/commons": ^24.10.0
+    "@magic-sdk/types": ^24.8.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2172,17 +2172,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.9.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.10.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2192,7 +2192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2208,8 +2208,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.10.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/react-native-bare": ^29.11.0
+    "@magic-sdk/types": ^24.8.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2224,7 +2224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.10.0
+    "@magic-sdk/react-native-expo": ^29.11.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2239,7 +2239,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2250,7 +2250,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
@@ -2290,16 +2290,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.9.0
+    "@magic-sdk/commons": ^24.10.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.9.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.10.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.9.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/provider": ^28.10.0
+    "@magic-sdk/types": ^24.8.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2323,17 +2323,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.9.0
-    magic-sdk: ^28.9.0
+    "@magic-ext/oauth": ^22.10.0
+    magic-sdk: ^28.10.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.9.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.10.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/types": ^24.8.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2345,7 +2345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.10.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.11.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2353,9 +2353,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.9.0
-    "@magic-sdk/provider": ^28.9.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/commons": ^24.10.0
+    "@magic-sdk/provider": ^28.10.0
+    "@magic-sdk/types": ^24.8.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2386,7 +2386,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.10.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.11.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2394,9 +2394,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.9.0
-    "@magic-sdk/provider": ^28.9.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/commons": ^24.10.0
+    "@magic-sdk/provider": ^28.10.0
+    "@magic-sdk/types": ^24.8.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2427,7 +2427,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.7.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.8.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12772,16 +12772,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.9.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.10.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.9.0
-    "@magic-sdk/provider": ^28.9.0
-    "@magic-sdk/types": ^24.7.0
+    "@magic-sdk/commons": ^24.10.0
+    "@magic-sdk/provider": ^28.10.0
+    "@magic-sdk/types": ^24.8.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

In this PR I am adding new handlers to enableMFA method

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

- Enable MFA - https://drive.google.com/file/d/1Fm04Qr70XRIPdN6A7CqPhyTKODmrYRbA/view?usp=drive_link
- Disable MFA with TOTP - https://drive.google.com/file/d/1j3g4VxtXUZFTUfhvNHDxx0EBEc-Ei9cZ/view?usp=sharing
- Disable MFA with Recovery code - https://drive.google.com/file/d/1U9zy0C8cHkVtrYao-YBZMezrnYwM4BId/view?usp=sharing

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/aptos@11.11.0-canary.808.10939028069.0
  npm install @magic-ext/avalanche@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/bitcoin@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/conflux@21.11.0-canary.808.10939028069.0
  npm install @magic-ext/cosmos@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/ed25519@19.11.0-canary.808.10939028069.0
  npm install @magic-ext/farcaster@0.11.0-canary.808.10939028069.0
  npm install @magic-ext/flow@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/gdkms@11.11.0-canary.808.10939028069.0
  npm install @magic-ext/harmony@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/icon@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/near@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/oauth@22.11.0-canary.808.10939028069.0
  npm install @magic-ext/oauth2@9.11.0-canary.808.10939028069.0
  npm install @magic-ext/oidc@11.11.0-canary.808.10939028069.0
  npm install @magic-ext/polkadot@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/react-native-bare-oauth@25.12.0-canary.808.10939028069.0
  npm install @magic-ext/react-native-expo-oauth@25.12.0-canary.808.10939028069.0
  npm install @magic-ext/solana@25.12.0-canary.808.10939028069.0
  npm install @magic-ext/sui@0.12.0-canary.808.10939028069.0
  npm install @magic-ext/taquito@20.11.0-canary.808.10939028069.0
  npm install @magic-ext/terra@20.11.0-canary.808.10939028069.0
  npm install @magic-ext/tezos@23.11.0-canary.808.10939028069.0
  npm install @magic-ext/webauthn@22.11.0-canary.808.10939028069.0
  npm install @magic-ext/zilliqa@23.11.0-canary.808.10939028069.0
  npm install @magic-sdk/commons@24.11.0-canary.808.10939028069.0
  npm install @magic-sdk/pnp@22.11.0-canary.808.10939028069.0
  npm install @magic-sdk/provider@28.11.0-canary.808.10939028069.0
  npm install @magic-sdk/react-native-bare@29.12.0-canary.808.10939028069.0
  npm install @magic-sdk/react-native-expo@29.12.0-canary.808.10939028069.0
  npm install @magic-sdk/types@24.9.0-canary.808.10939028069.0
  npm install magic-sdk@28.11.0-canary.808.10939028069.0
  # or 
  yarn add @magic-ext/algorand@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/aptos@11.11.0-canary.808.10939028069.0
  yarn add @magic-ext/avalanche@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/bitcoin@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/conflux@21.11.0-canary.808.10939028069.0
  yarn add @magic-ext/cosmos@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/ed25519@19.11.0-canary.808.10939028069.0
  yarn add @magic-ext/farcaster@0.11.0-canary.808.10939028069.0
  yarn add @magic-ext/flow@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/gdkms@11.11.0-canary.808.10939028069.0
  yarn add @magic-ext/harmony@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/icon@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/near@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/oauth@22.11.0-canary.808.10939028069.0
  yarn add @magic-ext/oauth2@9.11.0-canary.808.10939028069.0
  yarn add @magic-ext/oidc@11.11.0-canary.808.10939028069.0
  yarn add @magic-ext/polkadot@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/react-native-bare-oauth@25.12.0-canary.808.10939028069.0
  yarn add @magic-ext/react-native-expo-oauth@25.12.0-canary.808.10939028069.0
  yarn add @magic-ext/solana@25.12.0-canary.808.10939028069.0
  yarn add @magic-ext/sui@0.12.0-canary.808.10939028069.0
  yarn add @magic-ext/taquito@20.11.0-canary.808.10939028069.0
  yarn add @magic-ext/terra@20.11.0-canary.808.10939028069.0
  yarn add @magic-ext/tezos@23.11.0-canary.808.10939028069.0
  yarn add @magic-ext/webauthn@22.11.0-canary.808.10939028069.0
  yarn add @magic-ext/zilliqa@23.11.0-canary.808.10939028069.0
  yarn add @magic-sdk/commons@24.11.0-canary.808.10939028069.0
  yarn add @magic-sdk/pnp@22.11.0-canary.808.10939028069.0
  yarn add @magic-sdk/provider@28.11.0-canary.808.10939028069.0
  yarn add @magic-sdk/react-native-bare@29.12.0-canary.808.10939028069.0
  yarn add @magic-sdk/react-native-expo@29.12.0-canary.808.10939028069.0
  yarn add @magic-sdk/types@24.9.0-canary.808.10939028069.0
  yarn add magic-sdk@28.11.0-canary.808.10939028069.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
