### PR TITLE
Pdeexp 1544 implement magic auth recover account provider

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -16,6 +16,8 @@ import {
   RecencyCheckEventEmit,
   RecoveryFactorEventHandlers,
   RecoveryFactorEventEmit,
+  RecoverAccountEventHandlers,
+  RecoverAccountEventEmit,
 } from '@magic-sdk/types';
 import { getItem, setItem, removeItem } from '../util/storage';
 import { BaseModule } from './base-module';
@@ -143,11 +145,23 @@ export class UserModule extends BaseModule {
   }
 
   public recoverAccount(configuration: RecoverAccountConfiguration) {
-    const requestPayload = createJsonRpcRequestPayload(
-      this.sdk.testMode ? MagicPayloadMethod.RecoverAccountTestMode : MagicPayloadMethod.RecoverAccount,
-      [configuration],
-    );
-    return this.request<boolean | null>(requestPayload);
+    const { email, showUI } = configuration;
+    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA, [{ email, showUI }]);
+    const handle = this.request<string | boolean | null, RecoverAccountEventHandlers>(requestPayload);
+
+    if (!showUI && handle) {
+      handle.on(RecoverAccountEventEmit.Cancel, () => {
+        this.createIntermediaryEvent(RecoverAccountEventEmit.Cancel, requestPayload.id as string)();
+      });
+      handle.on(RecoverAccountEventEmit.ResendSms, () => {
+        this.createIntermediaryEvent(RecoverAccountEventEmit.ResendSms, requestPayload.id as string)();
+      });
+      handle.on(RecoverAccountEventEmit.VerifyOtp, (otp: string) => {
+        this.createIntermediaryEvent(RecoverAccountEventEmit.VerifyOtp, requestPayload.id as string)(otp);
+      });
+    }
+
+    return handle;
   }
 
   public revealPrivateKey() {

--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -146,7 +146,10 @@ export class UserModule extends BaseModule {
 
   public recoverAccount(configuration: RecoverAccountConfiguration) {
     const { email, showUI } = configuration;
-    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.RecoverAccount, [{ email, showUI }]);
+    const requestPayload = createJsonRpcRequestPayload(
+      this.sdk.testMode ? MagicPayloadMethod.RecoverAccountTestMode : MagicPayloadMethod.RecoverAccount,
+      [{ email, showUI }],
+    );
     const handle = this.request<string | boolean | null, RecoverAccountEventHandlers>(requestPayload);
 
     if (!showUI && handle) {

--- a/packages/@magic-sdk/provider/src/modules/user.ts
+++ b/packages/@magic-sdk/provider/src/modules/user.ts
@@ -146,7 +146,7 @@ export class UserModule extends BaseModule {
 
   public recoverAccount(configuration: RecoverAccountConfiguration) {
     const { email, showUI } = configuration;
-    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.EnableMFA, [{ email, showUI }]);
+    const requestPayload = createJsonRpcRequestPayload(MagicPayloadMethod.RecoverAccount, [{ email, showUI }]);
     const handle = this.request<string | boolean | null, RecoverAccountEventHandlers>(requestPayload);
 
     if (!showUI && handle) {

--- a/packages/@magic-sdk/provider/test/spec/modules/user/recoverAccount.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/user/recoverAccount.spec.ts
@@ -10,27 +10,69 @@ test('Generate JSON RPC request payload with method `magic_auth_recover_account`
   const magic = createMagicSDK();
   magic.user.request = jest.fn();
 
-  await magic.user.recoverAccount({ email: 'test' });
+  await magic.user.recoverAccount({ email: 'test', showUI: false });
 
   const requestPayload = magic.user.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe('magic_auth_recover_account');
-  expect(requestPayload.params).toEqual([{ email: 'test' }]);
+  expect(requestPayload.params).toEqual([{ email: 'test', showUI: false }]);
 });
 
 test('If `testMode` is enabled, testing-specific RPC method is used', async () => {
   const magic = createMagicSDKTestMode();
   magic.user.request = jest.fn();
 
-  await magic.user.recoverAccount({ email: 'test' });
+  await magic.user.recoverAccount({ email: 'test', showUI: false });
 
   const requestPayload = magic.user.request.mock.calls[0][0];
   expect(requestPayload.jsonrpc).toBe('2.0');
   expect(requestPayload.method).toBe('magic_auth_recover_account_testing_mode');
-  expect(requestPayload.params).toEqual([{ email: 'test' }]);
+  expect(requestPayload.params).toEqual([{ email: 'test', showUI: false }]);
 });
 
 test('method should return a PromiEvent', () => {
   const magic = createMagicSDK();
-  expect(isPromiEvent(magic.user.recoverAccount({ email: 'test' }))).toBeTruthy();
+  expect(isPromiEvent(magic.user.recoverAccount({ email: 'test', showUI: false }))).toBeTruthy();
+});
+
+test('method should create intermediary event on cancel', () => {
+  const magic = createMagicSDK();
+  magic.user.overlay.post = jest.fn().mockImplementation(() => new Promise(() => {}));
+  const createIntermediaryEventFn = jest.fn();
+  magic.user.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  const handle = magic.user.recoverAccount({ email: 'test', showUI: false });
+  handle.emit('cancel');
+
+  const cancelEvent = magic.user.createIntermediaryEvent.mock.calls[0][0];
+
+  expect(cancelEvent).toBe('cancel');
+});
+
+test('method should create intermediary event on ResendSms', () => {
+  const magic = createMagicSDK();
+  magic.user.overlay.post = jest.fn().mockImplementation(() => new Promise(() => {}));
+  const createIntermediaryEventFn = jest.fn();
+  magic.user.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  const handle = magic.user.recoverAccount({ email: 'test', showUI: false });
+  handle.emit('resend-sms-otp');
+
+  const resendEvent = magic.user.createIntermediaryEvent.mock.calls[0][0];
+
+  expect(resendEvent).toBe('resend-sms-otp');
+});
+
+test('method should create intermediary event on VerifyOtp', () => {
+  const magic = createMagicSDK();
+  magic.user.overlay.post = jest.fn().mockImplementation(() => new Promise(() => {}));
+  const createIntermediaryEventFn = jest.fn();
+  magic.user.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  const handle = magic.user.recoverAccount({ email: 'test', showUI: false });
+  handle.emit('verify-otp-code');
+
+  const verifyEvent = magic.user.createIntermediaryEvent.mock.calls[0][0];
+
+  expect(verifyEvent).toBe('verify-otp-code');
 });

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -22,7 +22,12 @@ import { NftCheckoutIntermediaryEvents } from './nft-types';
 
 import { WalletEventOnReceived } from './wallet-types';
 import { UiEventsEmit } from './common-types';
-import { RecoveryFactorEventEmit, RecoveryFactorEventOnReceived } from './user-types';
+import {
+  RecoverAccountEventEmit,
+  RecoverAccountEventOnReceived,
+  RecoveryFactorEventEmit,
+  RecoveryFactorEventOnReceived,
+} from './user-types';
 
 export type IntermediaryEvents =
   // EmailOTP
@@ -60,4 +65,7 @@ export type IntermediaryEvents =
   | `${EnableMFAEventEmit}`
   // Disable MFA Events
   | `${DisableMFAEventOnReceived}`
-  | `${DisableMFAEventEmit}`;
+  | `${DisableMFAEventEmit}`
+  // Recover Account Events
+  | `${RecoverAccountEventOnReceived}`
+  | `${RecoverAccountEventEmit}`;

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -104,6 +104,7 @@ export interface RecoverAccountConfiguration {
    * The email to recover
    */
   email: string;
+  showUI: boolean;
 }
 
 export interface ShowSettingsConfiguration {
@@ -113,3 +114,35 @@ export interface ShowSettingsConfiguration {
   page: DeepLinkPage;
   showUI?: boolean;
 }
+
+export enum RecoverAccountEventOnReceived {
+  SmsOtpSent = 'sms-otp-sent',
+  LoginThrottled = 'login-throttled',
+  InvalidSmsOtp = 'invalid-sms-otp',
+  SmsVerified = 'sms-verified',
+}
+
+export enum RecoverAccountEventEmit {
+  Cancel = 'cancel',
+  VerifyOtp = 'verify-otp-code',
+  ResendSms = 'resend-sms-otp',
+}
+
+export type RecoverAccountEventHandlers = {
+  // Event Received
+  [RecoverAccountEventEmit.Cancel]: () => void;
+  [RecoverAccountEventEmit.VerifyOtp]: (otp: string) => void;
+  [RecoverAccountEventEmit.ResendSms]: () => void;
+
+  // Event sent
+  [RecoverAccountEventOnReceived.SmsOtpSent]: ({ phoneNumber }: { phoneNumber: string }) => void;
+  [RecoverAccountEventOnReceived.LoginThrottled]: (error: string) => {};
+  [RecoverAccountEventOnReceived.InvalidSmsOtp]: ({
+    errorMessage,
+    errorCode,
+  }: {
+    errorMessage: string;
+    errorCode: string;
+  }) => {};
+  [RecoverAccountEventOnReceived.SmsVerified]: () => {};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2054,8 +2054,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.15.0
-    "@magic-sdk/provider": ^28.15.0
+    "@magic-sdk/commons": ^24.16.0
+    "@magic-sdk/provider": ^28.16.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2067,7 +2067,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2075,7 +2075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2083,7 +2083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2091,7 +2091,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2099,7 +2099,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2107,7 +2107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2115,7 +2115,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2128,8 +2128,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/commons": ^24.16.0
+    "@magic-sdk/types": ^24.14.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2138,7 +2138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2156,7 +2156,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2164,7 +2164,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2172,7 +2172,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2180,17 +2180,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.15.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^22.16.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2200,7 +2200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2208,7 +2208,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2216,8 +2216,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.16.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/react-native-bare": ^29.17.0
+    "@magic-sdk/types": ^24.14.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
     react-native-device-info: ^10.3.0
@@ -2232,7 +2232,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.16.0
+    "@magic-sdk/react-native-expo": ^29.17.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2247,7 +2247,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2258,7 +2258,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2266,7 +2266,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2274,7 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2282,7 +2282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2290,7 +2290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
@@ -2298,16 +2298,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.15.0
+    "@magic-sdk/commons": ^24.16.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.15.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^24.16.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.15.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/provider": ^28.16.0
+    "@magic-sdk/types": ^24.14.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2331,17 +2331,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.15.0
-    magic-sdk: ^28.16.0
+    "@magic-ext/oauth": ^22.16.0
+    magic-sdk: ^28.17.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.15.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^28.16.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/types": ^24.14.0
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2353,7 +2353,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.16.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^29.17.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2361,9 +2361,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.15.0
-    "@magic-sdk/provider": ^28.15.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/commons": ^24.16.0
+    "@magic-sdk/provider": ^28.16.0
+    "@magic-sdk/types": ^24.14.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2394,7 +2394,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.16.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^29.17.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2402,9 +2402,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.15.0
-    "@magic-sdk/provider": ^28.15.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/commons": ^24.16.0
+    "@magic-sdk/provider": ^28.16.0
+    "@magic-sdk/types": ^24.14.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2435,7 +2435,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.13.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.14.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -12780,16 +12780,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.16.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^28.17.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.15.0
-    "@magic-sdk/provider": ^28.15.0
-    "@magic-sdk/types": ^24.13.0
+    "@magic-sdk/commons": ^24.16.0
+    "@magic-sdk/provider": ^28.16.0
+    "@magic-sdk/types": ^24.14.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown


### PR DESCRIPTION
### 📦 Pull Request

https://magiclink.atlassian.net/browse/PDEEXP-1544

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/aptos@11.17.0-canary.832.11709014109.0
  npm install @magic-ext/avalanche@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/bitcoin@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/conflux@21.17.0-canary.832.11709014109.0
  npm install @magic-ext/cosmos@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/ed25519@19.17.0-canary.832.11709014109.0
  npm install @magic-ext/farcaster@0.17.0-canary.832.11709014109.0
  npm install @magic-ext/flow@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/gdkms@11.17.0-canary.832.11709014109.0
  npm install @magic-ext/harmony@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/icon@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/kadena@0.7.0-canary.832.11709014109.0
  npm install @magic-ext/near@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/oauth@22.17.0-canary.832.11709014109.0
  npm install @magic-ext/oauth2@9.17.0-canary.832.11709014109.0
  npm install @magic-ext/oidc@11.17.0-canary.832.11709014109.0
  npm install @magic-ext/polkadot@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/react-native-bare-oauth@25.18.0-canary.832.11709014109.0
  npm install @magic-ext/react-native-expo-oauth@25.18.0-canary.832.11709014109.0
  npm install @magic-ext/solana@25.18.0-canary.832.11709014109.0
  npm install @magic-ext/sui@0.18.0-canary.832.11709014109.0
  npm install @magic-ext/taquito@20.17.0-canary.832.11709014109.0
  npm install @magic-ext/terra@20.17.0-canary.832.11709014109.0
  npm install @magic-ext/tezos@23.17.0-canary.832.11709014109.0
  npm install @magic-ext/webauthn@22.17.0-canary.832.11709014109.0
  npm install @magic-ext/zilliqa@23.17.0-canary.832.11709014109.0
  npm install @magic-sdk/commons@24.17.0-canary.832.11709014109.0
  npm install @magic-sdk/pnp@22.18.0-canary.832.11709014109.0
  npm install @magic-sdk/provider@28.17.0-canary.832.11709014109.0
  npm install @magic-sdk/react-native-bare@29.18.0-canary.832.11709014109.0
  npm install @magic-sdk/react-native-expo@29.18.0-canary.832.11709014109.0
  npm install @magic-sdk/types@24.15.0-canary.832.11709014109.0
  npm install magic-sdk@28.18.0-canary.832.11709014109.0
  # or 
  yarn add @magic-ext/algorand@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/aptos@11.17.0-canary.832.11709014109.0
  yarn add @magic-ext/avalanche@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/bitcoin@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/conflux@21.17.0-canary.832.11709014109.0
  yarn add @magic-ext/cosmos@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/ed25519@19.17.0-canary.832.11709014109.0
  yarn add @magic-ext/farcaster@0.17.0-canary.832.11709014109.0
  yarn add @magic-ext/flow@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/gdkms@11.17.0-canary.832.11709014109.0
  yarn add @magic-ext/harmony@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/icon@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/kadena@0.7.0-canary.832.11709014109.0
  yarn add @magic-ext/near@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/oauth@22.17.0-canary.832.11709014109.0
  yarn add @magic-ext/oauth2@9.17.0-canary.832.11709014109.0
  yarn add @magic-ext/oidc@11.17.0-canary.832.11709014109.0
  yarn add @magic-ext/polkadot@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/react-native-bare-oauth@25.18.0-canary.832.11709014109.0
  yarn add @magic-ext/react-native-expo-oauth@25.18.0-canary.832.11709014109.0
  yarn add @magic-ext/solana@25.18.0-canary.832.11709014109.0
  yarn add @magic-ext/sui@0.18.0-canary.832.11709014109.0
  yarn add @magic-ext/taquito@20.17.0-canary.832.11709014109.0
  yarn add @magic-ext/terra@20.17.0-canary.832.11709014109.0
  yarn add @magic-ext/tezos@23.17.0-canary.832.11709014109.0
  yarn add @magic-ext/webauthn@22.17.0-canary.832.11709014109.0
  yarn add @magic-ext/zilliqa@23.17.0-canary.832.11709014109.0
  yarn add @magic-sdk/commons@24.17.0-canary.832.11709014109.0
  yarn add @magic-sdk/pnp@22.18.0-canary.832.11709014109.0
  yarn add @magic-sdk/provider@28.17.0-canary.832.11709014109.0
  yarn add @magic-sdk/react-native-bare@29.18.0-canary.832.11709014109.0
  yarn add @magic-sdk/react-native-expo@29.18.0-canary.832.11709014109.0
  yarn add @magic-sdk/types@24.15.0-canary.832.11709014109.0
  yarn add magic-sdk@28.18.0-canary.832.11709014109.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
