### PR TITLE
farcaster login channel reuse

### DIFF
--- a/packages/@magic-ext/farcaster/src/index.ts
+++ b/packages/@magic-ext/farcaster/src/index.ts
@@ -78,6 +78,8 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
       {
         data: {
           showUI: params?.showUI ?? DEFAULT_SHOW_UI,
+          domain: window.location.host,
+          siweUri: window.location.origin,
         },
       },
     ]);

--- a/packages/@magic-ext/farcaster/src/index.ts
+++ b/packages/@magic-ext/farcaster/src/index.ts
@@ -88,6 +88,7 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
     const handle = this.request<string, FarcasterLoginEventHandlers>(payload);
 
     handle.on('channel', (channel: CreateChannelAPIResponse) => {
+      console.log('channel from res', channel);
       if (isMobile() && isMainFrame()) {
         window.location.href = channel.url;
       }

--- a/packages/@magic-ext/farcaster/src/index.ts
+++ b/packages/@magic-ext/farcaster/src/index.ts
@@ -88,7 +88,6 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
     const handle = this.request<string, FarcasterLoginEventHandlers>(payload);
 
     handle.on('channel', (channel: CreateChannelAPIResponse) => {
-      console.log('channel from res', channel);
       if (isMobile() && isMainFrame()) {
         window.location.href = channel.url;
       }

--- a/packages/@magic-ext/farcaster/src/index.ts
+++ b/packages/@magic-ext/farcaster/src/index.ts
@@ -78,9 +78,6 @@ export class FarcasterExtension extends Extension.Internal<'farcaster'> {
       {
         data: {
           showUI: params?.showUI ?? DEFAULT_SHOW_UI,
-          domain: window.location.origin,
-          isMobile: isMobile(),
-          isMainFrame: isMainFrame(),
         },
       },
     ]);


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/aptos@11.18.1-canary.841.12162160785.0
  npm install @magic-ext/avalanche@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/bitcoin@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/conflux@21.18.1-canary.841.12162160785.0
  npm install @magic-ext/cosmos@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/ed25519@19.18.1-canary.841.12162160785.0
  npm install @magic-ext/farcaster@0.18.1-canary.841.12162160785.0
  npm install @magic-ext/flow@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/gdkms@11.18.1-canary.841.12162160785.0
  npm install @magic-ext/harmony@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/hedera@1.0.4-canary.841.12162160785.0
  npm install @magic-ext/icon@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/kadena@0.8.1-canary.841.12162160785.0
  npm install @magic-ext/near@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/oauth@22.18.1-canary.841.12162160785.0
  npm install @magic-ext/oauth2@9.18.1-canary.841.12162160785.0
  npm install @magic-ext/oidc@11.18.1-canary.841.12162160785.0
  npm install @magic-ext/polkadot@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/react-native-bare-oauth@25.19.1-canary.841.12162160785.0
  npm install @magic-ext/react-native-expo-oauth@25.19.1-canary.841.12162160785.0
  npm install @magic-ext/solana@25.19.1-canary.841.12162160785.0
  npm install @magic-ext/sui@0.19.1-canary.841.12162160785.0
  npm install @magic-ext/taquito@20.18.1-canary.841.12162160785.0
  npm install @magic-ext/terra@20.18.1-canary.841.12162160785.0
  npm install @magic-ext/tezos@23.18.1-canary.841.12162160785.0
  npm install @magic-ext/webauthn@22.18.1-canary.841.12162160785.0
  npm install @magic-ext/zilliqa@23.18.1-canary.841.12162160785.0
  npm install @magic-sdk/commons@24.18.1-canary.841.12162160785.0
  npm install @magic-sdk/pnp@22.19.1-canary.841.12162160785.0
  npm install @magic-sdk/provider@28.18.1-canary.841.12162160785.0
  npm install @magic-sdk/react-native-bare@29.19.1-canary.841.12162160785.0
  npm install @magic-sdk/react-native-expo@29.19.1-canary.841.12162160785.0
  npm install @magic-sdk/types@24.16.1-canary.841.12162160785.0
  npm install magic-sdk@28.19.1-canary.841.12162160785.0
  # or 
  yarn add @magic-ext/algorand@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/aptos@11.18.1-canary.841.12162160785.0
  yarn add @magic-ext/avalanche@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/bitcoin@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/conflux@21.18.1-canary.841.12162160785.0
  yarn add @magic-ext/cosmos@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/ed25519@19.18.1-canary.841.12162160785.0
  yarn add @magic-ext/farcaster@0.18.1-canary.841.12162160785.0
  yarn add @magic-ext/flow@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/gdkms@11.18.1-canary.841.12162160785.0
  yarn add @magic-ext/harmony@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/hedera@1.0.4-canary.841.12162160785.0
  yarn add @magic-ext/icon@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/kadena@0.8.1-canary.841.12162160785.0
  yarn add @magic-ext/near@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/oauth@22.18.1-canary.841.12162160785.0
  yarn add @magic-ext/oauth2@9.18.1-canary.841.12162160785.0
  yarn add @magic-ext/oidc@11.18.1-canary.841.12162160785.0
  yarn add @magic-ext/polkadot@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/react-native-bare-oauth@25.19.1-canary.841.12162160785.0
  yarn add @magic-ext/react-native-expo-oauth@25.19.1-canary.841.12162160785.0
  yarn add @magic-ext/solana@25.19.1-canary.841.12162160785.0
  yarn add @magic-ext/sui@0.19.1-canary.841.12162160785.0
  yarn add @magic-ext/taquito@20.18.1-canary.841.12162160785.0
  yarn add @magic-ext/terra@20.18.1-canary.841.12162160785.0
  yarn add @magic-ext/tezos@23.18.1-canary.841.12162160785.0
  yarn add @magic-ext/webauthn@22.18.1-canary.841.12162160785.0
  yarn add @magic-ext/zilliqa@23.18.1-canary.841.12162160785.0
  yarn add @magic-sdk/commons@24.18.1-canary.841.12162160785.0
  yarn add @magic-sdk/pnp@22.19.1-canary.841.12162160785.0
  yarn add @magic-sdk/provider@28.18.1-canary.841.12162160785.0
  yarn add @magic-sdk/react-native-bare@29.19.1-canary.841.12162160785.0
  yarn add @magic-sdk/react-native-expo@29.19.1-canary.841.12162160785.0
  yarn add @magic-sdk/types@24.16.1-canary.841.12162160785.0
  yarn add magic-sdk@28.19.1-canary.841.12162160785.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
