### PR TITLE
remove 15s auto success

### DIFF
--- a/packages/@magic-sdk/provider/src/core/view-controller.ts
+++ b/packages/@magic-sdk/provider/src/core/view-controller.ts
@@ -43,7 +43,7 @@ function getRequestPayloadFromBatch(
   id?: string | number | null,
 ): JsonRpcRequestPayload | undefined {
   return id && Array.isArray(requestPayload)
-    ? requestPayload.find((p) => p.id === id)
+    ? requestPayload.find(p => p.id === id)
     : (requestPayload as JsonRpcRequestPayload);
 }
 
@@ -175,7 +175,7 @@ export abstract class ViewController {
       }
 
       const batchData: JsonRpcResponse[] = [];
-      const batchIds = Array.isArray(payload) ? payload.map((p) => p.id) : [];
+      const batchIds = Array.isArray(payload) ? payload.map(p => p.id) : [];
       const msg = await createMagicRequest(`${msgType}-${this.parameters}`, payload, this.networkHash);
 
       await this._post(msg);
@@ -240,22 +240,12 @@ export abstract class ViewController {
   }
 
   private waitForReady() {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>(resolve => {
       const unsubscribe = this.on(MagicIncomingWindowMessage.MAGIC_OVERLAY_READY, () => {
         this.isReadyForRequest = true;
         resolve();
         unsubscribe();
       });
-
-      // We expect the overlay to be ready within 15 seconds.
-      // Sometimes the message is not properly processed due to
-      // webview issues. In that case, after 15 seconds we consider
-      // the overlay ready, to avoid requests hanging forever.
-      setTimeout(() => {
-        this.isReadyForRequest = true;
-        resolve();
-        unsubscribe();
-      }, 15000);
     });
   }
 

--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/waitForReady.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/waitForReady.spec.ts
@@ -6,7 +6,7 @@ beforeEach(() => {
   browserEnv();
 });
 
-test('Receive MAGIC_OVERLAY_READY, resolve `waitForReady` promise', (done) => {
+test('Receive MAGIC_OVERLAY_READY, resolve `waitForReady` promise', done => {
   const overlay = createViewController('');
   const waitForReady = (overlay as any).waitForReady();
 
@@ -15,18 +15,4 @@ test('Receive MAGIC_OVERLAY_READY, resolve `waitForReady` promise', (done) => {
   });
 
   window.postMessage({ msgType: MSG_TYPES().MAGIC_OVERLAY_READY }, '*');
-});
-
-test('Resolve `waitForReady` promise after timeout', (done) => {
-  jest.useFakeTimers();
-  const overlay = createViewController('');
-  const waitForReady = (overlay as any).waitForReady();
-
-  waitForReady.then(() => {
-    done();
-  });
-
-  // Fast forward time to 15 seconds
-  jest.advanceTimersByTime(15000);
-  jest.useRealTimers();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,7 +2407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2416,8 +2416,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^24.20.0
-    "@magic-sdk/provider": ^28.20.0
+    "@magic-sdk/commons": ^25.0.0
+    "@magic-sdk/provider": ^29.0.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2429,7 +2429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2437,7 +2437,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2445,7 +2445,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2453,7 +2453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2461,7 +2461,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2469,7 +2469,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2477,7 +2477,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2490,7 +2490,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@magic-sdk/types": ^24.18.0
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2500,7 +2500,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2518,7 +2518,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2526,7 +2526,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2534,7 +2534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2542,17 +2542,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^22.20.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^23.0.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
   languageName: unknown
@@ -2562,7 +2562,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2570,7 +2570,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2578,7 +2578,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^29.21.0
+    "@magic-sdk/react-native-bare": ^30.0.0
     "@magic-sdk/types": ^24.18.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2594,7 +2594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^29.21.0
+    "@magic-sdk/react-native-expo": ^30.0.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~3.1.47
     crypto-js: ^3.3.0
@@ -2609,7 +2609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2620,7 +2620,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2628,7 +2628,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2636,7 +2636,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2644,7 +2644,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2652,7 +2652,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/web3modal-ethers5@workspace:packages/@magic-ext/web3modal-ethers5"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
     "@magic-sdk/types": 24.0.6-canary.742.10067162636.0
     "@web3modal/ethers5": 5.0.3
     ethers: 5.7.2
@@ -2663,7 +2663,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
@@ -2671,15 +2671,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^24.20.0
+    "@magic-sdk/commons": ^25.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^24.20.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^25.0.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^28.20.0
+    "@magic-sdk/provider": ^29.0.0
     "@magic-sdk/types": ^24.18.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -2704,12 +2704,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^22.20.0
-    magic-sdk: ^28.21.1
+    "@magic-ext/oauth": ^23.0.0
+    magic-sdk: ^29.0.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^28.20.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^29.0.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -2726,7 +2726,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^29.21.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^30.0.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2734,8 +2734,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.20.0
-    "@magic-sdk/provider": ^28.20.0
+    "@magic-sdk/commons": ^25.0.0
+    "@magic-sdk/provider": ^29.0.0
     "@magic-sdk/types": ^24.18.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -2767,7 +2767,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^29.21.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^30.0.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2775,8 +2775,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^24.20.0
-    "@magic-sdk/provider": ^28.20.0
+    "@magic-sdk/commons": ^25.0.0
+    "@magic-sdk/provider": ^29.0.0
     "@magic-sdk/types": ^24.18.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -15104,15 +15104,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^28.21.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^29.0.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^24.20.0
-    "@magic-sdk/provider": ^28.20.0
+    "@magic-sdk/commons": ^25.0.0
+    "@magic-sdk/provider": ^29.0.0
     "@magic-sdk/types": ^24.18.0
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/aptos@12.0.1-canary.861.13705391022.0
  npm install @magic-ext/avalanche@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/bitcoin@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/conflux@22.0.1-canary.861.13705391022.0
  npm install @magic-ext/cosmos@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/ed25519@20.0.1-canary.861.13705391022.0
  npm install @magic-ext/farcaster@1.0.1-canary.861.13705391022.0
  npm install @magic-ext/flow@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/gdkms@12.0.1-canary.861.13705391022.0
  npm install @magic-ext/harmony@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/icon@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/kadena@1.0.1-canary.861.13705391022.0
  npm install @magic-ext/near@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/oauth@23.0.1-canary.861.13705391022.0
  npm install @magic-ext/oauth2@10.0.1-canary.861.13705391022.0
  npm install @magic-ext/oidc@12.0.1-canary.861.13705391022.0
  npm install @magic-ext/polkadot@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/react-native-bare-oauth@26.0.1-canary.861.13705391022.0
  npm install @magic-ext/react-native-expo-oauth@26.0.1-canary.861.13705391022.0
  npm install @magic-ext/solana@26.0.1-canary.861.13705391022.0
  npm install @magic-ext/sui@1.0.1-canary.861.13705391022.0
  npm install @magic-ext/taquito@21.0.1-canary.861.13705391022.0
  npm install @magic-ext/terra@21.0.1-canary.861.13705391022.0
  npm install @magic-ext/tezos@24.0.1-canary.861.13705391022.0
  npm install @magic-ext/web3modal-ethers5@1.0.1-canary.861.13705391022.0
  npm install @magic-ext/webauthn@23.0.1-canary.861.13705391022.0
  npm install @magic-ext/zilliqa@24.0.1-canary.861.13705391022.0
  npm install @magic-sdk/commons@25.0.1-canary.861.13705391022.0
  npm install @magic-sdk/pnp@23.0.1-canary.861.13705391022.0
  npm install @magic-sdk/provider@29.0.1-canary.861.13705391022.0
  npm install @magic-sdk/react-native-bare@30.0.1-canary.861.13705391022.0
  npm install @magic-sdk/react-native-expo@30.0.1-canary.861.13705391022.0
  npm install magic-sdk@29.0.1-canary.861.13705391022.0
  # or 
  yarn add @magic-ext/algorand@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/aptos@12.0.1-canary.861.13705391022.0
  yarn add @magic-ext/avalanche@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/bitcoin@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/conflux@22.0.1-canary.861.13705391022.0
  yarn add @magic-ext/cosmos@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/ed25519@20.0.1-canary.861.13705391022.0
  yarn add @magic-ext/farcaster@1.0.1-canary.861.13705391022.0
  yarn add @magic-ext/flow@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/gdkms@12.0.1-canary.861.13705391022.0
  yarn add @magic-ext/harmony@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/icon@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/kadena@1.0.1-canary.861.13705391022.0
  yarn add @magic-ext/near@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/oauth@23.0.1-canary.861.13705391022.0
  yarn add @magic-ext/oauth2@10.0.1-canary.861.13705391022.0
  yarn add @magic-ext/oidc@12.0.1-canary.861.13705391022.0
  yarn add @magic-ext/polkadot@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/react-native-bare-oauth@26.0.1-canary.861.13705391022.0
  yarn add @magic-ext/react-native-expo-oauth@26.0.1-canary.861.13705391022.0
  yarn add @magic-ext/solana@26.0.1-canary.861.13705391022.0
  yarn add @magic-ext/sui@1.0.1-canary.861.13705391022.0
  yarn add @magic-ext/taquito@21.0.1-canary.861.13705391022.0
  yarn add @magic-ext/terra@21.0.1-canary.861.13705391022.0
  yarn add @magic-ext/tezos@24.0.1-canary.861.13705391022.0
  yarn add @magic-ext/web3modal-ethers5@1.0.1-canary.861.13705391022.0
  yarn add @magic-ext/webauthn@23.0.1-canary.861.13705391022.0
  yarn add @magic-ext/zilliqa@24.0.1-canary.861.13705391022.0
  yarn add @magic-sdk/commons@25.0.1-canary.861.13705391022.0
  yarn add @magic-sdk/pnp@23.0.1-canary.861.13705391022.0
  yarn add @magic-sdk/provider@29.0.1-canary.861.13705391022.0
  yarn add @magic-sdk/react-native-bare@30.0.1-canary.861.13705391022.0
  yarn add @magic-sdk/react-native-expo@30.0.1-canary.861.13705391022.0
  yarn add magic-sdk@29.0.1-canary.861.13705391022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
