### PR TITLE
bump crypto-js

### DIFF
--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -29,10 +29,9 @@
     ]
   },
   "dependencies": {
-    "crypto-js": "^3.3.0"
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
-    "@magic-sdk/commons": "^25.0.1",
-    "@types/crypto-js": "~3.1.47"
+    "@types/crypto-js": "~4.2.0"
   }
 }

--- a/packages/@magic-ext/oauth/package.json
+++ b/packages/@magic-ext/oauth/package.json
@@ -32,6 +32,7 @@
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {
+    "@magic-sdk/commons": "latest",
     "@types/crypto-js": "~4.2.0"
   }
 }

--- a/packages/@magic-ext/oauth/src/crypto.ts
+++ b/packages/@magic-ext/oauth/src/crypto.ts
@@ -17,8 +17,6 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
-function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
 function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');

--- a/packages/@magic-ext/oauth/src/crypto.ts
+++ b/packages/@magic-ext/oauth/src/crypto.ts
@@ -17,9 +17,9 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: Crypto.WordArray): string;
+function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
 function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
-function base64URLEncodeFromByteArray(arg: Crypto.WordArray | ArrayBuffer): string {
+function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   };
@@ -27,7 +27,7 @@ function base64URLEncodeFromByteArray(arg: Crypto.WordArray | ArrayBuffer): stri
   if (arg instanceof ArrayBuffer) {
     const bytes = new Uint8Array(arg);
     const utf8Binary = Array.from(bytes)
-      .map((value) => String.fromCharCode(value))
+      .map(value => String.fromCharCode(value))
       .join('');
 
     const base64 = btoa(utf8Binary);

--- a/packages/@magic-ext/oauth2/package.json
+++ b/packages/@magic-ext/oauth2/package.json
@@ -29,10 +29,9 @@
     ]
   },
   "dependencies": {
-    "crypto-js": "^3.3.0"
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
-    "@magic-sdk/commons": "^25.0.1",
-    "@types/crypto-js": "~3.1.47"
+    "@types/crypto-js": "4.2.0"
   }
 }

--- a/packages/@magic-ext/oauth2/package.json
+++ b/packages/@magic-ext/oauth2/package.json
@@ -32,6 +32,7 @@
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {
+    "@magic-sdk/commons": "latest",
     "@types/crypto-js": "4.2.0"
   }
 }

--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -26,13 +26,13 @@
     ]
   },
   "dependencies": {
-    "crypto-js": "^3.3.0",
+    "crypto-js": "^4.2.0",
     "react-native-device-info": "^10.3.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native-bare": "^30.0.1",
     "@magic-sdk/types": "^24.18.0",
-    "@types/crypto-js": "~3.1.47",
+    "@types/crypto-js": "~4.2.0",
     "react-native-inappbrowser-reborn": "^3.7.0"
   },
   "peerDependencies": {

--- a/packages/@magic-ext/react-native-bare-oauth/package.json
+++ b/packages/@magic-ext/react-native-bare-oauth/package.json
@@ -30,6 +30,7 @@
     "react-native-device-info": "^10.3.0"
   },
   "devDependencies": {
+    "@magic-sdk/commons": "latest",
     "@magic-sdk/react-native-bare": "^30.0.1",
     "@magic-sdk/types": "^24.18.0",
     "@types/crypto-js": "~4.2.0",

--- a/packages/@magic-ext/react-native-bare-oauth/src/crypto.ts
+++ b/packages/@magic-ext/react-native-bare-oauth/src/crypto.ts
@@ -19,8 +19,6 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
-function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
 function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');

--- a/packages/@magic-ext/react-native-bare-oauth/src/crypto.ts
+++ b/packages/@magic-ext/react-native-bare-oauth/src/crypto.ts
@@ -1,4 +1,4 @@
-import { WordArray } from 'crypto-js';
+import Crypto from 'crypto-js';
 import sha256Fallback from 'crypto-js/sha256';
 import Base64 from 'crypto-js/enc-base64';
 
@@ -19,9 +19,9 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: WordArray): string;
+function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
 function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
-function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
+function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   };
@@ -29,7 +29,7 @@ function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
   if (arg instanceof ArrayBuffer) {
     const bytes = new Uint8Array(arg);
     const utf8Binary = Array.from(bytes)
-      .map((value) => String.fromCharCode(value))
+      .map(value => String.fromCharCode(value))
       .join('');
 
     const base64 = btoa(utf8Binary);

--- a/packages/@magic-ext/react-native-expo-oauth/package.json
+++ b/packages/@magic-ext/react-native-expo-oauth/package.json
@@ -27,13 +27,13 @@
   },
   "dependencies": {
     "@magic-sdk/types": "^10.0.0",
-    "crypto-js": "^3.3.0",
+    "crypto-js": "^4.2.0",
     "expo-application": "^5.0.1",
     "expo-web-browser": ">=12.0.0"
   },
   "devDependencies": {
     "@magic-sdk/react-native-expo": "^30.0.1",
-    "@types/crypto-js": "~3.1.47"
+    "@types/crypto-js": "~4.2.0"
   },
   "peerDependencies": {
     "@magic-sdk/react-native-expo": ">=13.0.0"

--- a/packages/@magic-ext/react-native-expo-oauth/src/crypto.ts
+++ b/packages/@magic-ext/react-native-expo-oauth/src/crypto.ts
@@ -19,8 +19,6 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
-function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
 function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');

--- a/packages/@magic-ext/react-native-expo-oauth/src/crypto.ts
+++ b/packages/@magic-ext/react-native-expo-oauth/src/crypto.ts
@@ -1,4 +1,4 @@
-import { WordArray } from 'crypto-js';
+import Crypto from 'crypto-js';
 import sha256Fallback from 'crypto-js/sha256';
 import Base64 from 'crypto-js/enc-base64';
 
@@ -19,9 +19,9 @@ function bytesToVerifierString(bytes: Uint8Array) {
  * Stringifies argument (as CryptoJS `WordArray` or EcmaScript `ArrayBuffer`)
  * and encodes to URL-safe Base64.
  */
-function base64URLEncodeFromByteArray(wordArray: WordArray): string;
+function base64URLEncodeFromByteArray(wordArray: Crypto.lib.WordArray): string;
 function base64URLEncodeFromByteArray(arrayBuffer: ArrayBuffer): string;
-function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
+function base64URLEncodeFromByteArray(arg: Crypto.lib.WordArray | ArrayBuffer): string {
   const makeURLSafe = (base64: string) => {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   };
@@ -29,7 +29,7 @@ function base64URLEncodeFromByteArray(arg: WordArray | ArrayBuffer): string {
   if (arg instanceof ArrayBuffer) {
     const bytes = new Uint8Array(arg);
     const utf8Binary = Array.from(bytes)
-      .map((value) => String.fromCharCode(value))
+      .map(value => String.fromCharCode(value))
       .join('');
 
     const base64 = btoa(utf8Binary);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
+    "@magic-sdk/commons": latest
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -2551,6 +2552,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
+    "@magic-sdk/commons": latest
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -2576,6 +2578,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
+    "@magic-sdk/commons": latest
     "@magic-sdk/react-native-bare": ^30.0.1
     "@magic-sdk/types": ^24.18.0
     "@types/crypto-js": ~4.2.0
@@ -2692,6 +2695,16 @@ __metadata:
     "@magic-sdk/provider": ">=4.3.0"
     "@magic-sdk/types": ">=3.1.1"
   checksum: 43c71771ddf3355d16fe1eed29d778cdb01b40b2af5f67a07173d0c41b3bc3f14a8513221948a84191805372b2d34f1097e8f0de771ed867c3485ffb1805dcd8
+  languageName: node
+  linkType: hard
+
+"@magic-sdk/commons@npm:latest":
+  version: 25.0.2
+  resolution: "@magic-sdk/commons@npm:25.0.2"
+  peerDependencies:
+    "@magic-sdk/provider": ">=18.6.0"
+    "@magic-sdk/types": ">=15.8.0"
+  checksum: 0d1fcf38d0d19493a1baae23d328e11135fc4c36b53600313b96ce229c86c988321ef47568a462ed7e2f3e3e1f0108a660ce3a54ac028e3a9778b8eeb0938b05
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,7 +2407,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2416,8 +2416,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^25.0.1
-    "@magic-sdk/provider": ^29.0.1
+    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/provider": ^29.0.2
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2429,7 +2429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2437,7 +2437,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2445,7 +2445,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2453,7 +2453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2461,7 +2461,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2469,7 +2469,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2477,7 +2477,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2490,8 +2490,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/types": ^24.18.1
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
   linkType: soft
@@ -2500,7 +2500,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2518,7 +2518,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2526,7 +2526,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2534,7 +2534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2542,17 +2542,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": latest
+    "@magic-sdk/commons": ^25.0.2
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^23.0.1, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^23.0.2, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": latest
+    "@magic-sdk/commons": ^25.0.2
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -2562,7 +2562,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2570,7 +2570,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2578,9 +2578,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/commons": latest
-    "@magic-sdk/react-native-bare": ^30.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/react-native-bare": ^30.0.2
+    "@magic-sdk/types": ^24.18.1
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
     react-native-device-info: ^10.3.0
@@ -2595,7 +2594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^30.0.1
+    "@magic-sdk/react-native-expo": ^30.0.2
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -2610,7 +2609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2621,7 +2620,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2629,7 +2628,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2637,7 +2636,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2645,7 +2644,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2653,7 +2652,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/web3modal-ethers5@workspace:packages/@magic-ext/web3modal-ethers5"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
     "@magic-sdk/types": 24.0.6-canary.742.10067162636.0
     "@web3modal/ethers5": 5.0.3
     ethers: 5.7.2
@@ -2664,7 +2663,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
@@ -2672,16 +2671,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
+    "@magic-sdk/commons": ^25.0.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^25.0.1, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^25.0.2, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^29.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/types": ^24.18.1
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -2698,16 +2697,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@magic-sdk/commons@npm:latest":
-  version: 25.0.2
-  resolution: "@magic-sdk/commons@npm:25.0.2"
-  peerDependencies:
-    "@magic-sdk/provider": ">=18.6.0"
-    "@magic-sdk/types": ">=15.8.0"
-  checksum: 0d1fcf38d0d19493a1baae23d328e11135fc4c36b53600313b96ce229c86c988321ef47568a462ed7e2f3e3e1f0108a660ce3a54ac028e3a9778b8eeb0938b05
-  languageName: node
-  linkType: hard
-
 "@magic-sdk/pnp@workspace:packages/@magic-sdk/pnp":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/pnp@workspace:packages/@magic-sdk/pnp"
@@ -2715,17 +2704,17 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^23.0.1
-    magic-sdk: ^29.0.1
+    "@magic-ext/oauth": ^23.0.2
+    magic-sdk: ^29.0.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^29.0.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^29.0.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/types": ^24.18.1
     "@peculiar/webcrypto": ^1.1.7
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
@@ -2737,7 +2726,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^30.0.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^30.0.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2745,9 +2734,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^25.0.1
-    "@magic-sdk/provider": ^29.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/types": ^24.18.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2778,7 +2767,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^30.0.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^30.0.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2786,9 +2775,9 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^25.0.1
-    "@magic-sdk/provider": ^29.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/types": ^24.18.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@testing-library/react-native": ^12.4.0
@@ -2819,7 +2808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.18.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.18.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -15122,16 +15111,16 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^29.0.1, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^29.0.2, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^25.0.1
-    "@magic-sdk/provider": ^29.0.1
-    "@magic-sdk/types": ^24.18.0
+    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/types": ^24.18.1
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,9 +2542,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
-    "@types/crypto-js": ~3.1.47
-    crypto-js: ^3.3.0
+    "@types/crypto-js": 4.2.0
+    crypto-js: ^4.2.0
   languageName: unknown
   linkType: soft
 
@@ -2552,9 +2551,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^25.0.1
-    "@types/crypto-js": ~3.1.47
-    crypto-js: ^3.3.0
+    "@types/crypto-js": ~4.2.0
+    crypto-js: ^4.2.0
   languageName: unknown
   linkType: soft
 
@@ -2580,8 +2578,8 @@ __metadata:
   dependencies:
     "@magic-sdk/react-native-bare": ^30.0.1
     "@magic-sdk/types": ^24.18.0
-    "@types/crypto-js": ~3.1.47
-    crypto-js: ^3.3.0
+    "@types/crypto-js": ~4.2.0
+    crypto-js: ^4.2.0
     react-native-device-info: ^10.3.0
     react-native-inappbrowser-reborn: ^3.7.0
   peerDependencies:
@@ -2596,8 +2594,8 @@ __metadata:
   dependencies:
     "@magic-sdk/react-native-expo": ^30.0.1
     "@magic-sdk/types": ^10.0.0
-    "@types/crypto-js": ~3.1.47
-    crypto-js: ^3.3.0
+    "@types/crypto-js": ~4.2.0
+    crypto-js: ^4.2.0
     expo-application: ^5.0.1
     expo-web-browser: ">=12.0.0"
   peerDependencies:
@@ -4558,10 +4556,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/crypto-js@npm:~3.1.47":
-  version: 3.1.47
-  resolution: "@types/crypto-js@npm:3.1.47"
-  checksum: fdeabd526cb3bf3a37300752a2a7313d360292a08b40c97709981ba520cf66b90b872672e32da3c5f0ad29faa8dcd22d14a8f418e24ba6a1e154acd5a123d050
+"@types/crypto-js@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@types/crypto-js@npm:4.2.0"
+  checksum: bf2f9fc7140d2fd16f443e306f80d4a822d9b35df61e7fbad0c483849d47d4953ca986741c218d84e2f3b9ac77a976ffc7c9064e6655b38c47864c02d756e68a
+  languageName: node
+  linkType: hard
+
+"@types/crypto-js@npm:~4.2.0":
+  version: 4.2.2
+  resolution: "@types/crypto-js@npm:4.2.2"
+  checksum: 727daa0d2db35f0abefbab865c23213b6ee6a270e27e177939bbe4b70d1e84c2202d9fac4ea84859c4b4d49a4ee50f948f601327a39b69ec013288018ba07ca5
   languageName: node
   linkType: hard
 
@@ -8339,10 +8344,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-js@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "crypto-js@npm:3.3.0"
-  checksum: 193923143a4784b2f974366068d96fe8280168fd3fef2bfea9551a5c3e32096f5a8fa49ff4eeb5bd0b9716d325618d38cfbe6125e359a4ef488fbca93e600824
+"crypto-js@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "crypto-js@npm:4.2.0"
+  checksum: f051666dbc077c8324777f44fbd3aaea2986f198fe85092535130d17026c7c2ccf2d23ee5b29b36f7a4a07312db2fae23c9094b644cc35f7858b1b4fcaf27774
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

This bumps crypto-js dependency to the latest

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/oauth@23.1.0-canary.864.14042819872.0
  npm install @magic-ext/oauth2@11.1.0-canary.864.14042819872.0
  npm install @magic-ext/react-native-bare-oauth@26.1.0-canary.864.14042819872.0
  npm install @magic-ext/react-native-expo-oauth@26.1.0-canary.864.14042819872.0
  npm install @magic-sdk/pnp@23.1.0-canary.864.14042819872.0
  # or 
  yarn add @magic-ext/oauth@23.1.0-canary.864.14042819872.0
  yarn add @magic-ext/oauth2@11.1.0-canary.864.14042819872.0
  yarn add @magic-ext/react-native-bare-oauth@26.1.0-canary.864.14042819872.0
  yarn add @magic-ext/react-native-expo-oauth@26.1.0-canary.864.14042819872.0
  yarn add @magic-sdk/pnp@23.1.0-canary.864.14042819872.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
