### PR TITLE
add iframe.contentWindow check

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
           overwrite: true
 
   create_canary:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Canary
     permissions:
       contents: read
@@ -60,7 +60,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
           overwrite: true
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Publish
     permissions:
       contents: read
@@ -80,7 +80,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,17 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Run linter and package audit
     container:
-      image: node:20-slim
+      image: node:22-slim
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: |
           yarn -v
@@ -37,17 +37,17 @@ jobs:
         run: yarn audit --groups dependencies || true
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Run tests
     container:
-      image: node:20-slim
+      image: node:22-slim
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: |
           yarn -v

--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
@@ -87,6 +87,7 @@ beforeEach(() => {
   SDKEnvironment.platform = 'web';
   viewController = createViewController('asdf');
   viewController.isReadyForRequest = true;
+  viewController.checkRelayerExistsInDOM = jest.fn(() => Promise.resolve(true));
 });
 
 afterEach(() => {
@@ -329,4 +330,25 @@ test('Sends a batch payload and resolves with multiple responses', async () => {
     new JsonRpcResponse(response2.data.response),
     new JsonRpcResponse(response3.data.response),
   ]);
+});
+
+test('When iframe is lost, re-init iframe and keep posting messages', async () => {
+  createJwtStub.mockImplementationOnce(() => Promise.resolve(FAKE_JWT_TOKEN));
+  viewController.checkRelayerExistsInDOM = jest.fn(() => Promise.resolve(false));
+  viewController.reloadRelayer = jest.fn(() => Promise.resolve(undefined));
+  viewController.waitForReady = jest.fn(() => Promise.resolve(undefined));
+
+  const { handlerSpy, onSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  const payload = requestPayload();
+
+  const response = await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, payload);
+
+  expect(onSpy.mock.calls[0][0]).toBe(MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE);
+  expect(viewController.isReadyForRequest).toBe(false);
+  expect(viewController.reloadRelayer).toBeCalledTimes(1);
+  expect(viewController.waitForReady).toBeCalledTimes(1);
+  expect(handlerSpy).toBeCalledTimes(1);
+  expect(response).toEqual(new JsonRpcResponse(responseEvent().data.response));
 });

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -287,8 +287,8 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   // Todo - implement these methods
-  protected checkRelayerExistsInDOM(): boolean {
-    return true;
+  protected checkRelayerExistsInDOM(): Promise<boolean> {
+    return Promise.resolve(true);
   }
 
   /* istanbul ignore next */

--- a/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-bare/src/react-native-webview-controller.tsx
@@ -287,6 +287,7 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   // Todo - implement these methods
+  /* istanbul ignore next */
   protected checkRelayerExistsInDOM(): Promise<boolean> {
     return Promise.resolve(true);
   }

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -287,8 +287,8 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   // Todo - implement these methods
-  protected checkRelayerExistsInDOM(): boolean {
-    return true;
+  protected checkRelayerExistsInDOM(): Promise<boolean> {
+    return Promise.resolve(true);
   }
 
   /* istanbul ignore next */

--- a/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
+++ b/packages/@magic-sdk/react-native-expo/src/react-native-webview-controller.tsx
@@ -287,6 +287,7 @@ export class ReactNativeWebViewController extends ViewController {
   }
 
   // Todo - implement these methods
+  /* istanbul ignore next */
   protected checkRelayerExistsInDOM(): Promise<boolean> {
     return Promise.resolve(true);
   }

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -142,7 +142,14 @@ export class IframeController extends ViewController {
     }
   }
 
-  protected checkRelayerExistsInDOM() {
+  protected async checkRelayerExistsInDOM() {
+    const iframe = await this.iframe;
+
+    // Check iframe reference
+    if (!iframe || !iframe.contentWindow) {
+      return false;
+    }
+
     // Check if the iframe is already in the DOM
     const iframes: HTMLIFrameElement[] = [].slice.call(document.querySelectorAll('.magic-iframe'));
     return Boolean(iframes.find(iframe => iframe.src.includes(encodeURIComponent(this.parameters))));
@@ -154,12 +161,21 @@ export class IframeController extends ViewController {
     // Reset HeartBeat
     this.stopHeartBeat();
 
-    if (iframe) {
-      // reload the iframe source
-      iframe.src = this.relayerSrc;
-    } else {
+    if (!iframe) {
       this.init();
       console.warn('Magic SDK: Modal lost, re-initiating');
+      return;
+    }
+
+    if (!iframe.contentWindow) {
+      document.body.appendChild(iframe);
+      console.warn('Magic SDK: Modal did not append in the iframe, re-initiating');
+      return;
+    }
+
+    if (iframe) {
+      // if iframe exists reload the iframe source
+      iframe.src = this.relayerSrc;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,7 +2421,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2430,8 +2430,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^25.0.2
-    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/commons": ^25.0.3
+    "@magic-sdk/provider": ^29.0.3
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -2443,7 +2443,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2451,7 +2451,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2459,7 +2459,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2467,7 +2467,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2475,7 +2475,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2483,7 +2483,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2491,7 +2491,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -2504,7 +2504,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@magic-sdk/types": ^24.18.1
     "@peculiar/webcrypto": ^1.4.3
   languageName: unknown
@@ -2514,7 +2514,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2532,7 +2532,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2540,7 +2540,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2548,7 +2548,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2556,17 +2556,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^23.0.3, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^23.0.4, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -2576,7 +2576,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2584,7 +2584,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2592,7 +2592,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^30.0.2
+    "@magic-sdk/react-native-bare": ^30.0.3
     "@magic-sdk/types": ^24.18.1
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -2608,7 +2608,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^30.0.2
+    "@magic-sdk/react-native-expo": ^30.0.3
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -2623,7 +2623,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -2634,7 +2634,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2642,7 +2642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2650,7 +2650,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2658,7 +2658,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2666,7 +2666,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/web3modal-ethers5@workspace:packages/@magic-ext/web3modal-ethers5"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
     "@magic-sdk/types": 24.0.6-canary.742.10067162636.0
     "@web3modal/ethers5": 5.0.3
     ethers: 5.7.2
@@ -2677,7 +2677,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
@@ -2685,15 +2685,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^25.0.2
+    "@magic-sdk/commons": ^25.0.3
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^25.0.2, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^25.0.3, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/provider": ^29.0.3
     "@magic-sdk/types": ^24.18.1
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
@@ -2718,12 +2718,12 @@ __metadata:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-ext/oauth": ^23.0.3
-    magic-sdk: ^29.0.2
+    "@magic-ext/oauth": ^23.0.4
+    magic-sdk: ^29.0.3
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^29.0.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^29.0.3, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
@@ -2740,7 +2740,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^30.0.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^30.0.3, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
@@ -2748,8 +2748,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^25.0.2
-    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/commons": ^25.0.3
+    "@magic-sdk/provider": ^29.0.3
     "@magic-sdk/types": ^24.18.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -2781,7 +2781,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^30.0.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^30.0.3, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
@@ -2789,8 +2789,8 @@ __metadata:
     "@babel/core": ^7.15.0
     "@babel/plugin-transform-flow-strip-types": ^7.14.5
     "@babel/runtime": ~7.10.4
-    "@magic-sdk/commons": ^25.0.2
-    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/commons": ^25.0.3
+    "@magic-sdk/provider": ^29.0.3
     "@magic-sdk/types": ^24.18.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
@@ -15159,15 +15159,15 @@ fsevents@^2.3.2:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^29.0.2, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^29.0.3, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
     "@babel/core": ^7.9.6
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
     "@babel/runtime": ^7.9.6
-    "@magic-sdk/commons": ^25.0.2
-    "@magic-sdk/provider": ^29.0.2
+    "@magic-sdk/commons": ^25.0.3
+    "@magic-sdk/provider": ^29.0.3
     "@magic-sdk/types": ^24.18.1
     localforage: ^1.7.4
     localforage-driver-memory: ^1.0.5


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Fix an edge case where iframe.contentWindow is empty

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/aptos@12.0.4-canary.870.14203885986.0
  npm install @magic-ext/avalanche@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/bitcoin@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/conflux@22.0.4-canary.870.14203885986.0
  npm install @magic-ext/cosmos@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/ed25519@20.0.4-canary.870.14203885986.0
  npm install @magic-ext/farcaster@1.0.4-canary.870.14203885986.0
  npm install @magic-ext/flow@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/gdkms@12.0.4-canary.870.14203885986.0
  npm install @magic-ext/harmony@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/icon@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/kadena@1.0.4-canary.870.14203885986.0
  npm install @magic-ext/near@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/oauth@23.0.5-canary.870.14203885986.0
  npm install @magic-ext/oauth2@11.0.4-canary.870.14203885986.0
  npm install @magic-ext/oidc@12.0.4-canary.870.14203885986.0
  npm install @magic-ext/polkadot@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/react-native-bare-oauth@26.0.5-canary.870.14203885986.0
  npm install @magic-ext/react-native-expo-oauth@26.0.5-canary.870.14203885986.0
  npm install @magic-ext/solana@26.0.4-canary.870.14203885986.0
  npm install @magic-ext/sui@1.0.4-canary.870.14203885986.0
  npm install @magic-ext/taquito@21.0.4-canary.870.14203885986.0
  npm install @magic-ext/terra@21.0.4-canary.870.14203885986.0
  npm install @magic-ext/tezos@24.0.4-canary.870.14203885986.0
  npm install @magic-ext/web3modal-ethers5@1.0.4-canary.870.14203885986.0
  npm install @magic-ext/webauthn@23.0.4-canary.870.14203885986.0
  npm install @magic-ext/zilliqa@24.0.4-canary.870.14203885986.0
  npm install @magic-sdk/commons@25.0.4-canary.870.14203885986.0
  npm install @magic-sdk/pnp@23.0.5-canary.870.14203885986.0
  npm install @magic-sdk/provider@29.0.4-canary.870.14203885986.0
  npm install @magic-sdk/react-native-bare@30.0.4-canary.870.14203885986.0
  npm install @magic-sdk/react-native-expo@30.0.4-canary.870.14203885986.0
  npm install magic-sdk@29.0.4-canary.870.14203885986.0
  # or 
  yarn add @magic-ext/algorand@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/aptos@12.0.4-canary.870.14203885986.0
  yarn add @magic-ext/avalanche@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/bitcoin@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/conflux@22.0.4-canary.870.14203885986.0
  yarn add @magic-ext/cosmos@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/ed25519@20.0.4-canary.870.14203885986.0
  yarn add @magic-ext/farcaster@1.0.4-canary.870.14203885986.0
  yarn add @magic-ext/flow@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/gdkms@12.0.4-canary.870.14203885986.0
  yarn add @magic-ext/harmony@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/icon@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/kadena@1.0.4-canary.870.14203885986.0
  yarn add @magic-ext/near@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/oauth@23.0.5-canary.870.14203885986.0
  yarn add @magic-ext/oauth2@11.0.4-canary.870.14203885986.0
  yarn add @magic-ext/oidc@12.0.4-canary.870.14203885986.0
  yarn add @magic-ext/polkadot@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/react-native-bare-oauth@26.0.5-canary.870.14203885986.0
  yarn add @magic-ext/react-native-expo-oauth@26.0.5-canary.870.14203885986.0
  yarn add @magic-ext/solana@26.0.4-canary.870.14203885986.0
  yarn add @magic-ext/sui@1.0.4-canary.870.14203885986.0
  yarn add @magic-ext/taquito@21.0.4-canary.870.14203885986.0
  yarn add @magic-ext/terra@21.0.4-canary.870.14203885986.0
  yarn add @magic-ext/tezos@24.0.4-canary.870.14203885986.0
  yarn add @magic-ext/web3modal-ethers5@1.0.4-canary.870.14203885986.0
  yarn add @magic-ext/webauthn@23.0.4-canary.870.14203885986.0
  yarn add @magic-ext/zilliqa@24.0.4-canary.870.14203885986.0
  yarn add @magic-sdk/commons@25.0.4-canary.870.14203885986.0
  yarn add @magic-sdk/pnp@23.0.5-canary.870.14203885986.0
  yarn add @magic-sdk/provider@29.0.4-canary.870.14203885986.0
  yarn add @magic-sdk/react-native-bare@30.0.4-canary.870.14203885986.0
  yarn add @magic-sdk/react-native-expo@30.0.4-canary.870.14203885986.0
  yarn add magic-sdk@29.0.4-canary.870.14203885986.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
