### PR TITLE
feat: handle dpop error

### DIFF
--- a/packages/@magic-sdk/provider/src/core/json-rpc.ts
+++ b/packages/@magic-sdk/provider/src/core/json-rpc.ts
@@ -1,6 +1,7 @@
-import { JsonRpcRequestPayload, JsonRpcResponsePayload, JsonRpcError } from '@magic-sdk/types';
+import { JsonRpcRequestPayload, JsonRpcResponsePayload, JsonRpcError, RPCErrorCode } from '@magic-sdk/types';
 import { isJsonRpcResponsePayload } from '../util/type-guards';
 import { getPayloadId } from '../util/get-payload-id';
+import { clearKeys } from '../util/web-crypto';
 
 const payloadPreprocessedSymbol = Symbol('Payload pre-processed by Magic SDK');
 
@@ -102,6 +103,10 @@ export class JsonRpcResponse<ResultType = any> {
   }
 
   public get hasError() {
+    // Handle DPOP error and rotate new keys
+    if (this._error?.code === RPCErrorCode.DpopInvalidated) {
+      clearKeys();
+    }
     return typeof this._error !== 'undefined' && this._error !== null;
   }
 

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -132,6 +132,7 @@ export class AuthModule extends BaseModule {
     // Handle DPOP error
     if (handle) {
       handle.on('error', error => {
+        console.log({error});
         if (error?.code === -32603 && error?.message === 'DPOP signature validation error') {
           clearKeys();
         }

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -20,7 +20,6 @@ import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { SDKEnvironment } from '../core/sdk-environment';
 import { isMajorVersionAtLeast } from '../util/version-check';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
-import { clearKeys } from '../util';
 
 export const ProductConsolidationMethodRemovalVersions = {
   'magic-sdk': 'v18.0.0',
@@ -129,14 +128,6 @@ export class AuthModule extends BaseModule {
       });
     }
 
-    // Handle DPOP error
-    if (handle) {
-      handle.on('error', error => {
-        if (error?.message === 'DPOP signature validation error') {
-          clearKeys();
-        }
-      });
-    }
     return handle;
   }
 

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -20,6 +20,7 @@ import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { SDKEnvironment } from '../core/sdk-environment';
 import { isMajorVersionAtLeast } from '../util/version-check';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
+import { clearKeys } from '../util';
 
 export const ProductConsolidationMethodRemovalVersions = {
   'magic-sdk': 'v18.0.0',
@@ -126,6 +127,17 @@ export class AuthModule extends BaseModule {
       handle.on(LoginWithEmailOTPEventEmit.Cancel, () => {
         this.createIntermediaryEvent(LoginWithEmailOTPEventEmit.Cancel, requestPayload.id as any)();
       });
+    }
+
+    // Handle DPOP error
+    if (handle) {
+      handle.catch(error => {
+        console.log({error});
+        if (error?.message === 'DPOP signature validation error') {
+          clearKeys();
+        }
+        throw error
+      })
     }
     return handle;
   }

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -131,12 +131,10 @@ export class AuthModule extends BaseModule {
 
     // Handle DPOP error
     if (handle) {
-      handle.catch(error => {
-        console.log({error});
-        if (error?.message === 'DPOP signature validation error') {
+      handle.on('error', error => {
+        if (error?.code === -32603 && error?.message === 'DPOP signature validation error') {
           clearKeys();
         }
-        throw error
       })
     }
     return handle;

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -132,11 +132,10 @@ export class AuthModule extends BaseModule {
     // Handle DPOP error
     if (handle) {
       handle.on('error', error => {
-        console.log({error});
-        if (error?.code === -32603 && error?.message === 'DPOP signature validation error') {
+        if (error?.message === 'DPOP signature validation error') {
           clearKeys();
         }
-      })
+      });
     }
     return handle;
   }

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -51,11 +51,6 @@ export class BaseModule {
           else throw createMalformedResponseError();
         })
         .catch(err => {
-          // Handle DPOP error and rotate new keys
-          console.log('err', err);
-          if (err?.code === RPCErrorCode.DpopInvalidated) {
-            clearKeys();
-          }
           cleanupEvents();
           reject(err);
         });

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -5,7 +5,6 @@ import {
   MagicPayloadMethod,
   IntermediaryEvents,
   routeToMagicMethods,
-  RPCErrorCode,
 } from '@magic-sdk/types';
 import { createMalformedResponseError, MagicRPCError } from '../core/sdk-exceptions';
 import type { SDKBase } from '../core/sdk';
@@ -13,7 +12,6 @@ import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload } from '.
 import { createPromiEvent } from '../util/promise-tools';
 import type { ViewController } from '../core/view-controller';
 import type { EventsDefinition } from '../util/events';
-import { clearKeys } from '../util/web-crypto';
 
 export class BaseModule {
   constructor(protected sdk: SDKBase) {}

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -13,7 +13,7 @@ import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload } from '.
 import { createPromiEvent } from '../util/promise-tools';
 import type { ViewController } from '../core/view-controller';
 import type { EventsDefinition } from '../util/events';
-import { clearKeys } from '@magic-sdk/provider';
+import { clearKeys } from '../util/web-crypto';
 
 export class BaseModule {
   constructor(protected sdk: SDKBase) {}

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -52,6 +52,7 @@ export class BaseModule {
         })
         .catch(err => {
           // Handle DPOP error and rotate new keys
+          console.log('err', err);
           if (err?.code === RPCErrorCode.DpopInvalidated) {
             clearKeys();
           }

--- a/packages/@magic-sdk/provider/src/modules/base-module.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-module.ts
@@ -5,6 +5,7 @@ import {
   MagicPayloadMethod,
   IntermediaryEvents,
   routeToMagicMethods,
+  RPCErrorCode,
 } from '@magic-sdk/types';
 import { createMalformedResponseError, MagicRPCError } from '../core/sdk-exceptions';
 import type { SDKBase } from '../core/sdk';
@@ -12,6 +13,7 @@ import { createJsonRpcRequestPayload, standardizeJsonRpcRequestPayload } from '.
 import { createPromiEvent } from '../util/promise-tools';
 import type { ViewController } from '../core/view-controller';
 import type { EventsDefinition } from '../util/events';
+import { clearKeys } from '@magic-sdk/provider';
 
 export class BaseModule {
   constructor(protected sdk: SDKBase) {}
@@ -49,6 +51,10 @@ export class BaseModule {
           else throw createMalformedResponseError();
         })
         .catch(err => {
+          // Handle DPOP error and rotate new keys
+          if (err?.code === RPCErrorCode.DpopInvalidated) {
+            clearKeys();
+          }
           cleanupEvents();
           reject(err);
         });

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -19,6 +19,7 @@ export function isWebCryptoSupported() {
 }
 
 export function clearKeys() {
+  console.log('clearing keys');
   removeItem(STORE_KEY_PUBLIC_JWK);
   removeItem(STORE_KEY_PRIVATE_KEY);
 }

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -19,7 +19,6 @@ export function isWebCryptoSupported() {
 }
 
 export function clearKeys() {
-  console.log('clearing keys');
   removeItem(STORE_KEY_PUBLIC_JWK);
   removeItem(STORE_KEY_PRIVATE_KEY);
 }

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -19,7 +19,6 @@ export function isWebCryptoSupported() {
 }
 
 export function clearKeys() {
-  console.log("Clearing keys");
   removeItem(STORE_KEY_PUBLIC_JWK);
   removeItem(STORE_KEY_PRIVATE_KEY);
 }
@@ -116,7 +115,7 @@ function utf8ToBinaryString(str: string) {
 
 function uint8ToUrlBase64(uint8: Uint8Array) {
   let bin = '';
-  uint8.forEach((code) => {
+  uint8.forEach(code => {
     bin += String.fromCharCode(code);
   });
   return binToUrlBase64(bin);

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -19,6 +19,7 @@ export function isWebCryptoSupported() {
 }
 
 export function clearKeys() {
+  console.log("Clearing keys");
   removeItem(STORE_KEY_PUBLIC_JWK);
   removeItem(STORE_KEY_PRIVATE_KEY);
 }

--- a/packages/@magic-sdk/types/src/core/exception-types.ts
+++ b/packages/@magic-sdk/types/src/core/exception-types.ts
@@ -35,6 +35,7 @@ export enum RPCErrorCode {
   InactiveRecipient = -10010,
   AccessDeniedToUser = -10011,
   RedirectLoginComplete = -10015,
+  DpopInvalidated = -10019,
 }
 
 export type ErrorCode = SDKErrorCode | RPCErrorCode;


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/aptos@12.1.0-canary.886.14723677664.0
  npm install @magic-ext/avalanche@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/bitcoin@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/conflux@22.1.0-canary.886.14723677664.0
  npm install @magic-ext/cosmos@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/ed25519@20.1.0-canary.886.14723677664.0
  npm install @magic-ext/farcaster@1.1.0-canary.886.14723677664.0
  npm install @magic-ext/flow@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/gdkms@12.1.0-canary.886.14723677664.0
  npm install @magic-ext/harmony@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/icon@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/kadena@1.1.0-canary.886.14723677664.0
  npm install @magic-ext/near@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/oauth@23.1.0-canary.886.14723677664.0
  npm install @magic-ext/oauth2@11.1.0-canary.886.14723677664.0
  npm install @magic-ext/oidc@12.1.0-canary.886.14723677664.0
  npm install @magic-ext/polkadot@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/react-native-bare-oauth@26.1.0-canary.886.14723677664.0
  npm install @magic-ext/react-native-expo-oauth@26.1.0-canary.886.14723677664.0
  npm install @magic-ext/solana@26.1.0-canary.886.14723677664.0
  npm install @magic-ext/sui@1.1.0-canary.886.14723677664.0
  npm install @magic-ext/taquito@21.1.0-canary.886.14723677664.0
  npm install @magic-ext/terra@21.1.0-canary.886.14723677664.0
  npm install @magic-ext/tezos@24.1.0-canary.886.14723677664.0
  npm install @magic-ext/web3modal-ethers5@1.1.0-canary.886.14723677664.0
  npm install @magic-ext/webauthn@23.1.0-canary.886.14723677664.0
  npm install @magic-ext/zilliqa@24.1.0-canary.886.14723677664.0
  npm install @magic-sdk/commons@25.1.0-canary.886.14723677664.0
  npm install @magic-sdk/pnp@23.1.0-canary.886.14723677664.0
  npm install @magic-sdk/provider@29.1.0-canary.886.14723677664.0
  npm install @magic-sdk/react-native-bare@30.1.0-canary.886.14723677664.0
  npm install @magic-sdk/react-native-expo@30.1.0-canary.886.14723677664.0
  npm install @magic-sdk/types@24.19.0-canary.886.14723677664.0
  npm install magic-sdk@29.1.0-canary.886.14723677664.0
  # or 
  yarn add @magic-ext/algorand@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/aptos@12.1.0-canary.886.14723677664.0
  yarn add @magic-ext/avalanche@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/bitcoin@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/conflux@22.1.0-canary.886.14723677664.0
  yarn add @magic-ext/cosmos@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/ed25519@20.1.0-canary.886.14723677664.0
  yarn add @magic-ext/farcaster@1.1.0-canary.886.14723677664.0
  yarn add @magic-ext/flow@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/gdkms@12.1.0-canary.886.14723677664.0
  yarn add @magic-ext/harmony@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/icon@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/kadena@1.1.0-canary.886.14723677664.0
  yarn add @magic-ext/near@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/oauth@23.1.0-canary.886.14723677664.0
  yarn add @magic-ext/oauth2@11.1.0-canary.886.14723677664.0
  yarn add @magic-ext/oidc@12.1.0-canary.886.14723677664.0
  yarn add @magic-ext/polkadot@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/react-native-bare-oauth@26.1.0-canary.886.14723677664.0
  yarn add @magic-ext/react-native-expo-oauth@26.1.0-canary.886.14723677664.0
  yarn add @magic-ext/solana@26.1.0-canary.886.14723677664.0
  yarn add @magic-ext/sui@1.1.0-canary.886.14723677664.0
  yarn add @magic-ext/taquito@21.1.0-canary.886.14723677664.0
  yarn add @magic-ext/terra@21.1.0-canary.886.14723677664.0
  yarn add @magic-ext/tezos@24.1.0-canary.886.14723677664.0
  yarn add @magic-ext/web3modal-ethers5@1.1.0-canary.886.14723677664.0
  yarn add @magic-ext/webauthn@23.1.0-canary.886.14723677664.0
  yarn add @magic-ext/zilliqa@24.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/commons@25.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/pnp@23.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/provider@29.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/react-native-bare@30.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/react-native-expo@30.1.0-canary.886.14723677664.0
  yarn add @magic-sdk/types@24.19.0-canary.886.14723677664.0
  yarn add magic-sdk@29.1.0-canary.886.14723677664.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
