### PR TITLE
fix: correct @magic-ext packages link in magic-sdk README

### DIFF
--- a/packages/magic-sdk/README.md
+++ b/packages/magic-sdk/README.md
@@ -78,7 +78,7 @@ These are packages _you_ can install to enable Magic JS SDK functionality for yo
 
 ## Extensions
 
-Extend Magic JS SDK functionality for your use-case through [`@magic-ext/*` packages](./packages/@magic-ext).
+Extend Magic JS SDK functionality for your use-case through [`@magic-ext/*` packages](../@magic-ext).
 
 ### Internals
 


### PR DESCRIPTION
Fixed incorrect relative path to @magic-ext packages in magic-sdk README.md.
Changed from ./packages/@magic-ext to ../@magic-ext to properly reference
the @magic-ext directory from the magic-sdk package context.

This resolves the broken link that was causing file not found errors.