### PR TITLE
remove instance of Extension check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn wsrun:all --concurrency 1 --changedSince HEAD -c lint-staged
+npx yarn wsrun:all --concurrency 1 --changedSince HEAD -c lint-staged

--- a/packages/@magic-sdk/provider/src/core/sdk.ts
+++ b/packages/@magic-sdk/provider/src/core/sdk.ts
@@ -13,7 +13,7 @@ import { ThirdPartyWalletsModule } from '../modules/third-party-wallets';
 import { RPCProviderModule } from '../modules/rpc-provider';
 import { ViewController } from './view-controller';
 import { createURL } from '../util/url';
-import { BaseExtension, Extension } from '../modules/base-extension';
+import { BaseExtension } from '../modules/base-extension';
 import { isEmpty } from '../util/type-guards';
 import { SDKEnvironment, sdkNameToEnvName } from './sdk-environment';
 import { NFTModule } from '../modules/nft';
@@ -72,9 +72,7 @@ function prepareExtensions(this: SDKBase, options?: MagicSDKAdditionalConfigurat
           // Only apply extensions with a known, defined `name` parameter.
           (this as any)[ext.name] = ext;
         }
-        if (ext instanceof Extension.Internal) {
-          if (!isEmpty(ext.config)) extConfig[ext.name] = ext.config;
-        }
+        if (!isEmpty(ext.config)) extConfig[ext.name] = ext.config;
       } else {
         incompatibleExtensions.push(ext);
       }
@@ -85,9 +83,7 @@ function prepareExtensions(this: SDKBase, options?: MagicSDKAdditionalConfigurat
         extensions[name].init(this);
         const ext = extensions[name];
         (this as any)[name] = ext;
-        if (ext instanceof Extension.Internal) {
-          if (!isEmpty(ext.config)) extConfig[extensions[name].name] = ext.config;
-        }
+        if (!isEmpty(ext.config)) extConfig[extensions[name].name] = ext.config;
       } else {
         incompatibleExtensions.push(extensions[name]);
       }

--- a/packages/@magic-sdk/provider/src/modules/base-extension.ts
+++ b/packages/@magic-sdk/provider/src/modules/base-extension.ts
@@ -22,7 +22,7 @@ function getPrototypeChain<T extends BaseExtension<string>>(instance: T) {
   return protos;
 }
 
-export abstract class BaseExtension<TName extends string> extends BaseModule {
+export abstract class BaseExtension<TName extends string, TConfig extends any = any> extends BaseModule {
   /**
    * A structure describing the platform and version compatibility of this
    * extension.
@@ -35,6 +35,7 @@ export abstract class BaseExtension<TName extends string> extends BaseModule {
   };
 
   public abstract readonly name: TName;
+  public abstract readonly config: TConfig;
 
   private __sdk_access_field_descriptors__ = new Map<
     string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,7 +3483,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3492,8 +3492,8 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
-    "@magic-sdk/commons": ^25.3.0
-    "@magic-sdk/provider": ^29.3.0
+    "@magic-sdk/commons": ^25.4.0
+    "@magic-sdk/provider": ^29.4.0
     aptos: ^1.8.5
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^2.2.0
@@ -3505,7 +3505,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3513,7 +3513,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3521,7 +3521,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3529,7 +3529,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3537,7 +3537,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3545,7 +3545,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3553,7 +3553,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -3566,8 +3566,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/commons": ^25.4.0
+    "@magic-sdk/types": ^24.21.0
   languageName: unknown
   linkType: soft
 
@@ -3575,7 +3575,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3593,7 +3593,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3601,7 +3601,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3609,7 +3609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3617,17 +3617,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
   linkType: soft
 
-"@magic-ext/oauth@^23.3.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
+"@magic-ext/oauth@^23.4.0, @magic-ext/oauth@workspace:packages/@magic-ext/oauth":
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth@workspace:packages/@magic-ext/oauth"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -3637,7 +3637,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3645,7 +3645,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3653,8 +3653,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^30.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/react-native-bare": ^30.4.0
+    "@magic-sdk/types": ^24.21.0
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
     react-native-device-info: ^10.3.0
@@ -3669,7 +3669,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^30.3.0
+    "@magic-sdk/react-native-expo": ^30.4.0
     "@magic-sdk/types": ^10.0.0
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -3684,7 +3684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3695,7 +3695,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3703,7 +3703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3711,7 +3711,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3719,7 +3719,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3727,7 +3727,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/web3modal-ethers5@workspace:packages/@magic-ext/web3modal-ethers5"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
     "@magic-sdk/types": 24.0.6-canary.742.10067162636.0
     "@web3modal/ethers5": 5.0.3
     ethers: 5.7.2
@@ -3738,7 +3738,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
@@ -3746,16 +3746,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
+    "@magic-sdk/commons": ^25.4.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/commons@^25.3.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
+"@magic-sdk/commons@^25.4.0, @magic-sdk/commons@workspace:packages/@magic-sdk/commons":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/commons@workspace:packages/@magic-sdk/commons"
   dependencies:
-    "@magic-sdk/provider": ^29.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/provider": ^29.4.0
+    "@magic-sdk/types": ^24.21.0
   peerDependencies:
     "@magic-sdk/provider": ">=18.6.0"
     "@magic-sdk/types": ">=15.8.0"
@@ -3777,17 +3777,17 @@ __metadata:
   resolution: "@magic-sdk/pnp@workspace:packages/@magic-sdk/pnp"
   dependencies:
     "@babel/plugin-proposal-optional-chaining": ^7.9.0
-    "@magic-ext/oauth": ^23.3.0
-    magic-sdk: ^29.3.0
+    "@magic-ext/oauth": ^23.4.0
+    magic-sdk: ^29.4.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^29.3.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^29.4.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/types": ^24.21.0
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
     tslib: ^2.3.1
@@ -3796,15 +3796,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^30.3.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^30.4.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
     "@babel/plugin-transform-class-static-block": ^7.26.0
-    "@magic-sdk/commons": ^25.3.0
-    "@magic-sdk/provider": ^29.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/commons": ^25.4.0
+    "@magic-sdk/provider": ^29.4.0
+    "@magic-sdk/types": ^24.21.0
     "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/babel-preset": ^0.79.0
@@ -3835,16 +3835,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^30.3.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^30.4.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
     "@babel/plugin-transform-class-static-block": ^7.26.0
     "@babel/preset-env": ^7.26.9
-    "@magic-sdk/commons": ^25.3.0
-    "@magic-sdk/provider": ^29.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/commons": ^25.4.0
+    "@magic-sdk/provider": ^29.4.0
+    "@magic-sdk/types": ^24.21.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/assets-registry": ^0.78.2
@@ -3878,7 +3878,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^24.20.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^24.21.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -14857,13 +14857,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"magic-sdk@^29.3.0, magic-sdk@workspace:packages/magic-sdk":
+"magic-sdk@^29.4.0, magic-sdk@workspace:packages/magic-sdk":
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
-    "@magic-sdk/commons": ^25.3.0
-    "@magic-sdk/provider": ^29.3.0
-    "@magic-sdk/types": ^24.20.0
+    "@magic-sdk/commons": ^25.4.0
+    "@magic-sdk/provider": ^29.4.0
+    "@magic-sdk/types": ^24.21.0
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/aptos@12.4.1-canary.914.16661411429.0
  npm install @magic-ext/avalanche@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/bitcoin@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/conflux@22.4.1-canary.914.16661411429.0
  npm install @magic-ext/cosmos@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/ed25519@20.4.1-canary.914.16661411429.0
  npm install @magic-ext/farcaster@1.4.1-canary.914.16661411429.0
  npm install @magic-ext/flow@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/gdkms@12.4.1-canary.914.16661411429.0
  npm install @magic-ext/harmony@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/icon@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/kadena@1.4.1-canary.914.16661411429.0
  npm install @magic-ext/near@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/oauth@23.4.1-canary.914.16661411429.0
  npm install @magic-ext/oauth2@11.4.1-canary.914.16661411429.0
  npm install @magic-ext/oidc@12.4.1-canary.914.16661411429.0
  npm install @magic-ext/polkadot@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/react-native-bare-oauth@26.4.1-canary.914.16661411429.0
  npm install @magic-ext/react-native-expo-oauth@26.4.1-canary.914.16661411429.0
  npm install @magic-ext/solana@26.4.1-canary.914.16661411429.0
  npm install @magic-ext/sui@1.4.1-canary.914.16661411429.0
  npm install @magic-ext/taquito@21.4.1-canary.914.16661411429.0
  npm install @magic-ext/terra@21.4.1-canary.914.16661411429.0
  npm install @magic-ext/tezos@24.4.1-canary.914.16661411429.0
  npm install @magic-ext/web3modal-ethers5@1.4.1-canary.914.16661411429.0
  npm install @magic-ext/webauthn@23.4.1-canary.914.16661411429.0
  npm install @magic-ext/zilliqa@24.4.1-canary.914.16661411429.0
  npm install @magic-sdk/commons@25.4.1-canary.914.16661411429.0
  npm install @magic-sdk/pnp@23.4.1-canary.914.16661411429.0
  npm install @magic-sdk/provider@29.4.1-canary.914.16661411429.0
  npm install @magic-sdk/react-native-bare@30.4.1-canary.914.16661411429.0
  npm install @magic-sdk/react-native-expo@30.4.1-canary.914.16661411429.0
  npm install magic-sdk@29.4.1-canary.914.16661411429.0
  # or 
  yarn add @magic-ext/algorand@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/aptos@12.4.1-canary.914.16661411429.0
  yarn add @magic-ext/avalanche@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/bitcoin@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/conflux@22.4.1-canary.914.16661411429.0
  yarn add @magic-ext/cosmos@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/ed25519@20.4.1-canary.914.16661411429.0
  yarn add @magic-ext/farcaster@1.4.1-canary.914.16661411429.0
  yarn add @magic-ext/flow@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/gdkms@12.4.1-canary.914.16661411429.0
  yarn add @magic-ext/harmony@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/icon@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/kadena@1.4.1-canary.914.16661411429.0
  yarn add @magic-ext/near@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/oauth@23.4.1-canary.914.16661411429.0
  yarn add @magic-ext/oauth2@11.4.1-canary.914.16661411429.0
  yarn add @magic-ext/oidc@12.4.1-canary.914.16661411429.0
  yarn add @magic-ext/polkadot@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/react-native-bare-oauth@26.4.1-canary.914.16661411429.0
  yarn add @magic-ext/react-native-expo-oauth@26.4.1-canary.914.16661411429.0
  yarn add @magic-ext/solana@26.4.1-canary.914.16661411429.0
  yarn add @magic-ext/sui@1.4.1-canary.914.16661411429.0
  yarn add @magic-ext/taquito@21.4.1-canary.914.16661411429.0
  yarn add @magic-ext/terra@21.4.1-canary.914.16661411429.0
  yarn add @magic-ext/tezos@24.4.1-canary.914.16661411429.0
  yarn add @magic-ext/web3modal-ethers5@1.4.1-canary.914.16661411429.0
  yarn add @magic-ext/webauthn@23.4.1-canary.914.16661411429.0
  yarn add @magic-ext/zilliqa@24.4.1-canary.914.16661411429.0
  yarn add @magic-sdk/commons@25.4.1-canary.914.16661411429.0
  yarn add @magic-sdk/pnp@23.4.1-canary.914.16661411429.0
  yarn add @magic-sdk/provider@29.4.1-canary.914.16661411429.0
  yarn add @magic-sdk/react-native-bare@30.4.1-canary.914.16661411429.0
  yarn add @magic-sdk/react-native-expo@30.4.1-canary.914.16661411429.0
  yarn add magic-sdk@29.4.1-canary.914.16661411429.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
