### PR TITLE
fix(typo): correct "oauthAuthoriationURI" to "oauthAuthorizationURI"

### DIFF
--- a/packages/@magic-ext/oauth2/src/index.ts
+++ b/packages/@magic-ext/oauth2/src/index.ts
@@ -58,11 +58,11 @@ export class OAuthExtension extends Extension.Internal<'oauth2'> {
         );
       }
 
-      if (successResult?.oauthAuthoriationURI) {
+      if (successResult?.oauthAuthorizationURI) {
         const redirectURI = successResult.useMagicServerCallback
           ? // @ts-ignore - this.sdk.endpoint is marked protected but we need to access it.
-            new URL(successResult.oauthAuthoriationURI, this.sdk.endpoint).href
-          : successResult.oauthAuthoriationURI;
+            new URL(successResult.oauthAuthorizationURI, this.sdk.endpoint).href
+          : successResult.oauthAuthorizationURI;
 
         if (successResult?.shouldReturnURI) {
           resolve(redirectURI);

--- a/packages/@magic-ext/oauth2/src/types.ts
+++ b/packages/@magic-ext/oauth2/src/types.ts
@@ -71,7 +71,7 @@ export type OpenIDConnectUserInfo = OpenIDConnectProfile &
   OpenIDConnectAddress & { sub?: string; sources?: Record<string, any> } & Record<string, any>;
 
 export interface OAuthRedirectStartResult {
-  oauthAuthoriationURI?: string;
+  oauthAuthorizationURI?: string;
   useMagicServerCallback?: boolean;
   shouldReturnURI?: boolean;
 }


### PR DESCRIPTION
Fixed a consistent typo in variable/property names:

Replaced oauthAuthoriationURI → oauthAuthorizationURI in:

- packages/@magic-ext/oauth2/src/index.ts

- packages/@magic-ext/oauth2/src/types.ts