### PR TITLE
 fix typo in test descriptions

### DIFF
--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
@@ -102,7 +102,7 @@ afterEach(() => {
   FAKE_STORE = {};
 });
 
-test('Sends payload; recieves MAGIC_HANDLE_REQUEST event; resolves response', async () => {
+test('Sends payload; receives MAGIC_HANDLE_REQUEST event; resolves response', async () => {
   createJwtStub.mockImplementationOnce(() => Promise.resolve(FAKE_JWT_TOKEN));
   const { handlerSpy, onSpy } = stubViewController(viewController, [
     [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
@@ -284,7 +284,7 @@ test('does not call web crypto api if platform is not web', async () => {
   expect(response).toEqual(new JsonRpcResponse(responseEvent().data.response));
 });
 
-test('Sends payload recieves MAGIC_HANDLE_REQUEST event; skips payloads with non-matching ID; resolves response', async () => {
+test('Sends payload receives MAGIC_HANDLE_REQUEST event; skips payloads with non-matching ID; resolves response', async () => {
   const { handlerSpy, onSpy } = stubViewController(viewController, [
     [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent({ id: 1234 })], // Should be skipped
     [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],


### PR DESCRIPTION


# Description
## Summary
Fixed a spelling error in test case descriptions within the post controller test file.

## Changes
- **File:** `packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts`
- **Lines:** 105, 287
- **Fix:** Corrected "recieves" to "receives" in two test descriptions

