### PR TITLE
docs: update Magic Login Form documentation link

### DIFF
--- a/packages/@magic-sdk/pnp/README.md
+++ b/packages/@magic-sdk/pnp/README.md
@@ -12,7 +12,7 @@
 
 ## 📖 Documentation
 
-See the [developer documentation](https://magic.link/docs/login-form) to learn how you can build with Magic Login Form in a matter of minutes.
+See the [developer documentation](https://magic.link/docs/authentication/customization/login-ui) to learn how you can build with Magic Login Form in a matter of minutes.
 
 ## ⚡️ Quick Start (using `<script>` tags)
 


### PR DESCRIPTION
Replaced outdated documentation URL in packages/@magic-sdk/pnp/README.md with the updated link to the customization guide for the Login UI.
