### PR TITLE
patch: array sorting to ensure `magic-sdk` comes first

### DIFF
--- a/scripts/utils/workspace-helpers.ts
+++ b/scripts/utils/workspace-helpers.ts
@@ -38,7 +38,11 @@ export async function promptForPackage(options: { allowAll?: boolean } = {}) {
   const sdkPkgs = packages
     .filter((i) => i.includes('@magic-sdk') || i === 'magic-sdk')
     // sort `magic-sdk` first
-    .sort((i) => (i.startsWith('@') ? 0 : -1));
+    .sort((a, b) => {
+      if (a === 'magic-sdk') return -1;
+      if (b === 'magic-sdk') return 1;
+      return 0;
+    });
 
   const sep = { role: 'separator' };
 


### PR DESCRIPTION
### 📦 Pull Request

noticed the array wasn't always sorting correctly because the `sort` callback only received one parameter in some cases.

this change explicitly compares two elements (`a` and `b`) so that `magic-sdk` always ends up at the start of the list, with everything else following.

it should make the ordering consistent and predictable.

