### PR TITLE
docs: fix typos in comments

### DIFF
--- a/packages/@magic-sdk/pnp/src/context/callback.ts
+++ b/packages/@magic-sdk/pnp/src/context/callback.ts
@@ -42,7 +42,7 @@ export async function callback(): Promise<void> {
 
   /**
    * Generically handles auth callback for methods where
-   * a redirect in not applicable. Examples include:
+   * a redirect is not applicable. Examples include:
    *
    * - SMS login
    * - Magic link login w/o `redirectURI`

--- a/packages/@magic-sdk/provider/src/core/json-rpc.ts
+++ b/packages/@magic-sdk/provider/src/core/json-rpc.ts
@@ -8,7 +8,7 @@ const payloadPreprocessedSymbol = Symbol('Payload pre-processed by Magic SDK');
 /**
  * To avoid "pre-processing" a payload more than once (and needlessly
  * incrementing our payload ID generator), we attach a symbol to detect a
- * payloads we've already visited.
+ * payload we've already visited.
  */
 function markPayloadAsPreprocessed<T extends Partial<JsonRpcRequestPayload>>(payload: T): T {
   Object.defineProperty(payload, payloadPreprocessedSymbol, {


### PR DESCRIPTION
- Corrected grammar in `callback.ts` ("a redirect is not applicable").
- Fixed wording in `json-rpc.ts` ("payload we've already visited").
