### PR TITLE
Make `RPCProviderModule` compatible with `viem` `EIP1193Provider`

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/rpc-provider.ts
+++ b/packages/@magic-sdk/provider/src/modules/rpc-provider.ts
@@ -120,7 +120,7 @@ export class RPCProviderModule extends BaseModule implements TypedEmitter {
    * Here, we wrap `BaseModule.request` with an additional check
    * to determine if the RPC method requires a test-mode prefix.
    */
-  protected request<ResultType = any, Events extends EventsDefinition = void>(payload: Partial<JsonRpcRequestPayload>) {
+  public request<ResultType = any, Events extends EventsDefinition = void>(payload: Partial<JsonRpcRequestPayload>) {
     this.prefixPayloadMethodForTestMode(payload);
     return super.request<ResultType, Events>(payload);
   }


### PR DESCRIPTION
### 📦 Pull Request

Making `RPCProviderModule` compatible with `viem` `EIP1193Provider`

### ✅ Fixed Issues
- `patch`: Make `RPCProviderModule` compatible with `viem` `EIP1193Provider`

