### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/@magic-sdk/react-native-bare/README.md
+++ b/packages/@magic-sdk/react-native-bare/README.md
@@ -11,7 +11,7 @@
 </p>
 
 ## ⚠️ Removal of `loginWithMagicLink()`  ⚠️
-As of `v19.0.0`, passcodes (ie. `loginWithSMS()`, `loginWithEmailOTP()`) are replacing Magic Links (ie. `loginWithMagicLink()`) for all of our Mobile SDKs⁠. [Learn more](https://magic.link/docs/auth/login-methods/email/email-link-update-march-2023)
+As of `v19.0.0`, passcodes (ie. `loginWithSMS()`, `loginWithEmailOTP()`) are replacing Magic Links (ie. `loginWithMagicLink()`) for all of our Mobile SDKs⁠. [Learn more](https://magic.link/docs/authentication/login/magic-links)
 
 ## 📖 Documentation
 

--- a/packages/@magic-sdk/react-native-expo/README.md
+++ b/packages/@magic-sdk/react-native-expo/README.md
@@ -10,7 +10,7 @@
  </p>
 
  ## ⚠️ Removal of `loginWithMagicLink()`  ⚠️
-As of `v19.0.0`, passcodes (ie. `loginWithSMS()`, `loginWithEmailOTP()`) are replacing Magic Links (ie. `loginWithMagicLink()`) for all of our Mobile SDKs⁠. [Learn more](https://magic.link/docs/auth/login-methods/email/email-link-update-march-2023)
+As of `v19.0.0`, passcodes (ie. `loginWithSMS()`, `loginWithEmailOTP()`) are replacing Magic Links (ie. `loginWithMagicLink()`) for all of our Mobile SDKs⁠. [Learn more](https://magic.link/docs/authentication/login/magic-links)
 
  ## 📖 Documentation
 


### PR DESCRIPTION
fixed broken link
broken: https://magic.link/docs/auth/login-methods/email/email-link-update-march-2023
correct: https://magic.link/docs/authentication/login/magic-links