### PR TITLE
docs: fix typos and improve comments across packages

### DIFF
--- a/packages/@magic-ext/webauthn/src/types.ts
+++ b/packages/@magic-ext/webauthn/src/types.ts
@@ -24,7 +24,7 @@ export interface UpdateWebAuthnInfoConfiguration {
   id: string;
 
   /**
-   *  nickname that user attempts to update to the webauth device associate to the id.
+   *  nickname that user attempts to update to the webauthn device associate to the id.
    */
   nickname: string;
 }

--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -173,7 +173,7 @@ export class IframeController extends ViewController {
     }
 
     if (iframe) {
-      // if iframe exists reload the iframe source
+      // if iframe exists, reload the iframe source
       iframe.src = this.relayerSrc;
     }
   }

--- a/scripts/utils/esbuild.ts
+++ b/scripts/utils/esbuild.ts
@@ -111,7 +111,7 @@ async function getEntrypoint(format?: Format) {
 }
 
 /**
- * During the build step, we create an ephermeral "tsconfig.build.json" file
+ * During the build step, we create an ephemeral "tsconfig.build.json" file
  * containing config overrides to resolve "packages/.../src" as the "rootDir".
  *
  * Why? This is our workaround to avoid tsconfig project references, which make


### PR DESCRIPTION
- Corrected "webauth" → "webauthn" in type definition docstring.  
- Clarified iframe reload comment in `IframeController`.  
- Fixed typo "ephermeral" → "ephemeral" in build utils docstring.