### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/@magic-ext/oauth2/README.md
+++ b/packages/@magic-ext/oauth2/README.md
@@ -12,7 +12,7 @@
 
 ## 📖 Documentation
 
-See the [developer documentation](https://magic.link/docs/social-login) to learn how to get started with OAuth in Magic SDK.
+See the [developer documentation](https://magic.link/docs/authentication/login/social-logins/oauth-implementation) to learn how to get started with OAuth in Magic SDK.
 
 ## 🔗 Installation
 


### PR DESCRIPTION
https://magic.link/docs/social-login - broken
https://magic.link/docs/authentication/login/social-logins/oauth-implementation - works