### PR TITLE
chore: remove leftover debug field from iframe controller

### DIFF
--- a/packages/magic-sdk/src/iframe-controller.ts
+++ b/packages/magic-sdk/src/iframe-controller.ts
@@ -55,7 +55,6 @@ export class IframeController extends ViewController {
    * Initializes the underlying `Window.onmessage` event listener.
    */
   protected init() {
-    (this as any).test = 'hello';
     this.iframe = new Promise(resolve => {
       const onload = () => {
         if (!checkForSameSrcInstances(encodeURIComponent(this.parameters))) {


### PR DESCRIPTION
This removes a stray test field assignment from the iframe controller init method. The property is never read anywhere in the codebase and was likely introduced as temporary debug state, so keeping it adds noise to the public surface of the view controller without any functional benefit.