### PR TITLE
Align test mode prefix comment with implementation

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/rpc-provider.ts
+++ b/packages/@magic-sdk/provider/src/modules/rpc-provider.ts
@@ -131,7 +131,7 @@ export class RPCProviderModule extends BaseModule implements TypedEmitter {
   private prefixPayloadMethodForTestMode(payload: Partial<JsonRpcRequestPayload>) {
     const testModePrefix = 'testMode/eth/';
 
-    // In test mode, we prefix all RPC methods with `test/` so that the
+    // In test mode, we prefix all RPC methods with `testMode/eth/` so that the
     // Magic <iframe> can handle them without requiring network calls.
     if (this.sdk.testMode) {
       payload.method = `${testModePrefix}${payload.method}`;


### PR DESCRIPTION
The previous comment in prefixPayloadMethodForTestMode stated that test mode prefixes RPC methods with test/, while the actual implementation uses the testMode/eth/ prefix. This change updates the comment to accurately reflect the real prefix to avoid confusion for integrators and reviewers