### PR TITLE
fix name for request override

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/third-party-wallets.ts
+++ b/packages/@magic-sdk/provider/src/modules/third-party-wallets.ts
@@ -201,8 +201,8 @@ export class ThirdPartyWalletsModule extends BaseModule {
 
     if (isEthRequest || SIGN_REQUESTS.includes(payload.method as string)) {
       return createPromiEvent<unknown>((resolve, reject) => {
-        // @ts-expect-error Property 'magicWidget' does not exist on type 'SDKBase'.
-        this.sdk.magicWidget
+        // @ts-expect-error Property 'walletKit' does not exist on type 'SDKBase'.
+        this.sdk.walletKit
           .walletRequest(payload)
           .then(resolve)
           .catch((error: unknown) => reject(new MagicRPCError(error as JsonRpcError)));
@@ -215,8 +215,8 @@ export class ThirdPartyWalletsModule extends BaseModule {
   private magicWidgetLogout(payload: Partial<JsonRpcRequestPayload>): PromiEvent<boolean> {
     return createPromiEvent<boolean>(async resolve => {
       try {
-        // @ts-expect-error Property 'magicWidget' does not exist on type 'SDKBase'.
-        this.sdk.magicWidget.clearConnectedState();
+        // @ts-expect-error Property 'walletKit' does not exist on type 'SDKBase'.
+        this.sdk.walletKit.clearConnectedState();
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/aptos@16.2.1-canary.1024.21648263125.0
  npm install @magic-ext/avalanche@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/bitcoin@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/conflux@26.2.1-canary.1024.21648263125.0
  npm install @magic-ext/cosmos@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/ed25519@24.2.1-canary.1024.21648263125.0
  npm install @magic-ext/evm@1.1.1-canary.1024.21648263125.0
  npm install @magic-ext/farcaster@5.2.1-canary.1024.21648263125.0
  npm install @magic-ext/flow@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/gdkms@16.2.1-canary.1024.21648263125.0
  npm install @magic-ext/harmony@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/hedera@2.1.1-canary.1024.21648263125.0
  npm install @magic-ext/icon@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/kadena@5.2.1-canary.1024.21648263125.0
  npm install @magic-ext/near@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/oauth2@15.2.1-canary.1024.21648263125.0
  npm install @magic-ext/oidc@16.2.1-canary.1024.21648263125.0
  npm install @magic-ext/polkadot@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/siwe@3.2.1-canary.1024.21648263125.0
  npm install @magic-ext/solana@30.2.1-canary.1024.21648263125.0
  npm install @magic-ext/sui@5.2.1-canary.1024.21648263125.0
  npm install @magic-ext/taquito@25.2.1-canary.1024.21648263125.0
  npm install @magic-ext/terra@25.2.1-canary.1024.21648263125.0
  npm install @magic-ext/tezos@28.2.1-canary.1024.21648263125.0
  npm install @magic-ext/wallet-kit@0.2.1-canary.1024.21648263125.0
  npm install @magic-ext/webauthn@27.2.1-canary.1024.21648263125.0
  npm install @magic-ext/zilliqa@28.2.1-canary.1024.21648263125.0
  npm install @magic-sdk/provider@33.3.1-canary.1024.21648263125.0
  npm install magic-sdk@33.3.1-canary.1024.21648263125.0
  # or 
  yarn add @magic-ext/algorand@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/aptos@16.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/avalanche@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/bitcoin@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/conflux@26.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/cosmos@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/ed25519@24.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/evm@1.1.1-canary.1024.21648263125.0
  yarn add @magic-ext/farcaster@5.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/flow@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/gdkms@16.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/harmony@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/hedera@2.1.1-canary.1024.21648263125.0
  yarn add @magic-ext/icon@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/kadena@5.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/near@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/oauth2@15.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/oidc@16.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/polkadot@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/siwe@3.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/solana@30.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/sui@5.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/taquito@25.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/terra@25.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/tezos@28.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/wallet-kit@0.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/webauthn@27.2.1-canary.1024.21648263125.0
  yarn add @magic-ext/zilliqa@28.2.1-canary.1024.21648263125.0
  yarn add @magic-sdk/provider@33.3.1-canary.1024.21648263125.0
  yarn add magic-sdk@33.3.1-canary.1024.21648263125.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
