### PR TITLE
adds send 7702 transaction

### DIFF
--- a/packages/@magic-sdk/provider/src/modules/wallet.ts
+++ b/packages/@magic-sdk/provider/src/modules/wallet.ts
@@ -5,6 +5,8 @@ import {
   ShowUIPromiEvents,
   Sign7702AuthorizationRequest,
   Sign7702AuthorizationResponse,
+  Send7702TransactionRequest,
+  Send7702TransactionResponse,
 } from '@magic-sdk/types';
 import { BaseModule } from './base-module';
 import { createJsonRpcRequestPayload } from '../core/json-rpc';
@@ -90,6 +92,35 @@ export class WalletModule extends BaseModule {
   public sign7702Authorization(params: Sign7702AuthorizationRequest) {
     return this.request<Sign7702AuthorizationResponse>(
       createJsonRpcRequestPayload(MagicPayloadMethod.Sign7702Authorization, [params]),
+    );
+  }
+
+  /**
+   * Send an EIP-7702 (Type-4) transaction with an authorization list.
+   * This allows executing transactions with delegated smart contract implementations.
+   *
+   * @param params - The transaction parameters including to, value, data, gas settings, and authorizationList
+   * @returns Promise resolving to the transaction hash
+   *
+   * @example
+   * ```typescript
+   * // First, sign the authorization
+   * const auth = await magic.wallet.sign7702Authorization({
+   *   contractAddress: '0x000000004F43C49e93C970E84001853a70923B03',
+   *   chainId: 1,
+   * });
+   *
+   * // Then, send the transaction with the authorization
+   * const { transactionHash } = await magic.wallet.send7702Transaction({
+   *   to: '0x...',
+   *   data: '0x...',
+   *   authorizationList: [auth],
+   * });
+   * ```
+   */
+  public send7702Transaction(params: Send7702TransactionRequest) {
+    return this.request<Send7702TransactionResponse>(
+      createJsonRpcRequestPayload(MagicPayloadMethod.Send7702Transaction, [params]),
     );
   }
 }

--- a/packages/@magic-sdk/types/src/core/json-rpc-types.ts
+++ b/packages/@magic-sdk/types/src/core/json-rpc-types.ts
@@ -130,6 +130,7 @@ export enum MagicPayloadMethod {
   DisableMFA = 'magic_auth_disable_mfa_flow',
   GetMultichainPublicAddress = 'magic_get_multichain_public_address',
   Sign7702Authorization = 'magic_wallet_sign_7702_authorization',
+  Send7702Transaction = 'eth_send7702Transaction',
 }
 
 // Methods to not route if connected to third party wallet

--- a/packages/@magic-sdk/types/src/modules/wallet-types.ts
+++ b/packages/@magic-sdk/types/src/modules/wallet-types.ts
@@ -68,3 +68,63 @@ export interface Sign7702AuthorizationResponse {
    */
   signature?: string;
 }
+
+/**
+ * Request parameters for sending an EIP-7702 transaction with authorization list
+ */
+export interface Send7702TransactionRequest {
+  /**
+   * The recipient address
+   */
+  to: string;
+
+  /**
+   * The value to send in wei (as hex string)
+   */
+  value?: string;
+
+  /**
+   * The transaction data (calldata)
+   */
+  data?: string;
+
+  /**
+   * Gas limit for the transaction (as hex string)
+   */
+  gas?: string;
+
+  /**
+   * Gas limit for the transaction (alias for gas)
+   */
+  gasLimit?: string;
+
+  /**
+   * Maximum fee per gas for EIP-1559 transactions (as hex string)
+   */
+  maxFeePerGas?: string;
+
+  /**
+   * Maximum priority fee per gas for EIP-1559 transactions (as hex string)
+   */
+  maxPriorityFeePerGas?: string;
+
+  /**
+   * Transaction nonce (if not provided, will be fetched from network)
+   */
+  nonce?: number;
+
+  /**
+   * The list of signed EIP-7702 authorizations to include in the transaction
+   */
+  authorizationList: Sign7702AuthorizationResponse[];
+}
+
+/**
+ * Response from sending an EIP-7702 transaction
+ */
+export interface Send7702TransactionResponse {
+  /**
+   * The transaction hash
+   */
+  transactionHash: string;
+}


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/aptos@16.3.0-canary.1030.21726285866.0
  npm install @magic-ext/avalanche@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/bitcoin@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/conflux@26.3.0-canary.1030.21726285866.0
  npm install @magic-ext/cosmos@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/ed25519@24.3.0-canary.1030.21726285866.0
  npm install @magic-ext/evm@1.2.0-canary.1030.21726285866.0
  npm install @magic-ext/farcaster@5.3.0-canary.1030.21726285866.0
  npm install @magic-ext/flow@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/gdkms@16.3.0-canary.1030.21726285866.0
  npm install @magic-ext/harmony@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/hedera@2.2.0-canary.1030.21726285866.0
  npm install @magic-ext/icon@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/kadena@5.3.0-canary.1030.21726285866.0
  npm install @magic-ext/near@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/oauth2@15.3.0-canary.1030.21726285866.0
  npm install @magic-ext/oidc@16.3.0-canary.1030.21726285866.0
  npm install @magic-ext/polkadot@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/react-native-bare-oauth@30.3.0-canary.1030.21726285866.0
  npm install @magic-ext/react-native-expo-oauth@30.3.0-canary.1030.21726285866.0
  npm install @magic-ext/siwe@3.3.0-canary.1030.21726285866.0
  npm install @magic-ext/solana@30.3.0-canary.1030.21726285866.0
  npm install @magic-ext/sui@5.3.0-canary.1030.21726285866.0
  npm install @magic-ext/taquito@25.3.0-canary.1030.21726285866.0
  npm install @magic-ext/terra@25.3.0-canary.1030.21726285866.0
  npm install @magic-ext/tezos@28.3.0-canary.1030.21726285866.0
  npm install @magic-ext/wallet-kit@0.3.0-canary.1030.21726285866.0
  npm install @magic-ext/webauthn@27.3.0-canary.1030.21726285866.0
  npm install @magic-ext/zilliqa@28.3.0-canary.1030.21726285866.0
  npm install @magic-sdk/provider@33.4.0-canary.1030.21726285866.0
  npm install @magic-sdk/react-native-bare@34.2.0-canary.1030.21726285866.0
  npm install @magic-sdk/react-native-expo@34.2.0-canary.1030.21726285866.0
  npm install @magic-sdk/types@27.4.0-canary.1030.21726285866.0
  npm install magic-sdk@33.4.0-canary.1030.21726285866.0
  # or 
  yarn add @magic-ext/algorand@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/aptos@16.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/avalanche@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/bitcoin@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/conflux@26.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/cosmos@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/ed25519@24.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/evm@1.2.0-canary.1030.21726285866.0
  yarn add @magic-ext/farcaster@5.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/flow@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/gdkms@16.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/harmony@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/hedera@2.2.0-canary.1030.21726285866.0
  yarn add @magic-ext/icon@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/kadena@5.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/near@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/oauth2@15.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/oidc@16.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/polkadot@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/react-native-bare-oauth@30.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/react-native-expo-oauth@30.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/siwe@3.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/solana@30.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/sui@5.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/taquito@25.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/terra@25.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/tezos@28.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/wallet-kit@0.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/webauthn@27.3.0-canary.1030.21726285866.0
  yarn add @magic-ext/zilliqa@28.3.0-canary.1030.21726285866.0
  yarn add @magic-sdk/provider@33.4.0-canary.1030.21726285866.0
  yarn add @magic-sdk/react-native-bare@34.2.0-canary.1030.21726285866.0
  yarn add @magic-sdk/react-native-expo@34.2.0-canary.1030.21726285866.0
  yarn add @magic-sdk/types@27.4.0-canary.1030.21726285866.0
  yarn add magic-sdk@33.4.0-canary.1030.21726285866.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
