### PR TITLE
feat: duplicate webauthn package as new passkey package

### DIFF
--- a/packages/@magic-ext/passkey/.lintstagedrc.yml
+++ b/packages/@magic-ext/passkey/.lintstagedrc.yml
@@ -1,0 +1,2 @@
+'*.{ts,tsx}':
+  - eslint --fix

--- a/packages/@magic-ext/passkey/.prettierrc.js
+++ b/packages/@magic-ext/passkey/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../.prettierrc.js');

--- a/packages/@magic-ext/passkey/CHANGELOG.md
+++ b/packages/@magic-ext/passkey/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/@magic-ext/passkey/LICENSE
+++ b/packages/@magic-ext/passkey/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/@magic-ext/passkey/README.md
+++ b/packages/@magic-ext/passkey/README.md
@@ -1,0 +1,8 @@
+# Magic Extension Passkey
+
+## Installation
+```bash
+npm i magic-sdk @magic-ext/passkey
+```
+
+###

--- a/packages/@magic-ext/passkey/eslint.config.mjs
+++ b/packages/@magic-ext/passkey/eslint.config.mjs
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import rootEslintConfig from '../../../eslint.config.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default [
+  ...rootEslintConfig,
+  {
+    ignores: ['node_modules', 'coverage', 'dist', 'eslint.config.mjs', 'jest.config.ts'],
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: __dirname,
+      },
+    },
+  },
+];

--- a/packages/@magic-ext/passkey/package.json
+++ b/packages/@magic-ext/passkey/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@magic-ext/passkey",
+  "version": "1.0.0",
+  "description": "Magic SDK Passkey Extension",
+  "author": "Magic <team@magic.link> (https://magic.link/)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/magiclabs/magic-js"
+  },
+  "files": [
+    "dist"
+  ],
+  "target": "neutral",
+  "cdnGlobalName": "MagicPasskeyExtension",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/types/index.d.ts",
+  "jsdelivr": "./dist/extension.js",
+  "exports": {
+    "import": "./dist/es/index.mjs",
+    "types": "./dist/types/index.d.ts",
+    "require": "./dist/cjs/index.js"
+  },
+  "externals": {
+    "include": [
+      "@magic-sdk/provider"
+    ]
+  },
+  "devDependencies": {
+    "@magic-sdk/provider": "^33.7.0"
+  }
+}

--- a/packages/@magic-ext/passkey/package.json
+++ b/packages/@magic-ext/passkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-ext/passkey",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Magic SDK Passkey Extension",
   "author": "Magic <team@magic.link> (https://magic.link/)",
   "license": "MIT",

--- a/packages/@magic-ext/passkey/src/index.cdn.ts
+++ b/packages/@magic-ext/passkey/src/index.cdn.ts
@@ -1,0 +1,3 @@
+import { PasskeyExtension } from './index';
+
+export default PasskeyExtension;

--- a/packages/@magic-ext/passkey/src/index.native.ts
+++ b/packages/@magic-ext/passkey/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/packages/@magic-ext/passkey/src/index.ts
+++ b/packages/@magic-ext/passkey/src/index.ts
@@ -1,0 +1,142 @@
+import { Extension } from '@magic-sdk/provider';
+import {
+  RegisterNewUserConfiguration,
+  MagicPasskeyPayloadMethod,
+  PasskeySDKErrorCode,
+  LoginWithPasskeyConfiguration,
+} from './types';
+import { PasskeyResult, PasskeyEventHandlers, PasskeyMFAEventEmit, PasskeyMFAEventOnReceived } from '@magic-sdk/types';
+import { toJSON } from './utils/polyfills';
+
+export class PasskeyExtension extends Extension.Internal<'passkey', any> {
+  name = 'passkey' as const;
+  config: any = {};
+
+  private createPasskeyNotSupportError() {
+    this.createError(PasskeySDKErrorCode.PasskeyNotSupported, 'Passkey is not supported in this device.', {});
+  }
+
+  private createPasskeyCreateCredentialError(message: string) {
+    this.createError(PasskeySDKErrorCode.PasskeyRegisterError, `Error creating credential: ${message}`, {});
+  }
+
+  public async registerNewUser(configuration?: RegisterNewUserConfiguration) {
+    if (!window.PublicKeyCredential) {
+      throw this.createPasskeyNotSupportError();
+    }
+    const { username, nickname = '', skipDIDToken, lifespan } = configuration ?? {};
+
+    const { registrationOptions, registrationToken } = await this.request<any>(
+      this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.RegisterPasskeyStart, [{ username }]),
+    );
+
+    let credential;
+    try {
+      credential = (await navigator.credentials.create({
+        publicKey: registrationOptions,
+      })) as any;
+    } catch (err: any) {
+      throw this.createPasskeyCreateCredentialError(err);
+    }
+
+    return this.request<string | null>(
+      this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.RegisterPasskeyVerify, [
+        {
+          registrationToken,
+          registrationResponse: toJSON(credential),
+          nickname,
+          transport: credential.response.getTransports(),
+          userAgent: navigator.userAgent,
+          skipDIDToken,
+          lifespan,
+        },
+      ]),
+    );
+  }
+
+  public login(configuration?: LoginWithPasskeyConfiguration) {
+    const { username, showMfaModal, skipDIDToken, lifespan } = configuration ?? {};
+
+    let verifyPayloadId: string;
+
+    const promiEvent = this.utils.createPromiEvent<PasskeyResult, PasskeyEventHandlers>(async (resolve, reject) => {
+      if (!window.PublicKeyCredential) {
+        return reject(this.createPasskeyNotSupportError());
+      }
+
+      const { authenticationToken, authenticationOptions } = await this.request<any>(
+        this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.LoginWithPasskeyStart, [{ username }]),
+      );
+
+      let assertion;
+      try {
+        assertion = (await navigator.credentials.get({
+          publicKey: authenticationOptions,
+        })) as any;
+      } catch (err: any) {
+        return reject(this.createPasskeyCreateCredentialError(err));
+      }
+
+      const requestPayload = this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.LoginWithPasskeyVerify, [
+        {
+          authenticationToken,
+          assertionResponse: toJSON(assertion),
+          showUI: showMfaModal,
+          skipDIDToken,
+          lifespan,
+        },
+      ]);
+
+      verifyPayloadId = requestPayload.id as string;
+
+      const loginRequest = this.request<PasskeyResult, PasskeyEventHandlers>(requestPayload);
+
+      if (!showMfaModal) {
+        loginRequest.on(PasskeyMFAEventOnReceived.MfaSentHandle, () => {
+          promiEvent.emit(PasskeyMFAEventOnReceived.MfaSentHandle);
+        });
+        loginRequest.on(PasskeyMFAEventOnReceived.InvalidMfaOtp, () => {
+          promiEvent.emit(PasskeyMFAEventOnReceived.InvalidMfaOtp);
+        });
+        loginRequest.on(PasskeyMFAEventOnReceived.RecoveryCodeSentHandle, () => {
+          promiEvent.emit(PasskeyMFAEventOnReceived.RecoveryCodeSentHandle);
+        });
+        loginRequest.on(PasskeyMFAEventOnReceived.InvalidRecoveryCode, () => {
+          promiEvent.emit(PasskeyMFAEventOnReceived.InvalidRecoveryCode);
+        });
+        loginRequest.on(PasskeyMFAEventOnReceived.RecoveryCodeSuccess, () => {
+          promiEvent.emit(PasskeyMFAEventOnReceived.RecoveryCodeSuccess);
+        });
+      }
+
+      try {
+        const result = await loginRequest;
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    if (!showMfaModal && promiEvent) {
+      promiEvent.on(PasskeyMFAEventEmit.VerifyMFACode, (mfa: string) => {
+        this.createIntermediaryEvent(PasskeyMFAEventEmit.VerifyMFACode, verifyPayloadId)(mfa);
+      });
+      promiEvent.on(PasskeyMFAEventEmit.LostDevice, () => {
+        this.createIntermediaryEvent(PasskeyMFAEventEmit.LostDevice, verifyPayloadId)();
+      });
+      promiEvent.on(PasskeyMFAEventEmit.VerifyRecoveryCode, (recoveryCode: string) => {
+        this.createIntermediaryEvent(PasskeyMFAEventEmit.VerifyRecoveryCode, verifyPayloadId)(recoveryCode);
+      });
+      promiEvent.on(PasskeyMFAEventEmit.Cancel, () => {
+        this.createIntermediaryEvent(PasskeyMFAEventEmit.Cancel, verifyPayloadId)();
+      });
+    }
+
+    return promiEvent;
+  }
+
+  public getMetadata() {
+    const requestPayload = this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.GetPasskeyInfo, []);
+    return this.request<any[]>(requestPayload);
+  }
+}

--- a/packages/@magic-ext/passkey/src/types.ts
+++ b/packages/@magic-ext/passkey/src/types.ts
@@ -1,0 +1,40 @@
+export interface RegisterNewUserConfiguration {
+  /**
+   * The username of the user attempting to register.
+   * Optional parameter used as display name for the passkey
+   */
+  username?: string;
+
+  /**
+   * The nickname that the user attempts to set to this passkey.
+   */
+  nickname?: string;
+
+  skipDIDToken?: boolean;
+  lifespan?: number;
+}
+
+export interface LoginWithPasskeyConfiguration {
+  /**
+   * The username of the user attempting to login.
+   * Optional parameter used for legacy users
+   */
+  username?: string;
+
+  showMfaModal?: boolean;
+  skipDIDToken?: boolean;
+  lifespan?: number;
+}
+
+export enum MagicPasskeyPayloadMethod {
+  RegisterPasskeyStart = 'magic_auth_register_passkey_start',
+  RegisterPasskeyVerify = 'magic_auth_register_passkey_verify',
+  LoginWithPasskeyStart = 'magic_auth_login_with_passkey_start',
+  LoginWithPasskeyVerify = 'magic_auth_login_with_passkey_verify',
+  GetPasskeyInfo = 'magic_user_get_webauthn_credentials',
+}
+
+export enum PasskeySDKErrorCode {
+  PasskeyNotSupported = 'PASSKEY_NOT_SUPPORTED',
+  PasskeyRegisterError = 'PASSKEY_REGISTRATION_ERROR',
+}

--- a/packages/@magic-ext/passkey/src/utils/base64.ts
+++ b/packages/@magic-ext/passkey/src/utils/base64.ts
@@ -1,0 +1,28 @@
+/**
+ * Encode given buffer or decode given string with Base64URL.
+ */
+export class Base64URL {
+  /**
+   * Convert bytes into a base64url-encoded string
+   */
+  static encode(buffer: ArrayBuffer): string {
+    const base64 = globalThis.btoa(String.fromCharCode(...new Uint8Array(buffer)));
+
+    return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  }
+
+  /**
+   * Convert a base64url-encoded string into bytes
+   */
+  static decode(base64url: string): ArrayBuffer {
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    const binStr = globalThis.atob(base64);
+    const bin = new Uint8Array(binStr.length);
+
+    for (let i = 0; i < binStr.length; i++) {
+      bin[i] = binStr.charCodeAt(i);
+    }
+
+    return bin.buffer;
+  }
+}

--- a/packages/@magic-ext/passkey/src/utils/polyfills.ts
+++ b/packages/@magic-ext/passkey/src/utils/polyfills.ts
@@ -1,0 +1,85 @@
+import { Base64URL } from './base64';
+
+function isAuthenticatorAssertionResponse(value: AuthenticatorResponse): value is AuthenticatorAssertionResponse {
+  if (typeof value !== 'object') {
+    return false;
+  }
+  if (
+    (value as AuthenticatorAssertionResponse)?.authenticatorData === undefined ||
+    typeof (value as AuthenticatorAssertionResponse)?.authenticatorData !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isAuthenticatorAttestationResponse(value: AuthenticatorResponse): value is AuthenticatorAttestationResponse {
+  if (typeof value !== 'object') {
+    return false;
+  }
+  if (
+    (value as AuthenticatorAttestationResponse)?.attestationObject === undefined ||
+    typeof (value as AuthenticatorAttestationResponse)?.attestationObject !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Polyfill `PublicKeyCredential.prototype.toJSON`
+ *
+ * See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
+ */
+export function toJSON(cred: PublicKeyCredential): PublicKeyCredentialJSON {
+  // Prefer native implementation if available
+  if (typeof cred.toJSON === 'function') {
+    return cred.toJSON();
+  }
+
+  try {
+    const id = cred.id;
+    const rawId = Base64URL.encode(cred.rawId);
+    const authenticatorAttachment = cred.authenticatorAttachment;
+    const clientExtensionResults = {};
+    const type = cred.type;
+
+    // This is authentication.
+    if (isAuthenticatorAssertionResponse(cred.response)) {
+      return {
+        id,
+        rawId,
+        response: {
+          authenticatorData: Base64URL.encode(cred.response.authenticatorData),
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          signature: Base64URL.encode(cred.response.signature),
+          userHandle: cred.response.userHandle ? Base64URL.encode(cred.response.userHandle) : undefined,
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    if (isAuthenticatorAttestationResponse(cred.response)) {
+      // This is registration.
+      return {
+        id,
+        rawId,
+        response: {
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          attestationObject: Base64URL.encode(cred.response.attestationObject),
+          transports: cred.response?.getTransports() || [],
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    throw new Error('Unexpected object.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}

--- a/packages/@magic-ext/passkey/tsconfig.json
+++ b/packages/@magic-ext/passkey/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.settings.json",
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@magic-ext/passkey@workspace:packages/@magic-ext/passkey":
+  version: 0.0.0-use.local
+  resolution: "@magic-ext/passkey@workspace:packages/@magic-ext/passkey"
+  dependencies:
+    "@magic-sdk/provider": ^33.7.0
+  languageName: unknown
+  linkType: soft
+
 "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot":
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/passkey@1.0.0-canary.1085.25119171769.0
  # or 
  yarn add @magic-ext/passkey@1.0.0-canary.1085.25119171769.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
