### PR TITLE
feat: add type for passkey metadata

### DIFF
--- a/packages/@magic-ext/passkey/src/index.ts
+++ b/packages/@magic-ext/passkey/src/index.ts
@@ -5,7 +5,13 @@ import {
   PasskeySDKErrorCode,
   LoginWithPasskeyConfiguration,
 } from './types';
-import { PasskeyResult, PasskeyEventHandlers, PasskeyMFAEventEmit, PasskeyMFAEventOnReceived } from '@magic-sdk/types';
+import {
+  PasskeyResult,
+  PasskeyEventHandlers,
+  PasskeyMFAEventEmit,
+  PasskeyMFAEventOnReceived,
+  PasskeyMetadata,
+} from '@magic-sdk/types';
 import { toJSON } from './utils/polyfills';
 
 export class PasskeyExtension extends Extension.Internal<'passkey', any> {
@@ -39,7 +45,7 @@ export class PasskeyExtension extends Extension.Internal<'passkey', any> {
       throw this.createPasskeyCreateCredentialError(err);
     }
 
-    return this.request<string | null>(
+    return this.request<PasskeyResult>(
       this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.RegisterPasskeyVerify, [
         {
           registrationToken,
@@ -137,6 +143,6 @@ export class PasskeyExtension extends Extension.Internal<'passkey', any> {
 
   public getMetadata() {
     const requestPayload = this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.GetPasskeyInfo, []);
-    return this.request<any[]>(requestPayload);
+    return this.request<PasskeyMetadata>(requestPayload);
   }
 }

--- a/packages/@magic-sdk/types/src/modules/webauthn-types.ts
+++ b/packages/@magic-sdk/types/src/modules/webauthn-types.ts
@@ -3,12 +3,18 @@ export interface PasskeyResult {
   idToken: string | null;
 
   // Info of the device used to authenticate
-  deviceInfo: {
-    id: string;
-    nickname: string;
-    transport: string;
-    userAgent: string;
-  };
+  deviceInfo: DeviceInfo;
+}
+
+export interface DeviceInfo {
+  id: string;
+  nickname: string;
+  transport: string;
+  userAgent: string;
+}
+
+export interface PasskeyMetadata {
+  devicesInfo: DeviceInfo[];
 }
 
 export enum PasskeyMFAEventEmit {


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/aptos@16.6.1-canary.1087.25389224724.0
  npm install @magic-ext/avalanche@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/bitcoin@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/conflux@26.6.1-canary.1087.25389224724.0
  npm install @magic-ext/cosmos@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/ed25519@24.6.1-canary.1087.25389224724.0
  npm install @magic-ext/evm@1.5.1-canary.1087.25389224724.0
  npm install @magic-ext/farcaster@5.6.1-canary.1087.25389224724.0
  npm install @magic-ext/flow@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/gdkms@16.6.1-canary.1087.25389224724.0
  npm install @magic-ext/harmony@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/hedera@2.5.1-canary.1087.25389224724.0
  npm install @magic-ext/icon@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/kadena@5.6.1-canary.1087.25389224724.0
  npm install @magic-ext/near@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/oauth2@15.7.1-canary.1087.25389224724.0
  npm install @magic-ext/oidc@16.6.1-canary.1087.25389224724.0
  npm install @magic-ext/passkey@1.0.1-canary.1087.25389224724.0
  npm install @magic-ext/polkadot@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/react-native-bare-oauth@30.7.1-canary.1087.25389224724.0
  npm install @magic-ext/react-native-expo-oauth@30.7.1-canary.1087.25389224724.0
  npm install @magic-ext/siwe@3.6.1-canary.1087.25389224724.0
  npm install @magic-ext/smart-account@1.1.1-canary.1087.25389224724.0
  npm install @magic-ext/solana@30.6.1-canary.1087.25389224724.0
  npm install @magic-ext/sui@5.6.1-canary.1087.25389224724.0
  npm install @magic-ext/taquito@25.6.1-canary.1087.25389224724.0
  npm install @magic-ext/terra@25.6.1-canary.1087.25389224724.0
  npm install @magic-ext/tezos@28.6.1-canary.1087.25389224724.0
  npm install @magic-ext/wallet-kit@0.10.1-canary.1087.25389224724.0
  npm install @magic-ext/webauthn@27.6.1-canary.1087.25389224724.0
  npm install @magic-ext/zilliqa@28.6.1-canary.1087.25389224724.0
  npm install @magic-sdk/provider@33.7.1-canary.1087.25389224724.0
  npm install @magic-sdk/react-native-bare@34.6.1-canary.1087.25389224724.0
  npm install @magic-sdk/react-native-expo@34.6.1-canary.1087.25389224724.0
  npm install @magic-sdk/types@27.7.1-canary.1087.25389224724.0
  npm install magic-sdk@33.7.1-canary.1087.25389224724.0
  # or 
  yarn add @magic-ext/algorand@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/aptos@16.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/avalanche@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/bitcoin@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/conflux@26.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/cosmos@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/ed25519@24.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/evm@1.5.1-canary.1087.25389224724.0
  yarn add @magic-ext/farcaster@5.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/flow@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/gdkms@16.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/harmony@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/hedera@2.5.1-canary.1087.25389224724.0
  yarn add @magic-ext/icon@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/kadena@5.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/near@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/oauth2@15.7.1-canary.1087.25389224724.0
  yarn add @magic-ext/oidc@16.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/passkey@1.0.1-canary.1087.25389224724.0
  yarn add @magic-ext/polkadot@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/react-native-bare-oauth@30.7.1-canary.1087.25389224724.0
  yarn add @magic-ext/react-native-expo-oauth@30.7.1-canary.1087.25389224724.0
  yarn add @magic-ext/siwe@3.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/smart-account@1.1.1-canary.1087.25389224724.0
  yarn add @magic-ext/solana@30.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/sui@5.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/taquito@25.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/terra@25.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/tezos@28.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/wallet-kit@0.10.1-canary.1087.25389224724.0
  yarn add @magic-ext/webauthn@27.6.1-canary.1087.25389224724.0
  yarn add @magic-ext/zilliqa@28.6.1-canary.1087.25389224724.0
  yarn add @magic-sdk/provider@33.7.1-canary.1087.25389224724.0
  yarn add @magic-sdk/react-native-bare@34.6.1-canary.1087.25389224724.0
  yarn add @magic-sdk/react-native-expo@34.6.1-canary.1087.25389224724.0
  yarn add @magic-sdk/types@27.7.1-canary.1087.25389224724.0
  yarn add magic-sdk@33.7.1-canary.1087.25389224724.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
