### PR TITLE
fix(provider): handle v-prefixed SDK versions

### DIFF
--- a/packages/@magic-sdk/provider/src/util/version-check.ts
+++ b/packages/@magic-sdk/provider/src/util/version-check.ts
@@ -1,6 +1,6 @@
 export function isMajorVersionAtLeast(version: string, majorVersion: number): boolean {
   // Split the version string into major, minor, and patch versions
-  const [major] = version.split('.').map(Number);
+  const [major] = version.replace(/^v/i, '').split('.').map(Number);
 
   // Check if the major version is at least the required major version
   return major >= majorVersion;

--- a/packages/@magic-sdk/provider/test/spec/util/isMajorVersionAtLeast.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/util/isMajorVersionAtLeast.spec.ts
@@ -22,6 +22,11 @@ describe('isMajorVersionAtLeast', () => {
     expect(isMajorVersionAtLeast('0', 1)).toBe(false);
   });
 
+  it('should handle version strings prefixed with v', () => {
+    expect(isMajorVersionAtLeast('v19.0.0', 19)).toBe(true);
+    expect(isMajorVersionAtLeast('V18.2.1', 19)).toBe(false);
+  });
+
   it('should handle non-standard version strings correctly', () => {
     expect(isMajorVersionAtLeast('1.beta', 1)).toBe(true);
     expect(isMajorVersionAtLeast('1.alpha', 2)).toBe(false);


### PR DESCRIPTION
### 📦 Pull Request

This PR updates `isMajorVersionAtLeast` to handle SDK version strings prefixed with `v` or `V`, such as `v19.0.0`.

The provider code already uses v-prefixed removal versions in `ProductConsolidationMethodRemovalVersions`, but the version comparison helper previously parsed those values as `NaN`. This change normalizes the optional prefix before reading the major version.


### ✅ Fixed Issues

- N/A

### 🚨 Test instructions

Ran:

- `../../../node_modules/.bin/jest test/spec/util/isMajorVersionAtLeast.spec.ts --runInBand --coverage=false`
- `./node_modules/.bin/prettier --check packages/@magic-sdk/provider/src/util/version-check.ts packages/@magic-sdk/provider/test/spec/util/isMajorVersionAtLeast.spec.ts`
- `./node_modules/.bin/eslint packages/@magic-sdk/provider/src/util/version-check.ts packages/@magic-sdk/provider/test/spec/util/isMajorVersionAtLeast.spec.ts`
- `PKG=@magic-sdk/provider yarn build`
- `git diff --check`
- 

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- 
### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️
