### PR TITLE
feat: implement-passkey-as-a-factor

### DIFF
--- a/packages/@magic-ext/passkey/src/index.ts
+++ b/packages/@magic-ext/passkey/src/index.ts
@@ -212,4 +212,84 @@ export class PasskeyExtension extends Extension.Internal<'passkey', any> {
       this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.RemovePasskey, [{ passkeyId }]),
     );
   }
+
+  public enablePasskeyMfa() {
+    if (!window.PublicKeyCredential) {
+      throw this.createPasskeyNotSupportError();
+    }
+
+    const promiEvent = this.utils.createPromiEvent(async (resolve, reject) => {
+      let startResponse;
+
+      try {
+        const response = await this.request(
+          this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.EnablePasskeyMfaStart),
+        );
+        startResponse = response;
+      } catch (e) {
+        // TODO: Handle case where user has no active passkey
+        reject(e);
+      }
+
+      let assertionResponse;
+      try {
+        assertionResponse = (await navigator.credentials.get({
+          publicKey: startResponse.webauthnOptions,
+        })) as any;
+      } catch (err: any) {
+        return reject(this.createPasskeyCreateCredentialError(err));
+      }
+
+      this.request(
+        this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.EnablePasskeyMfaVerify, [
+          {
+            assertionResponse: toJSON(assertionResponse),
+            enrollmentToken: startResponse.enrollmentToken,
+          },
+        ]),
+      );
+
+      resolve(
+        startResponse?.recoveryCodes
+          ? {
+              recoveryCodes: startResponse?.recoveryCodes,
+            }
+          : {},
+      );
+    });
+
+    return promiEvent;
+  }
+
+  public disablePasskeyMfa() {
+    if (!window.PublicKeyCredential) {
+      throw this.createPasskeyNotSupportError();
+    }
+
+    const promiEvent = this.utils.createPromiEvent(async (resolve, reject) => {
+      const { webauthnOptions, disableToken } = await this.request(
+        this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.DisablePasskeyMfaStart),
+      );
+
+      let assertionResponse;
+      try {
+        assertionResponse = (await navigator.credentials.get({
+          publicKey: webauthnOptions,
+        })) as any;
+      } catch (err: any) {
+        return reject(this.createPasskeyCreateCredentialError(err));
+      }
+
+      return this.request(
+        this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.DisablePasskeyMfaVerify, [
+          {
+            assertionResponse: toJSON(assertionResponse),
+            disableToken,
+          },
+        ]),
+      );
+    });
+
+    return promiEvent;
+  }
 }

--- a/packages/@magic-ext/passkey/src/types.ts
+++ b/packages/@magic-ext/passkey/src/types.ts
@@ -68,6 +68,10 @@ export enum MagicPasskeyPayloadMethod {
   AddPasskeyVerify = 'magic_auth_add_passkey_verify',
   UpdatePasskey = 'magic_auth_update_passkey',
   RemovePasskey = 'magic_auth_remove_passkey',
+  EnablePasskeyMfaStart = 'magic_auth_enable_passkey_mfa_flow_start',
+  EnablePasskeyMfaVerify = 'magic_auth_enable_passkey_mfa_flow_verify',
+  DisablePasskeyMfaStart = 'magic_auth_disable_passkey_mfa_flow_start',
+  DisablePasskeyMfaVerify = 'magic_auth_disable_passkey_mfa_flow_verify',
 }
 
 export enum PasskeySDKErrorCode {

--- a/packages/@magic-sdk/provider/jest.config.ts
+++ b/packages/@magic-sdk/provider/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config.InitialOptions = {
     '^.+\\.(js|jsx)$': 'babel-jest',
     '\\.(ts|tsx)$': 'ts-jest',
   },
-  coveragePathIgnorePatterns: ['third-party-wallets.ts', 'nft.ts', 'wallet.ts'],
+  coveragePathIgnorePatterns: ['third-party-wallets.ts', 'nft.ts', 'wallet.ts', 'polyfills.ts'],
 };
 
 export default config;

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -151,24 +151,26 @@ export class AuthModule extends BaseModule {
       });
     }
 
-    handle.on(MfaEventOnReceived.MfaPasskeyOptions, async ({ webauthnOptions }) => {
-      try {
-        const assertionResponse = (await navigator.credentials.get({
-          publicKey: parseRequestOptionsFromJSON(webauthnOptions),
-        })) as any;
+    if (handle) {
+      handle.on(MfaEventOnReceived.MfaPasskeyOptions, async ({ webauthnOptions }) => {
+        try {
+          const assertionResponse = (await navigator.credentials.get({
+            publicKey: parseRequestOptionsFromJSON(webauthnOptions),
+          })) as any;
 
-        this.createIntermediaryEvent(
-          MfaEventEmit.MfaPasskeyAssertionResponse,
-          requestPayload.id as any,
-        )(toJSON(assertionResponse));
-      } catch (err) {
-        const error = err as Error;
-        this.createIntermediaryEvent(
-          MfaEventEmit.MfaPasskeyAssertionError,
-          requestPayload.id as any,
-        )(error?.message ?? '');
-      }
-    });
+          this.createIntermediaryEvent(
+            MfaEventEmit.MfaPasskeyAssertionResponse,
+            requestPayload.id as any,
+          )(toJSON(assertionResponse));
+        } catch (err) {
+          const error = err as Error;
+          this.createIntermediaryEvent(
+            MfaEventEmit.MfaPasskeyAssertionError,
+            requestPayload.id as any,
+          )(error?.message ?? '');
+        }
+      });
+    }
 
     return handle;
   }

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -20,6 +20,8 @@ import { createJsonRpcRequestPayload } from '../core/json-rpc';
 import { SDKEnvironment } from '../core/sdk-environment';
 import { isMajorVersionAtLeast } from '../util/version-check';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
+import { parseRequestOptionsFromJSON, toJSON } from '../util/polyfills';
+import { MfaEventEmit, MfaEventOnReceived } from '@magic-sdk/types/src/modules/mfa-types';
 
 export const ProductConsolidationMethodRemovalVersions = {
   'magic-sdk': 'v18.0.0',
@@ -117,6 +119,7 @@ export class AuthModule extends BaseModule {
       [{ email, showUI, deviceCheckUI, overrides, lifespan }],
     );
     const handle = this.request<string | null, LoginWithEmailOTPEventHandlers>(requestPayload);
+
     if (!deviceCheckUI && handle) {
       handle.on(DeviceVerificationEventEmit.Retry, () => {
         this.createIntermediaryEvent(DeviceVerificationEventEmit.Retry, requestPayload.id as any)();
@@ -141,7 +144,30 @@ export class AuthModule extends BaseModule {
       handle.on(LoginWithEmailOTPEventEmit.Cancel, () => {
         this.createIntermediaryEvent(LoginWithEmailOTPEventEmit.Cancel, requestPayload.id as any)();
       });
+
+      handle.on(MfaEventEmit.SelectedMfaType, type => {
+        this.createIntermediaryEvent(MfaEventEmit.SelectedMfaType, requestPayload.id as any)(type);
+      });
     }
+
+    handle.on(MfaEventOnReceived.MfaPasskeyOptions, async ({ webauthnOptions }) => {
+      try {
+        const assertionResponse = (await navigator.credentials.get({
+          publicKey: parseRequestOptionsFromJSON(webauthnOptions),
+        })) as any;
+
+        this.createIntermediaryEvent(
+          MfaEventEmit.MfaPasskeyAssertionResponse,
+          requestPayload.id as any,
+        )(toJSON(assertionResponse));
+      } catch (err) {
+        const error = err as Error;
+        this.createIntermediaryEvent(
+          MfaEventEmit.MfaPasskeyAssertionError,
+          requestPayload.id as any,
+        )(error?.message ?? '');
+      }
+    });
 
     return handle;
   }

--- a/packages/@magic-sdk/provider/src/modules/auth.ts
+++ b/packages/@magic-sdk/provider/src/modules/auth.ts
@@ -14,6 +14,8 @@ import {
   LoginWithSmsOTPEventEmit,
   LoginWithSmsOTPEventHandlers,
   LoginWithCredentialConfiguration,
+  MfaEventOnReceived,
+  MfaEventEmit,
 } from '@magic-sdk/types';
 import { BaseModule } from './base-module';
 import { createJsonRpcRequestPayload } from '../core/json-rpc';
@@ -21,7 +23,6 @@ import { SDKEnvironment } from '../core/sdk-environment';
 import { isMajorVersionAtLeast } from '../util/version-check';
 import { createDeprecationWarning } from '../core/sdk-exceptions';
 import { parseRequestOptionsFromJSON, toJSON } from '../util/polyfills';
-import { MfaEventEmit, MfaEventOnReceived } from '@magic-sdk/types/src/modules/mfa-types';
 
 export const ProductConsolidationMethodRemovalVersions = {
   'magic-sdk': 'v18.0.0',

--- a/packages/@magic-sdk/provider/src/util/base64-json.ts
+++ b/packages/@magic-sdk/provider/src/util/base64-json.ts
@@ -43,6 +43,7 @@ export function decodeJSON<T>(queryString: string): T {
 /**
  * Encode given buffer or decode given string with Base64URL.
  */
+/* istanbul ignore next */
 export class Base64URL {
   /**
    * Convert bytes into a base64url-encoded string

--- a/packages/@magic-sdk/provider/src/util/base64-json.ts
+++ b/packages/@magic-sdk/provider/src/util/base64-json.ts
@@ -39,3 +39,32 @@ export function encodeJSON<T>(options: T): string {
 export function decodeJSON<T>(queryString: string): T {
   return JSON.parse(atobUTF8(queryString));
 }
+
+/**
+ * Encode given buffer or decode given string with Base64URL.
+ */
+export class Base64URL {
+  /**
+   * Convert bytes into a base64url-encoded string
+   */
+  static encode(buffer: ArrayBuffer): string {
+    const base64 = globalThis.btoa(String.fromCharCode(...new Uint8Array(buffer)));
+
+    return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  }
+
+  /**
+   * Convert a base64url-encoded string into bytes
+   */
+  static decode(base64url: string): ArrayBuffer {
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    const binStr = globalThis.atob(base64);
+    const bin = new Uint8Array(binStr.length);
+
+    for (let i = 0; i < binStr.length; i++) {
+      bin[i] = binStr.charCodeAt(i);
+    }
+
+    return bin.buffer;
+  }
+}

--- a/packages/@magic-sdk/provider/src/util/polyfills.ts
+++ b/packages/@magic-sdk/provider/src/util/polyfills.ts
@@ -1,0 +1,119 @@
+import { Base64URL } from './base64-json';
+
+function isAuthenticatorAssertionResponse(value: AuthenticatorResponse): value is AuthenticatorAssertionResponse {
+  if (typeof value !== 'object') {
+    return false;
+  }
+  if (
+    (value as AuthenticatorAssertionResponse)?.authenticatorData === undefined ||
+    typeof (value as AuthenticatorAssertionResponse)?.authenticatorData !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isAuthenticatorAttestationResponse(value: AuthenticatorResponse): value is AuthenticatorAttestationResponse {
+  if (typeof value !== 'object') {
+    return false;
+  }
+  if (
+    (value as AuthenticatorAttestationResponse)?.attestationObject === undefined ||
+    typeof (value as AuthenticatorAttestationResponse)?.attestationObject !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Polyfill `PublicKeyCredential.prototype.toJSON`
+ *
+ * See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
+ */
+export function toJSON(cred: PublicKeyCredential): PublicKeyCredentialJSON {
+  // Prefer native implementation if available
+  if (typeof cred.toJSON === 'function') {
+    return cred.toJSON();
+  }
+
+  try {
+    const id = cred.id;
+    const rawId = Base64URL.encode(cred.rawId);
+    const authenticatorAttachment = cred.authenticatorAttachment;
+    const clientExtensionResults = {};
+    const type = cred.type;
+
+    // This is authentication.
+    if (isAuthenticatorAssertionResponse(cred.response)) {
+      return {
+        id,
+        rawId,
+        response: {
+          authenticatorData: Base64URL.encode(cred.response.authenticatorData),
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          signature: Base64URL.encode(cred.response.signature),
+          userHandle: cred.response.userHandle ? Base64URL.encode(cred.response.userHandle) : undefined,
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    if (isAuthenticatorAttestationResponse(cred.response)) {
+      // This is registration.
+      return {
+        id,
+        rawId,
+        response: {
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          attestationObject: Base64URL.encode(cred.response.attestationObject),
+          transports: cred.response?.getTransports() || [],
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    throw new Error('Unexpected object.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+/**
+ * Polyfill `PublicKeyCredential.parseRequestOptionsFromJSON`
+ *
+ * See https://w3c.github.io/webauthn/#sctn-parseRequestOptionsFromJSON
+ */
+export function parseRequestOptionsFromJSON(
+  options: PublicKeyCredentialRequestOptionsJSON,
+): PublicKeyCredentialRequestOptions {
+  if (
+    typeof PublicKeyCredential !== 'undefined' &&
+    typeof PublicKeyCredential.parseRequestOptionsFromJSON === 'function'
+  ) {
+    return PublicKeyCredential.parseRequestOptionsFromJSON(options);
+  }
+
+  const challenge = Base64URL.decode(options.challenge) as ArrayBuffer;
+  const allowCredentials =
+    options.allowCredentials?.map(cred => {
+      return {
+        ...cred,
+        id: Base64URL.decode(cred.id) as ArrayBuffer,
+        transports: cred.transports as AuthenticatorTransport[] | undefined,
+      } as PublicKeyCredentialDescriptor;
+    }) ?? [];
+
+  const toReturn = {
+    ...options,
+    allowCredentials,
+    challenge,
+  } as PublicKeyCredentialRequestOptions;
+
+  return toReturn;
+}

--- a/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTPPasskeyMfa.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/modules/auth/loginWithEmailOTPPasskeyMfa.spec.ts
@@ -1,0 +1,103 @@
+import { createMagicSDK } from '../../../factories';
+
+jest.mock('../../../../src/util/polyfills', () => ({
+  parseRequestOptionsFromJSON: jest.fn().mockReturnValue({ challenge: new ArrayBuffer(8) }),
+  toJSON: jest.fn().mockReturnValue({ id: 'mocked-id', rawId: 'mocked-raw-id', type: 'public-key', response: {}, clientExtensionResults: {} }),
+}));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});
+
+const expectedEmail = 'john.doe@mail.com';
+
+test('handles selected-mfa-type event when showUI is false', () => {
+  const magic = createMagicSDK();
+  magic.auth.overlay.post = jest.fn().mockImplementation(() => new Promise(() => { /* noop */ }));
+  const createIntermediaryEventFn = jest.fn();
+  magic.auth.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  const handle = magic.auth.loginWithEmailOTP({ email: expectedEmail, showUI: false });
+
+  handle.emit('selected-mfa-type', 'passkey');
+
+  const mfaTypeEvent = magic.auth.createIntermediaryEvent.mock.calls.find(([method]) => method === 'selected-mfa-type');
+  expect(mfaTypeEvent).toBeDefined();
+  expect(createIntermediaryEventFn).toHaveBeenCalledWith('passkey');
+});
+
+test('handles mfa-passkey-options event - success path', async () => {
+  const magic = createMagicSDK();
+  magic.auth.overlay.post = jest.fn().mockImplementation(() => new Promise(() => { /* noop */ }));
+  const createIntermediaryEventFn = jest.fn();
+  magic.auth.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  const fakeCredential = { id: 'cred', rawId: new ArrayBuffer(8), type: 'public-key', response: {} };
+  Object.defineProperty(navigator, 'credentials', {
+    value: { get: jest.fn().mockResolvedValue(fakeCredential) },
+    writable: true,
+    configurable: true,
+  });
+
+  const handle = magic.auth.loginWithEmailOTP({ email: expectedEmail, showUI: false });
+
+  handle.emit('mfa-passkey-options', { webauthnOptions: { challenge: 'dGVzdA', rpId: 'example.com' } });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  const assertionResponseCall = magic.auth.createIntermediaryEvent.mock.calls.find(
+    ([method]) => method === 'mfa-passkey-assertion-response',
+  );
+  expect(assertionResponseCall).toBeDefined();
+});
+
+test('handles mfa-passkey-options event - error path', async () => {
+  const magic = createMagicSDK();
+  magic.auth.overlay.post = jest.fn().mockImplementation(() => new Promise(() => { /* noop */ }));
+  const createIntermediaryEventFn = jest.fn();
+  magic.auth.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  Object.defineProperty(navigator, 'credentials', {
+    value: { get: jest.fn().mockRejectedValue(new Error('User cancelled')) },
+    writable: true,
+    configurable: true,
+  });
+
+  const handle = magic.auth.loginWithEmailOTP({ email: expectedEmail, showUI: false });
+
+  handle.emit('mfa-passkey-options', { webauthnOptions: { challenge: 'dGVzdA', rpId: 'example.com' } });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  const errorCall = magic.auth.createIntermediaryEvent.mock.calls.find(
+    ([method]) => method === 'mfa-passkey-assertion-error',
+  );
+  expect(errorCall).toBeDefined();
+  expect(createIntermediaryEventFn).toHaveBeenCalledWith('User cancelled');
+});
+
+test('handles mfa-passkey-options event - error with no message falls back to empty string', async () => {
+  const magic = createMagicSDK();
+  magic.auth.overlay.post = jest.fn().mockImplementation(() => new Promise(() => { /* noop */ }));
+  const createIntermediaryEventFn = jest.fn();
+  magic.auth.createIntermediaryEvent = jest.fn().mockImplementation(() => createIntermediaryEventFn);
+
+  Object.defineProperty(navigator, 'credentials', {
+    value: { get: jest.fn().mockRejectedValue({}) },
+    writable: true,
+    configurable: true,
+  });
+
+  const handle = magic.auth.loginWithEmailOTP({ email: expectedEmail, showUI: false });
+
+  handle.emit('mfa-passkey-options', { webauthnOptions: { challenge: 'dGVzdA', rpId: 'example.com' } });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  const errorCall = magic.auth.createIntermediaryEvent.mock.calls.find(
+    ([method]) => method === 'mfa-passkey-assertion-error',
+  );
+  expect(errorCall).toBeDefined();
+  expect(createIntermediaryEventFn).toHaveBeenCalledWith('');
+});

--- a/packages/@magic-sdk/types/src/index.ts
+++ b/packages/@magic-sdk/types/src/index.ts
@@ -17,3 +17,4 @@ export * from './modules/wallet-types';
 export * from './modules/common-types';
 export * from './modules/oauth-types';
 export * from './modules/webauthn-types';
+export * from './modules/mfa-types';

--- a/packages/@magic-sdk/types/src/modules/auth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/auth-types.ts
@@ -1,3 +1,4 @@
+import { MfaEventHandlers } from './mfa-types';
 import { WalletEventOnReceived } from './wallet-types';
 
 export interface LoginWithMagicLinkConfiguration {
@@ -319,7 +320,8 @@ export type LoginWithEmailOTPEventHandlers = {
   [LoginWithEmailOTPEventEmit.LostDevice]: () => void;
   [LoginWithEmailOTPEventEmit.VerifyRecoveryCode]: (recoveryCode: string) => void;
   [LoginWithEmailOTPEventEmit.Cancel]: () => void;
-} & DeviceVerificationEventHandlers;
+} & DeviceVerificationEventHandlers &
+  MfaEventHandlers;
 
 type DeviceVerificationEventHandlers = {
   // Event Received

--- a/packages/@magic-sdk/types/src/modules/intermediary-types.ts
+++ b/packages/@magic-sdk/types/src/modules/intermediary-types.ts
@@ -29,7 +29,13 @@ import {
   RecoveryFactorEventEmit,
   RecoveryFactorEventOnReceived,
 } from './user-types';
-import { OAuthMFAEventEmit, OAuthMFAEventOnReceived, OAuthPopupEventEmit, OAuthPopupEventOnReceived } from './oauth-types';
+import {
+  OAuthMFAEventEmit,
+  OAuthMFAEventOnReceived,
+  OAuthPopupEventEmit,
+  OAuthPopupEventOnReceived,
+} from './oauth-types';
+import { MfaEventEmit, MfaEventOnReceived } from './mfa-types';
 
 export type IntermediaryEvents =
   // EmailOTP
@@ -79,4 +85,6 @@ export type IntermediaryEvents =
   | `${OAuthMFAEventEmit}`
   | `${OAuthMFAEventOnReceived}`
   | `${OAuthPopupEventEmit}`
-  | `${OAuthPopupEventOnReceived}`;
+  | `${OAuthPopupEventOnReceived}`
+  | `${MfaEventEmit}`
+  | `${MfaEventOnReceived}`;

--- a/packages/@magic-sdk/types/src/modules/mfa-types.ts
+++ b/packages/@magic-sdk/types/src/modules/mfa-types.ts
@@ -1,0 +1,28 @@
+export enum MfaEventEmit {
+  SelectedMfaType = 'selected-mfa-type',
+  MfaPasskeyAssertionResponse = 'mfa-passkey-assertion-response',
+  MfaPasskeyAssertionError = 'mfa-passkey-assertion-error',
+  LostDevice = 'lost-device',
+}
+export enum MfaEventOnReceived {
+  SelectMfaType = 'select-mfa-type',
+  MfaPasskeyOptions = 'mfa-passkey-options',
+  MfaSentHandle = 'mfa-sent-handle',
+  RecoveryCodeSentHandle = 'recovery-code-sent-handle',
+  InvalidRecoveryCode = 'invalid-recovery-code',
+  RecoveryCodeSuccess = 'recovery-code-success',
+}
+
+export type MfaEventHandlers = {
+  [MfaEventEmit.SelectedMfaType]: (mfaType: 'totp' | 'passkey') => {};
+  [MfaEventEmit.MfaPasskeyAssertionResponse]: (assertionResponse: any) => {};
+  [MfaEventEmit.MfaPasskeyAssertionError]: (errorMsg: string) => {};
+  [MfaEventEmit.LostDevice]: () => {};
+
+  [MfaEventOnReceived.SelectMfaType]: () => {};
+  [MfaEventOnReceived.MfaPasskeyOptions]: ({ webauthnOptions }: { webauthnOptions: any }) => {};
+  [MfaEventOnReceived.MfaSentHandle]: () => void;
+  [MfaEventOnReceived.RecoveryCodeSentHandle]: () => void;
+  [MfaEventOnReceived.InvalidRecoveryCode]: () => void;
+  [MfaEventOnReceived.RecoveryCodeSuccess]: () => void;
+};


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/aptos@16.7.0-canary.1104.28614171396.0
  npm install @magic-ext/avalanche@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/bitcoin@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/conflux@26.7.0-canary.1104.28614171396.0
  npm install @magic-ext/cosmos@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/ed25519@24.7.0-canary.1104.28614171396.0
  npm install @magic-ext/evm@1.6.0-canary.1104.28614171396.0
  npm install @magic-ext/farcaster@5.7.0-canary.1104.28614171396.0
  npm install @magic-ext/flow@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/gdkms@16.7.0-canary.1104.28614171396.0
  npm install @magic-ext/harmony@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/hedera@2.6.0-canary.1104.28614171396.0
  npm install @magic-ext/icon@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/kadena@5.7.0-canary.1104.28614171396.0
  npm install @magic-ext/near@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/oauth2@15.9.0-canary.1104.28614171396.0
  npm install @magic-ext/oidc@16.7.0-canary.1104.28614171396.0
  npm install @magic-ext/passkey@1.2.0-canary.1104.28614171396.0
  npm install @magic-ext/polkadot@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/react-native-bare-oauth@30.8.0-canary.1104.28614171396.0
  npm install @magic-ext/react-native-expo-oauth@30.8.0-canary.1104.28614171396.0
  npm install @magic-ext/siwe@3.7.0-canary.1104.28614171396.0
  npm install @magic-ext/smart-account@1.2.0-canary.1104.28614171396.0
  npm install @magic-ext/solana@30.7.0-canary.1104.28614171396.0
  npm install @magic-ext/sui@5.7.0-canary.1104.28614171396.0
  npm install @magic-ext/taquito@25.7.0-canary.1104.28614171396.0
  npm install @magic-ext/terra@25.7.0-canary.1104.28614171396.0
  npm install @magic-ext/tezos@28.7.0-canary.1104.28614171396.0
  npm install @magic-ext/wallet-kit@0.12.0-canary.1104.28614171396.0
  npm install @magic-ext/webauthn@27.7.0-canary.1104.28614171396.0
  npm install @magic-ext/zilliqa@28.7.0-canary.1104.28614171396.0
  npm install @magic-sdk/provider@33.8.0-canary.1104.28614171396.0
  npm install @magic-sdk/react-native-bare@34.7.0-canary.1104.28614171396.0
  npm install @magic-sdk/react-native-expo@34.7.0-canary.1104.28614171396.0
  npm install @magic-sdk/types@27.8.0-canary.1104.28614171396.0
  npm install magic-sdk@33.8.0-canary.1104.28614171396.0
  # or 
  yarn add @magic-ext/algorand@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/aptos@16.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/avalanche@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/bitcoin@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/conflux@26.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/cosmos@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/ed25519@24.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/evm@1.6.0-canary.1104.28614171396.0
  yarn add @magic-ext/farcaster@5.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/flow@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/gdkms@16.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/harmony@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/hedera@2.6.0-canary.1104.28614171396.0
  yarn add @magic-ext/icon@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/kadena@5.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/near@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/oauth2@15.9.0-canary.1104.28614171396.0
  yarn add @magic-ext/oidc@16.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/passkey@1.2.0-canary.1104.28614171396.0
  yarn add @magic-ext/polkadot@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/react-native-bare-oauth@30.8.0-canary.1104.28614171396.0
  yarn add @magic-ext/react-native-expo-oauth@30.8.0-canary.1104.28614171396.0
  yarn add @magic-ext/siwe@3.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/smart-account@1.2.0-canary.1104.28614171396.0
  yarn add @magic-ext/solana@30.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/sui@5.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/taquito@25.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/terra@25.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/tezos@28.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/wallet-kit@0.12.0-canary.1104.28614171396.0
  yarn add @magic-ext/webauthn@27.7.0-canary.1104.28614171396.0
  yarn add @magic-ext/zilliqa@28.7.0-canary.1104.28614171396.0
  yarn add @magic-sdk/provider@33.8.0-canary.1104.28614171396.0
  yarn add @magic-sdk/react-native-bare@34.7.0-canary.1104.28614171396.0
  yarn add @magic-sdk/react-native-expo@34.7.0-canary.1104.28614171396.0
  yarn add @magic-sdk/types@27.8.0-canary.1104.28614171396.0
  yarn add magic-sdk@33.8.0-canary.1104.28614171396.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
