### PR TITLE
feat: add passkey mfa to oauth

### DIFF
--- a/packages/@magic-ext/oauth2/src/index.ts
+++ b/packages/@magic-ext/oauth2/src/index.ts
@@ -17,7 +17,10 @@ import {
   OAuthPopupEventHandlers,
   OAuthPopupEventOnReceived,
   OAuthGetResultEventHandlers,
+  MfaEventOnReceived,
+  MfaEventEmit,
 } from '@magic-sdk/types';
+import { parseRequestOptionsFromJSON, toJSON } from './utils/polyfills';
 import { createCryptoChallenge } from './crypto';
 
 const PKCE_STORAGE_KEY = 'magic_oauth_pkce_verifier';
@@ -227,6 +230,24 @@ export class OAuthExtension extends Extension.Internal<'oauth2'> {
           });
         }
 
+        oauthPopupRequest.on(MfaEventOnReceived.MfaPasskeyOptions, async ({ webauthnOptions }) => {
+          try {
+            const assertionResponse = (await navigator.credentials.get({
+              publicKey: parseRequestOptionsFromJSON(webauthnOptions),
+            })) as any;
+            this.createIntermediaryEvent(
+              MfaEventEmit.MfaPasskeyAssertionResponse,
+              requestPayload.id as string,
+            )(toJSON(assertionResponse));
+          } catch (err) {
+            const error = err as Error;
+            this.createIntermediaryEvent(
+              MfaEventEmit.MfaPasskeyAssertionError,
+              requestPayload.id as string,
+            )(error?.message ?? '');
+          }
+        });
+
         const result = await oauthPopupRequest;
         window.removeEventListener('message', redirectEvent);
 
@@ -260,6 +281,9 @@ export class OAuthExtension extends Extension.Internal<'oauth2'> {
       });
       promiEvent.on(OAuthMFAEventEmit.Cancel, () => {
         this.createIntermediaryEvent(OAuthMFAEventEmit.Cancel, requestPayload.id as string)();
+      });
+      promiEvent.on(MfaEventEmit.SelectedMfaType, type => {
+        this.createIntermediaryEvent(MfaEventEmit.SelectedMfaType, requestPayload.id as string)(type);
       });
     }
 
@@ -325,6 +349,24 @@ export class OAuthExtension extends Extension.Internal<'oauth2'> {
           });
         }
 
+        getResultRequest.on(MfaEventOnReceived.MfaPasskeyOptions, async ({ webauthnOptions }) => {
+          try {
+            const assertionResponse = (await navigator.credentials.get({
+              publicKey: parseRequestOptionsFromJSON(webauthnOptions),
+            })) as any;
+            this.createIntermediaryEvent(
+              MfaEventEmit.MfaPasskeyAssertionResponse,
+              requestPayload.id as string,
+            )(toJSON(assertionResponse));
+          } catch (err) {
+            const error = err as Error;
+            this.createIntermediaryEvent(
+              MfaEventEmit.MfaPasskeyAssertionError,
+              requestPayload.id as string,
+            )(error?.message ?? '');
+          }
+        });
+
         // Parse the result, which may contain an OAuth-formatted error.
         const resultOrError = await getResultRequest;
         const maybeResult = resultOrError as OAuthRedirectResult;
@@ -355,6 +397,9 @@ export class OAuthExtension extends Extension.Internal<'oauth2'> {
       });
       promiEvent.on(OAuthMFAEventEmit.Cancel, () => {
         this.createIntermediaryEvent(OAuthMFAEventEmit.Cancel, requestPayload.id as string)();
+      });
+      promiEvent.on(MfaEventEmit.SelectedMfaType, type => {
+        this.createIntermediaryEvent(MfaEventEmit.SelectedMfaType, requestPayload.id as string)(type);
       });
     }
 

--- a/packages/@magic-ext/oauth2/src/utils/base64.ts
+++ b/packages/@magic-ext/oauth2/src/utils/base64.ts
@@ -1,0 +1,16 @@
+export class Base64URL {
+  static encode(buffer: ArrayBuffer): string {
+    const base64 = globalThis.btoa(String.fromCharCode(...new Uint8Array(buffer)));
+    return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  }
+
+  static decode(base64url: string): ArrayBuffer {
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    const binStr = globalThis.atob(base64);
+    const bin = new Uint8Array(binStr.length);
+    for (let i = 0; i < binStr.length; i++) {
+      bin[i] = binStr.charCodeAt(i);
+    }
+    return bin.buffer;
+  }
+}

--- a/packages/@magic-ext/oauth2/src/utils/polyfills.ts
+++ b/packages/@magic-ext/oauth2/src/utils/polyfills.ts
@@ -1,0 +1,108 @@
+import { Base64URL } from './base64';
+
+function isAuthenticatorAssertionResponse(value: AuthenticatorResponse): value is AuthenticatorAssertionResponse {
+  if (typeof value !== 'object') return false;
+  if (
+    (value as AuthenticatorAssertionResponse)?.authenticatorData === undefined ||
+    typeof (value as AuthenticatorAssertionResponse)?.authenticatorData !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isAuthenticatorAttestationResponse(value: AuthenticatorResponse): value is AuthenticatorAttestationResponse {
+  if (typeof value !== 'object') return false;
+  if (
+    (value as AuthenticatorAttestationResponse)?.attestationObject === undefined ||
+    typeof (value as AuthenticatorAttestationResponse)?.attestationObject !== 'object'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Polyfill `PublicKeyCredential.prototype.toJSON`
+ *
+ * See https://w3c.github.io/webauthn/#dom-publickeycredential-tojson
+ */
+export function toJSON(cred: PublicKeyCredential): PublicKeyCredentialJSON {
+  if (typeof cred.toJSON === 'function') {
+    return cred.toJSON();
+  }
+
+  try {
+    const id = cred.id;
+    const rawId = Base64URL.encode(cred.rawId);
+    const authenticatorAttachment = cred.authenticatorAttachment;
+    const clientExtensionResults = {};
+    const type = cred.type;
+
+    if (isAuthenticatorAssertionResponse(cred.response)) {
+      return {
+        id,
+        rawId,
+        response: {
+          authenticatorData: Base64URL.encode(cred.response.authenticatorData),
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          signature: Base64URL.encode(cred.response.signature),
+          userHandle: cred.response.userHandle ? Base64URL.encode(cred.response.userHandle) : undefined,
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    if (isAuthenticatorAttestationResponse(cred.response)) {
+      return {
+        id,
+        rawId,
+        response: {
+          clientDataJSON: Base64URL.encode(cred.response.clientDataJSON),
+          attestationObject: Base64URL.encode(cred.response.attestationObject),
+          transports: cred.response?.getTransports() || [],
+        },
+        authenticatorAttachment,
+        clientExtensionResults,
+        type,
+      };
+    }
+
+    throw new Error('Unexpected object.');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+/**
+ * Polyfill `PublicKeyCredential.parseRequestOptionsFromJSON`
+ *
+ * See https://w3c.github.io/webauthn/#sctn-parseRequestOptionsFromJSON
+ */
+export function parseRequestOptionsFromJSON(
+  options: PublicKeyCredentialRequestOptionsJSON,
+): PublicKeyCredentialRequestOptions {
+  if (
+    typeof PublicKeyCredential !== 'undefined' &&
+    typeof PublicKeyCredential.parseRequestOptionsFromJSON === 'function'
+  ) {
+    return PublicKeyCredential.parseRequestOptionsFromJSON(options);
+  }
+
+  const challenge = Base64URL.decode(options.challenge) as ArrayBuffer;
+  const allowCredentials =
+    options.allowCredentials?.map(cred => ({
+      ...cred,
+      id: Base64URL.decode(cred.id) as ArrayBuffer,
+      transports: cred.transports as AuthenticatorTransport[] | undefined,
+    })) ?? [];
+
+  return {
+    ...options,
+    allowCredentials,
+    challenge,
+  } as PublicKeyCredentialRequestOptions;
+}

--- a/packages/@magic-sdk/types/src/modules/oauth-types.ts
+++ b/packages/@magic-sdk/types/src/modules/oauth-types.ts
@@ -1,3 +1,5 @@
+import { MfaEventHandlers } from './mfa-types';
+
 // Shared MFA events reused by both popup and redirect flows
 export enum OAuthMFAEventEmit {
   Cancel = 'cancel',
@@ -40,7 +42,8 @@ export enum OAuthPopupEventEmit {
 export type OAuthPopupEventHandlers = {
   [OAuthPopupEventEmit.PopupEvent]: (eventData: unknown) => void;
   [OAuthPopupEventOnReceived.PopupUrl]: (event: { popupUrl: string; provider: string }) => void;
-} & OAuthMFAEventHandlers;
+} & OAuthMFAEventHandlers &
+  MfaEventHandlers;
 
 // Redirect-specific handler type
-export type OAuthGetResultEventHandlers = OAuthMFAEventHandlers;
+export type OAuthGetResultEventHandlers = OAuthMFAEventHandlers & MfaEventHandlers;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,7 +3155,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/algorand@workspace:packages/@magic-ext/algorand"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3164,7 +3164,7 @@ __metadata:
   resolution: "@magic-ext/aptos@workspace:packages/@magic-ext/aptos"
   dependencies:
     "@aptos-labs/wallet-adapter-core": ^7.10.1
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
     aptos: ^1.22.1
   peerDependencies:
     "@aptos-labs/wallet-adapter-core": ^7.10.1
@@ -3176,7 +3176,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/avalanche@workspace:packages/@magic-ext/avalanche"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3184,7 +3184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3192,7 +3192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/conflux@workspace:packages/@magic-ext/conflux"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3200,7 +3200,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3208,7 +3208,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/ed25519@workspace:packages/@magic-ext/ed25519"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3216,8 +3216,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/evm@workspace:packages/@magic-ext/evm"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
   languageName: unknown
   linkType: soft
 
@@ -3225,8 +3225,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
   languageName: unknown
   linkType: soft
 
@@ -3234,7 +3234,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/flow@workspace:packages/@magic-ext/flow"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
     "@onflow/fcl": ^1.4.1
     "@onflow/types": ^1.1.0
   peerDependencies:
@@ -3247,8 +3247,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
   languageName: unknown
   linkType: soft
 
@@ -3256,7 +3256,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/harmony@workspace:packages/@magic-ext/harmony"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3264,7 +3264,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/hedera@workspace:packages/@magic-ext/hedera"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   peerDependencies:
     "@hashgraph/sdk": ^2.31.0
   languageName: unknown
@@ -3274,7 +3274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/icon@workspace:packages/@magic-ext/icon"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3282,7 +3282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/kadena@workspace:packages/@magic-ext/kadena"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3290,7 +3290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/near@workspace:packages/@magic-ext/near"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3298,7 +3298,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -3308,7 +3308,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oidc@workspace:packages/@magic-ext/oidc"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3316,7 +3316,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/passkey@workspace:packages/@magic-ext/passkey"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3324,7 +3324,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/polkadot@workspace:packages/@magic-ext/polkadot"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3332,8 +3332,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^34.6.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/react-native-bare": ^34.7.0
+    "@magic-sdk/types": ^27.8.0
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
     react-native-inappbrowser-reborn: ^3.7.0
@@ -3347,8 +3347,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^34.6.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/react-native-expo": ^34.7.0
+    "@magic-sdk/types": ^27.8.0
     "@react-native-async-storage/async-storage": ^2.1.2
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -3364,7 +3364,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/siwe@workspace:packages/@magic-ext/siwe"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
     "@signinwithethereum/siwe": ^4.1.0
     ethers: ^6.0.0
   peerDependencies:
@@ -3376,8 +3376,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/smart-account@workspace:packages/@magic-ext/smart-account"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
   languageName: unknown
   linkType: soft
 
@@ -3385,7 +3385,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3396,7 +3396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/sui@workspace:packages/@magic-ext/sui"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3404,7 +3404,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/taquito@workspace:packages/@magic-ext/taquito"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3412,7 +3412,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/terra@workspace:packages/@magic-ext/terra"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3420,7 +3420,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/tezos@workspace:packages/@magic-ext/tezos"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3428,8 +3428,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/wallet-kit@workspace:packages/@magic-ext/wallet-kit"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
     "@magiclabs/ui-components": ^2.3.0
     "@reown/appkit": ^1.8.0
     "@reown/appkit-adapter-wagmi": ^1.8.0
@@ -3463,7 +3463,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
@@ -3471,16 +3471,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/zilliqa@workspace:packages/@magic-ext/zilliqa"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
+    "@magic-sdk/provider": ^33.8.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^33.7.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^33.8.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/types": ^27.8.0
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
     tslib: ^2.3.1
@@ -3489,13 +3489,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^34.6.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^34.7.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
     "@magiclabs/react-native-device-crypto": ^0.1.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/netinfo": ">11.0.0"
@@ -3530,13 +3530,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^34.6.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^34.7.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/assets-registry": ^0.78.2
@@ -3570,7 +3570,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^27.7.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^27.8.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -18452,8 +18452,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
-    "@magic-sdk/provider": ^33.7.1
-    "@magic-sdk/types": ^27.7.1
+    "@magic-sdk/provider": ^33.8.0
+    "@magic-sdk/types": ^27.8.0
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/algorand@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/aptos@16.8.0-canary.1105.28622715740.0
  npm install @magic-ext/avalanche@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/bitcoin@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/conflux@26.8.0-canary.1105.28622715740.0
  npm install @magic-ext/cosmos@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/ed25519@24.8.0-canary.1105.28622715740.0
  npm install @magic-ext/evm@1.7.0-canary.1105.28622715740.0
  npm install @magic-ext/farcaster@5.8.0-canary.1105.28622715740.0
  npm install @magic-ext/flow@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/gdkms@16.8.0-canary.1105.28622715740.0
  npm install @magic-ext/harmony@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/hedera@2.7.0-canary.1105.28622715740.0
  npm install @magic-ext/icon@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/kadena@5.8.0-canary.1105.28622715740.0
  npm install @magic-ext/near@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/oauth2@15.10.0-canary.1105.28622715740.0
  npm install @magic-ext/oidc@16.8.0-canary.1105.28622715740.0
  npm install @magic-ext/passkey@1.3.0-canary.1105.28622715740.0
  npm install @magic-ext/polkadot@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/react-native-bare-oauth@30.9.0-canary.1105.28622715740.0
  npm install @magic-ext/react-native-expo-oauth@30.9.0-canary.1105.28622715740.0
  npm install @magic-ext/siwe@3.8.0-canary.1105.28622715740.0
  npm install @magic-ext/smart-account@1.3.0-canary.1105.28622715740.0
  npm install @magic-ext/solana@30.8.0-canary.1105.28622715740.0
  npm install @magic-ext/sui@5.8.0-canary.1105.28622715740.0
  npm install @magic-ext/taquito@25.8.0-canary.1105.28622715740.0
  npm install @magic-ext/terra@25.8.0-canary.1105.28622715740.0
  npm install @magic-ext/tezos@28.8.0-canary.1105.28622715740.0
  npm install @magic-ext/wallet-kit@0.13.0-canary.1105.28622715740.0
  npm install @magic-ext/webauthn@27.8.0-canary.1105.28622715740.0
  npm install @magic-ext/zilliqa@28.8.0-canary.1105.28622715740.0
  npm install @magic-sdk/provider@33.9.0-canary.1105.28622715740.0
  npm install @magic-sdk/react-native-bare@34.8.0-canary.1105.28622715740.0
  npm install @magic-sdk/react-native-expo@34.8.0-canary.1105.28622715740.0
  npm install @magic-sdk/types@27.9.0-canary.1105.28622715740.0
  npm install magic-sdk@33.9.0-canary.1105.28622715740.0
  # or 
  yarn add @magic-ext/algorand@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/aptos@16.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/avalanche@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/bitcoin@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/conflux@26.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/cosmos@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/ed25519@24.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/evm@1.7.0-canary.1105.28622715740.0
  yarn add @magic-ext/farcaster@5.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/flow@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/gdkms@16.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/harmony@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/hedera@2.7.0-canary.1105.28622715740.0
  yarn add @magic-ext/icon@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/kadena@5.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/near@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/oauth2@15.10.0-canary.1105.28622715740.0
  yarn add @magic-ext/oidc@16.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/passkey@1.3.0-canary.1105.28622715740.0
  yarn add @magic-ext/polkadot@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/react-native-bare-oauth@30.9.0-canary.1105.28622715740.0
  yarn add @magic-ext/react-native-expo-oauth@30.9.0-canary.1105.28622715740.0
  yarn add @magic-ext/siwe@3.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/smart-account@1.3.0-canary.1105.28622715740.0
  yarn add @magic-ext/solana@30.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/sui@5.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/taquito@25.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/terra@25.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/tezos@28.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/wallet-kit@0.13.0-canary.1105.28622715740.0
  yarn add @magic-ext/webauthn@27.8.0-canary.1105.28622715740.0
  yarn add @magic-ext/zilliqa@28.8.0-canary.1105.28622715740.0
  yarn add @magic-sdk/provider@33.9.0-canary.1105.28622715740.0
  yarn add @magic-sdk/react-native-bare@34.8.0-canary.1105.28622715740.0
  yarn add @magic-sdk/react-native-expo@34.8.0-canary.1105.28622715740.0
  yarn add @magic-sdk/types@27.9.0-canary.1105.28622715740.0
  yarn add magic-sdk@33.9.0-canary.1105.28622715740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
