### PR TITLE
fix: declare isPasskeyMfaEnabled in MagicUserMetadata and await passkey MFA enrollment verify

### DIFF
--- a/packages/@magic-ext/passkey/src/index.ts
+++ b/packages/@magic-ext/passkey/src/index.ts
@@ -228,7 +228,7 @@ export class PasskeyExtension extends Extension.Internal<'passkey', any> {
         startResponse = response;
       } catch (e) {
         // TODO: Handle case where user has no active passkey
-        reject(e);
+        return reject(e);
       }
 
       let assertionResponse;
@@ -240,14 +240,18 @@ export class PasskeyExtension extends Extension.Internal<'passkey', any> {
         return reject(this.createPasskeyCreateCredentialError(err));
       }
 
-      this.request(
-        this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.EnablePasskeyMfaVerify, [
-          {
-            assertionResponse: toJSON(assertionResponse),
-            enrollmentToken: startResponse.enrollmentToken,
-          },
-        ]),
-      );
+      try {
+        await this.request(
+          this.utils.createJsonRpcRequestPayload(MagicPasskeyPayloadMethod.EnablePasskeyMfaVerify, [
+            {
+              assertionResponse: toJSON(assertionResponse),
+              enrollmentToken: startResponse.enrollmentToken,
+            },
+          ]),
+        );
+      } catch (e) {
+        return reject(e);
+      }
 
       resolve(
         startResponse?.recoveryCodes

--- a/packages/@magic-sdk/types/src/modules/user-types.ts
+++ b/packages/@magic-sdk/types/src/modules/user-types.ts
@@ -35,6 +35,7 @@ export interface MagicUserMetadata {
   email: string | null;
   phoneNumber: string | null;
   isMfaEnabled: boolean;
+  isPasskeyMfaEnabled: boolean;
   recoveryFactors: [RecoveryFactor] | [];
   firstLoginAt: string | null;
   wallets: {


### PR DESCRIPTION
# fix: declare isPasskeyMfaEnabled in MagicUserMetadata and await passkey MFA enrollment verify

## 📦 Pull Request

Two related fixes around passkey MFA state on the client:

**1. `@magic-sdk/types` — `isPasskeyMfaEnabled` was returned but never typed**

The embedded wallet's `magic_get_info` response includes `isPasskeyMfaEnabled` (mapped from the user-info endpoint's `isPasskeyMfaActive`) alongside `isMfaEnabled`, but `MagicUserMetadata` never declared it. TypeScript consumers had to cast the result of `magic.user.getInfo()` to read passkey MFA state, and the field looked unofficial even though it is server-backed. This adds the field to the interface to match the actual runtime payload.

**2. `@magic-ext/passkey` — `enablePasskeyMfa()` resolved before enrollment completed**

`enablePasskeyMfa()` fired the `EnablePasskeyMfaVerify` request without awaiting it, so the returned promise resolved while enrollment was still in flight. Consequences:

- Calling `magic.user.getInfo()` right after `enablePasskeyMfa()` resolved could still report `isPasskeyMfaEnabled: false`.
- A failed verify was silently swallowed — the caller saw a successful resolution (including recovery codes) even though MFA was never enabled.

This awaits the verify request and rejects on failure, matching the existing `disablePasskeyMfa()` behavior. Also adds a missing `return` after `reject(e)` in the `EnablePasskeyMfaStart` catch block, which previously fell through and threw an unhandled `undefined` access on `startResponse.webauthnOptions`.

## ⚖️ Note for reviewers: required vs. optional

`isPasskeyMfaEnabled` is declared **required** (`boolean`), not optional. Rationale: every producer of `MagicUserMetadata` in this repo (`magic_get_info` and the OAuth redirect result) builds it from the hosted embedded-wallet payload, which always includes the field — same guarantee as the sibling `isMfaEnabled`. A required field also spares consumers an `undefined` branch, which matters for MFA gating logic where "unknown" being treated as "disabled" is an easy silent bug.

Tradeoff: adding a required field is a compile-time break for downstream code that hand-constructs `MagicUserMetadata` (test mocks, fixtures) — readers are unaffected. If you prefer strict semver hygiene for type consumers on a patch release, switching to `isPasskeyMfaEnabled?: boolean` is a one-character change; happy to do so, at the cost of every consumer handling `undefined` for a field that is in practice always present.

## ✅ Fixed Issues

<!-- link issue here if one is filed -->

## 🚨 Test instructions

1. Log in with a user that has a passkey registered.
2. `const result = await magic.passkey.enablePasskeyMfa();`
3. Immediately call `const info = await magic.user.getInfo();`
4. `info.isPasskeyMfaEnabled` is now `true` (previously could be `false` due to the race), and the field is present on the `MagicUserMetadata` type without casting.
5. Failure path: reject the WebAuthn prompt / force the verify call to fail — the promise now rejects instead of resolving.
