### PR TITLE
fix: re-mint the persisted DPoP proof when its iat goes stale

### DIFF
--- a/packages/@magic-sdk/provider/src/core/view-controller.ts
+++ b/packages/@magic-sdk/provider/src/core/view-controller.ts
@@ -21,7 +21,7 @@ import {
 import { standardizeResponse, debounce, StandardizedMagicRequest } from '../util/view-controller-utils';
 import { setItem, getItem } from '../util/storage';
 import { SDKEnvironment } from './sdk-environment';
-import { createJwt, isDpopProofStale } from '../util/web-crypto';
+import { createJwt, isDpopProofStale, isOwnDpopProof } from '../util/web-crypto';
 
 interface RemoveEventListenerFunction {
   (): void;
@@ -355,14 +355,24 @@ export abstract class ViewController {
     if (SDKEnvironment.platform === 'web') {
       try {
         const jwtFromStorage = await getItem<string>('jwt');
-        if (jwtFromStorage && !isDpopProofStale(jwtFromStorage)) return jwtFromStorage;
 
-        // A stale proof is guaranteed a 401 from the auth service, so re-mint.
-        // createJwt() reuses the persisted keypair (STORE_KEY_PUBLIC_JWK /
-        // STORE_KEY_PRIVATE_KEY) — device trust and refresh-token binding are
-        // keyed on its JWK thumbprint — so only the iat/jti claims change.
-        const newJwt = await createJwt();
-        return newJwt ?? jwtFromStorage;
+        if (jwtFromStorage) {
+          // Re-mint only a stored proof this SDK can safely refresh: our own
+          // DPoP proof (header JWK matches the stored keypair) whose iat has gone
+          // stale. createJwt() reuses that keypair, so the JWK thumbprint the
+          // auth service keys device trust and refresh-token binding on is
+          // unchanged — only iat/jti are fresh. Any other injected value (a
+          // non-DPoP token, or a proof under a different keypair) is passed
+          // through untouched; re-minting it would swap the thumbprint.
+          if ((await isOwnDpopProof(jwtFromStorage)) && isDpopProofStale(jwtFromStorage)) {
+            const newJwt = await createJwt();
+            return newJwt ?? jwtFromStorage;
+          }
+          return jwtFromStorage;
+        }
+
+        // No injected proof present: mint a fresh one for this request.
+        return await createJwt();
       } catch (e) {
         console.error('webcrypto error', e);
         return null;

--- a/packages/@magic-sdk/provider/src/core/view-controller.ts
+++ b/packages/@magic-sdk/provider/src/core/view-controller.ts
@@ -21,7 +21,7 @@ import {
 import { standardizeResponse, debounce, StandardizedMagicRequest } from '../util/view-controller-utils';
 import { setItem, getItem } from '../util/storage';
 import { SDKEnvironment } from './sdk-environment';
-import { createJwt } from '../util/web-crypto';
+import { createJwt, isDpopProofStale } from '../util/web-crypto';
 
 interface RemoveEventListenerFunction {
   (): void;
@@ -355,10 +355,14 @@ export abstract class ViewController {
     if (SDKEnvironment.platform === 'web') {
       try {
         const jwtFromStorage = await getItem<string>('jwt');
-        if (jwtFromStorage) return jwtFromStorage;
+        if (jwtFromStorage && !isDpopProofStale(jwtFromStorage)) return jwtFromStorage;
 
+        // A stale proof is guaranteed a 401 from the auth service, so re-mint.
+        // createJwt() reuses the persisted keypair (STORE_KEY_PUBLIC_JWK /
+        // STORE_KEY_PRIVATE_KEY) — device trust and refresh-token binding are
+        // keyed on its JWK thumbprint — so only the iat/jti claims change.
         const newJwt = await createJwt();
-        return newJwt;
+        return newJwt ?? jwtFromStorage;
       } catch (e) {
         console.error('webcrypto error', e);
         return null;

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -72,8 +72,8 @@ export async function createJwt() {
 /**
  * Returns true only when the proof's `iat` claim decodes to a timestamp older
  * than DPOP_PROOF_STALE_AFTER_SECONDS. Anything that cannot be decoded is NOT
- * treated as stale: the persisted `jwt` storage entry doubles as an injection
- * point for tokens this SDK did not mint, and those must pass through untouched.
+ * treated as stale — the caller falls back to passing the token through
+ * untouched. Staleness alone does not authorize a re-mint; see `isOwnDpopProof`.
  */
 export function isDpopProofStale(jwt: string): boolean {
   try {
@@ -87,6 +87,43 @@ export function isDpopProofStale(jwt: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * True only when `jwt` is a DPoP proof (`typ: 'dpop+jwt'`) whose embedded header
+ * JWK matches the public key this SDK has stored — i.e. a proof we can re-mint
+ * without changing the JWK thumbprint the auth service keys device trust and
+ * refresh-token binding on.
+ *
+ * The `jwt` storage entry is an external injection point (session-persistence
+ * escape hatch): the SDK never writes it. So a stored value may be a non-DPoP
+ * token, or a DPoP proof minted under a *different* keypair (e.g. a natively
+ * injected proof). Re-minting either of those would swap the thumbprint the
+ * server expects — exactly the failure this returning `false` prevents by
+ * leaving such tokens untouched.
+ */
+export async function isOwnDpopProof(jwt: string): Promise<boolean> {
+  try {
+    const headerSegment = jwt.split('.')[0];
+    if (!headerSegment) return false;
+
+    const header = JSON.parse(urlBase64ToStr(headerSegment));
+    if (header?.typ !== 'dpop+jwt' || !header.jwk) return false;
+
+    const storedJwk = await getItem<JsonWebKey>(STORE_KEY_PUBLIC_JWK);
+    return !!storedJwk && jwkPublicKeyMatches(header.jwk, storedJwk);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * EC public keys are identified by (kty, crv, x, y) — the same members that form
+ * the RFC 7638 JWK thumbprint — so equality across them means an identical
+ * thumbprint. Extra members (e.g. `use`, `kid`) are intentionally ignored.
+ */
+function jwkPublicKeyMatches(a: JsonWebKey, b: JsonWebKey): boolean {
+  return a.kty === b.kty && a.crv === b.crv && a.x === b.x && a.y === b.y;
 }
 
 async function getPublicKey() {
@@ -125,7 +162,13 @@ function strToUrlBase64(str: string) {
 }
 
 function urlBase64ToStr(urlBase64: string) {
-  const base64 = urlBase64.replace(/-/g, '+').replace(/_/g, '/');
+  let base64 = urlBase64.replace(/-/g, '+').replace(/_/g, '/');
+  // `binToUrlBase64` strips `=` padding, but some `atob` implementations reject
+  // unpadded input. Re-pad to a multiple of 4. (A remainder of 1 is never valid
+  // base64; padding still leaves it invalid so `atob` throws — the caller's
+  // try/catch then treats the token as undecodable, which is the safe path.)
+  const remainder = base64.length % 4;
+  if (remainder) base64 += '='.repeat(4 - remainder);
   return decodeURIComponent(
     atob(base64)
       .split('')

--- a/packages/@magic-sdk/provider/src/util/web-crypto.ts
+++ b/packages/@magic-sdk/provider/src/util/web-crypto.ts
@@ -6,6 +6,12 @@ export const STORE_KEY_PUBLIC_JWK = 'STORE_KEY_PUBLIC_JWK';
 const ALGO_NAME = 'ECDSA';
 const ALGO_CURVE = 'P-256';
 
+// The auth service rejects DPoP proofs whose `iat` is older than 180 seconds with
+// zero leeway (DPoPClaims.DPOP_PROOF_MAX_AGE). Stop reusing a proof well before
+// that so network latency and modest client-clock skew can't push a request over
+// the server's limit.
+export const DPOP_PROOF_STALE_AFTER_SECONDS = 120;
+
 const EC_GEN_PARAMS: EcKeyGenParams = {
   name: ALGO_NAME,
   namedCurve: ALGO_CURVE,
@@ -63,6 +69,26 @@ export async function createJwt() {
   return `${jws.protected}.${jws.claims}.${sig}`;
 }
 
+/**
+ * Returns true only when the proof's `iat` claim decodes to a timestamp older
+ * than DPOP_PROOF_STALE_AFTER_SECONDS. Anything that cannot be decoded is NOT
+ * treated as stale: the persisted `jwt` storage entry doubles as an injection
+ * point for tokens this SDK did not mint, and those must pass through untouched.
+ */
+export function isDpopProofStale(jwt: string): boolean {
+  try {
+    const claimsSegment = jwt.split('.')[1];
+    if (!claimsSegment) return false;
+
+    const { iat } = JSON.parse(urlBase64ToStr(claimsSegment));
+    if (typeof iat !== 'number') return false;
+
+    return Math.floor(Date.now() / 1000) - iat > DPOP_PROOF_STALE_AFTER_SECONDS;
+  } catch {
+    return false;
+  }
+}
+
 async function getPublicKey() {
   if (!isWebCryptoSupported()) {
     console.info('webcrypto is not supported');
@@ -96,6 +122,16 @@ async function generateWCKP() {
 
 function strToUrlBase64(str: string) {
   return binToUrlBase64(utf8ToBinaryString(str));
+}
+
+function urlBase64ToStr(urlBase64: string) {
+  const base64 = urlBase64.replace(/-/g, '+').replace(/_/g, '/');
+  return decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(char => `%${`00${char.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .join(''),
+  );
 }
 
 function strToUint8(str: string) {

--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
@@ -68,7 +68,7 @@ const FAKE_JWT_TOKEN = 'hot tokens';
 const FAKE_DEVICE_SHARE = 'fake device share';
 const FAKE_RT = 'will freshen';
 const FAKE_INJECTED_JWT = 'fake injected jwt';
-let FAKE_STORE: Record<string, string> = {};
+let FAKE_STORE: Record<string, any> = {};
 
 let viewController: TestViewController;
 
@@ -200,16 +200,31 @@ test('Sends payload with rt and an injected jwt when both rt and jwt are saved',
   expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: FAKE_INJECTED_JWT, rt: FAKE_RT }));
 });
 
-/** Builds a decodable DPoP-shaped jwt whose `iat` is `iatSecondsAgo` in the past. */
-function fakeDpopJwt(iatSecondsAgo: number) {
+// The keypair the SDK has "stored" for these tests, and a different one to stand
+// in for an externally injected proof minted elsewhere.
+const OWN_JWK = { kty: 'EC', crv: 'P-256', x: 'own-x-coordinate', y: 'own-y-coordinate' };
+const FOREIGN_JWK = { kty: 'EC', crv: 'P-256', x: 'foreign-x-coordinate', y: 'foreign-y-coordinate' };
+
+/** Seeds the stored public JWK so `isOwnDpopProof` can recognise our own proofs. */
+function seedStoredKeypair(jwk: object = OWN_JWK) {
+  FAKE_STORE[webCryptoUtils.STORE_KEY_PUBLIC_JWK] = jwk;
+}
+
+/**
+ * Builds a decodable DPoP-shaped jwt whose `iat` is `iatSecondsAgo` in the past.
+ * Defaults to our own keypair and `typ: 'dpop+jwt'`; override `jwk`/`typ` to
+ * simulate an injected token the SDK must not re-mint.
+ */
+function fakeDpopJwt(iatSecondsAgo: number, { jwk = OWN_JWK, typ = 'dpop+jwt' }: { jwk?: object; typ?: string } = {}) {
   const encode = (obj: unknown) =>
     btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+/g, '');
-  const header = encode({ typ: 'dpop+jwt', alg: 'ES256' });
+  const header = encode({ typ, alg: 'ES256', jwk });
   const claims = encode({ iat: Math.floor(Date.now() / 1000) - iatSecondsAgo, jti: 'test-jti' });
   return `${header}.${claims}.fake-signature`;
 }
 
 test('Sends the saved jwt while its iat is still fresh', async () => {
+  seedStoredKeypair();
   const freshJwt = fakeDpopJwt(30);
   FAKE_STORE.jwt = freshJwt;
 
@@ -222,7 +237,8 @@ test('Sends the saved jwt while its iat is still fresh', async () => {
   expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: freshJwt }));
 });
 
-test('Re-mints the jwt when the saved one has a stale iat', async () => {
+test('Re-mints the jwt when our own saved proof has a stale iat', async () => {
+  seedStoredKeypair();
   createJwtStub.mockImplementationOnce(() => Promise.resolve(FAKE_JWT_TOKEN));
   // older than the auth service's 180s DPOP_PROOF_MAX_AGE — reuse guarantees a 401
   FAKE_STORE.jwt = fakeDpopJwt(200);
@@ -236,7 +252,8 @@ test('Re-mints the jwt when the saved one has a stale iat', async () => {
   expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: FAKE_JWT_TOKEN }));
 });
 
-test('Falls back to the stale saved jwt when a fresh one cannot be minted', async () => {
+test('Falls back to the stale saved proof when a fresh one cannot be minted', async () => {
+  seedStoredKeypair();
   createJwtStub.mockImplementationOnce(() => Promise.resolve(undefined));
   const staleJwt = fakeDpopJwt(200);
   FAKE_STORE.jwt = staleJwt;
@@ -248,6 +265,39 @@ test('Falls back to the stale saved jwt when a fresh one cannot be minted', asyn
 
   expect(createJwtStub).toHaveBeenCalledTimes(1);
   expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: staleJwt }));
+});
+
+test('Does NOT re-mint a stale proof minted under a different keypair', async () => {
+  // A stale DPoP proof whose JWK is not ours (e.g. natively injected). Re-minting
+  // would swap the thumbprint the server binds device trust / refresh tokens to,
+  // so it must be passed through untouched.
+  seedStoredKeypair();
+  const injectedJwt = fakeDpopJwt(200, { jwk: FOREIGN_JWK });
+  FAKE_STORE.jwt = injectedJwt;
+
+  const { postSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, requestPayload());
+
+  expect(createJwtStub).not.toHaveBeenCalled();
+  expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: injectedJwt }));
+});
+
+test('Does NOT re-mint a stale non-DPoP token stored under the jwt key', async () => {
+  // Even with our own key echoed in the header, a non-'dpop+jwt' token is not
+  // something this SDK minted; leave the injected value alone.
+  seedStoredKeypair();
+  const injectedJwt = fakeDpopJwt(200, { typ: 'JWT' });
+  FAKE_STORE.jwt = injectedJwt;
+
+  const { postSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, requestPayload());
+
+  expect(createJwtStub).not.toHaveBeenCalled();
+  expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: injectedJwt }));
 });
 
 test('Sends payload without rt if no jwt can be made', async () => {

--- a/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/core/view-controller/post.spec.ts
@@ -200,6 +200,56 @@ test('Sends payload with rt and an injected jwt when both rt and jwt are saved',
   expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: FAKE_INJECTED_JWT, rt: FAKE_RT }));
 });
 
+/** Builds a decodable DPoP-shaped jwt whose `iat` is `iatSecondsAgo` in the past. */
+function fakeDpopJwt(iatSecondsAgo: number) {
+  const encode = (obj: unknown) =>
+    btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+/g, '');
+  const header = encode({ typ: 'dpop+jwt', alg: 'ES256' });
+  const claims = encode({ iat: Math.floor(Date.now() / 1000) - iatSecondsAgo, jti: 'test-jti' });
+  return `${header}.${claims}.fake-signature`;
+}
+
+test('Sends the saved jwt while its iat is still fresh', async () => {
+  const freshJwt = fakeDpopJwt(30);
+  FAKE_STORE.jwt = freshJwt;
+
+  const { postSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, requestPayload());
+
+  expect(createJwtStub).not.toHaveBeenCalled();
+  expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: freshJwt }));
+});
+
+test('Re-mints the jwt when the saved one has a stale iat', async () => {
+  createJwtStub.mockImplementationOnce(() => Promise.resolve(FAKE_JWT_TOKEN));
+  // older than the auth service's 180s DPOP_PROOF_MAX_AGE — reuse guarantees a 401
+  FAKE_STORE.jwt = fakeDpopJwt(200);
+
+  const { postSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, requestPayload());
+
+  expect(createJwtStub).toHaveBeenCalledTimes(1);
+  expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: FAKE_JWT_TOKEN }));
+});
+
+test('Falls back to the stale saved jwt when a fresh one cannot be minted', async () => {
+  createJwtStub.mockImplementationOnce(() => Promise.resolve(undefined));
+  const staleJwt = fakeDpopJwt(200);
+  FAKE_STORE.jwt = staleJwt;
+
+  const { postSpy } = stubViewController(viewController, [
+    [MagicIncomingWindowMessage.MAGIC_HANDLE_RESPONSE, responseEvent()],
+  ]);
+  await viewController.post(MagicOutgoingWindowMessage.MAGIC_HANDLE_REQUEST, requestPayload());
+
+  expect(createJwtStub).toHaveBeenCalledTimes(1);
+  expect(postSpy).toHaveBeenCalledWith(expect.objectContaining({ jwt: staleJwt }));
+});
+
 test('Sends payload without rt if no jwt can be made', async () => {
   createJwtStub.mockImplementation(() => Promise.resolve(undefined));
   FAKE_STORE.rt = FAKE_RT;

--- a/packages/@magic-sdk/provider/test/spec/util/web-crypto.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/util/web-crypto.spec.ts
@@ -1,6 +1,13 @@
 import { Crypto } from '@peculiar/webcrypto';
 import * as storage from '../../../src/util/storage';
-import { clearKeys, createJwt, STORE_KEY_PRIVATE_KEY, STORE_KEY_PUBLIC_JWK } from '../../../src/util/web-crypto';
+import {
+  clearKeys,
+  createJwt,
+  isDpopProofStale,
+  DPOP_PROOF_STALE_AFTER_SECONDS,
+  STORE_KEY_PRIVATE_KEY,
+  STORE_KEY_PUBLIC_JWK,
+} from '../../../src/util/web-crypto';
 import { TextEncoder } from 'util';
 
 let FAKE_STORE: Record<string, CryptoKey | null> = {};
@@ -58,6 +65,51 @@ test('should store public and private keys after creating JWT', async () => {
   await createJwt();
   expect(FAKE_STORE[STORE_KEY_PUBLIC_JWK]).toBeTruthy();
   expect(FAKE_STORE[STORE_KEY_PRIVATE_KEY]).toBeTruthy();
+});
+
+describe('isDpopProofStale', () => {
+  const encode = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+/g, '');
+  const jwtWithClaims = (claims: unknown) => `${encode({ typ: 'dpop+jwt', alg: 'ES256' })}.${encode(claims)}.sig`;
+  const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+  test('a fresh iat is not stale', () => {
+    expect(isDpopProofStale(jwtWithClaims({ iat: nowSeconds(), jti: 'a' }))).toBe(false);
+  });
+
+  test('an iat just inside the threshold is not stale', () => {
+    expect(isDpopProofStale(jwtWithClaims({ iat: nowSeconds() - DPOP_PROOF_STALE_AFTER_SECONDS + 5, jti: 'a' }))).toBe(
+      false,
+    );
+  });
+
+  test('an iat past the threshold is stale', () => {
+    expect(isDpopProofStale(jwtWithClaims({ iat: nowSeconds() - DPOP_PROOF_STALE_AFTER_SECONDS - 5, jti: 'a' }))).toBe(
+      true,
+    );
+  });
+
+  // Tokens we cannot positively date must pass through untouched — the persisted
+  // `jwt` entry doubles as an injection point for tokens this SDK did not mint.
+  test('a token with no iat claim is not stale', () => {
+    expect(isDpopProofStale(jwtWithClaims({ jti: 'a' }))).toBe(false);
+  });
+
+  test('a token with a non-numeric iat is not stale', () => {
+    expect(isDpopProofStale(jwtWithClaims({ iat: 'yesterday', jti: 'a' }))).toBe(false);
+  });
+
+  test('an undecodable token is not stale', () => {
+    expect(isDpopProofStale('not a jwt at all')).toBe(false);
+    expect(isDpopProofStale('one.!!!not-base64!!!.three')).toBe(false);
+    expect(isDpopProofStale('')).toBe(false);
+  });
+
+  test('a freshly minted proof is not stale', async () => {
+    const jwt = await createJwt();
+    expect(jwt).toBeTruthy();
+    expect(isDpopProofStale(jwt!)).toBe(false);
+  });
 });
 
 test('when asked should clear keys', async () => {

--- a/packages/@magic-sdk/provider/test/spec/util/web-crypto.spec.ts
+++ b/packages/@magic-sdk/provider/test/spec/util/web-crypto.spec.ts
@@ -4,13 +4,14 @@ import {
   clearKeys,
   createJwt,
   isDpopProofStale,
+  isOwnDpopProof,
   DPOP_PROOF_STALE_AFTER_SECONDS,
   STORE_KEY_PRIVATE_KEY,
   STORE_KEY_PUBLIC_JWK,
 } from '../../../src/util/web-crypto';
 import { TextEncoder } from 'util';
 
-let FAKE_STORE: Record<string, CryptoKey | null> = {};
+let FAKE_STORE: Record<string, any> = {};
 
 beforeAll(() => {
   jest.spyOn(storage, 'getItem').mockImplementation(async (key: string) => FAKE_STORE[key]);
@@ -109,6 +110,70 @@ describe('isDpopProofStale', () => {
     const jwt = await createJwt();
     expect(jwt).toBeTruthy();
     expect(isDpopProofStale(jwt!)).toBe(false);
+  });
+
+  // The claims segment is base64url with its `=` padding stripped; decoding must
+  // re-pad so `atob` never rejects it (which the try/catch would mask as "fresh").
+  // Varying the jti length walks the stripped payload through every length % 4
+  // remainder, including the 2- and 3-char cases that need padding.
+  test('decodes the claims regardless of base64url padding length', () => {
+    const remaindersSeen = new Set<number>();
+    for (let n = 0; n < 8; n++) {
+      const jwt = jwtWithClaims({ iat: nowSeconds() - DPOP_PROOF_STALE_AFTER_SECONDS - 5, jti: 'a'.repeat(n) });
+      remaindersSeen.add(jwt.split('.')[1].length % 4);
+      expect(isDpopProofStale(jwt)).toBe(true);
+    }
+    // ensure the loop actually exercised the padding-sensitive remainders
+    expect(remaindersSeen.has(2)).toBe(true);
+    expect(remaindersSeen.has(3)).toBe(true);
+  });
+});
+
+describe('isOwnDpopProof', () => {
+  const OWN_JWK = { kty: 'EC', crv: 'P-256', x: 'own-x-coordinate', y: 'own-y-coordinate' };
+  const encode = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+/g, '');
+  const proofWith = (header: object, claims: unknown = { iat: 1, jti: 'a' }) =>
+    `${encode(header)}.${encode(claims)}.sig`;
+
+  test('true when typ is dpop+jwt and the header jwk matches the stored key', async () => {
+    FAKE_STORE[STORE_KEY_PUBLIC_JWK] = OWN_JWK;
+    expect(await isOwnDpopProof(proofWith({ typ: 'dpop+jwt', alg: 'ES256', jwk: OWN_JWK }))).toBe(true);
+  });
+
+  test('matches on (kty, crv, x, y) and ignores extra jwk members', async () => {
+    FAKE_STORE[STORE_KEY_PUBLIC_JWK] = { ...OWN_JWK, use: 'sig', kid: '1' };
+    expect(await isOwnDpopProof(proofWith({ typ: 'dpop+jwt', alg: 'ES256', jwk: { ...OWN_JWK, ext: true } }))).toBe(true);
+  });
+
+  test('false when the header jwk is a different key', async () => {
+    FAKE_STORE[STORE_KEY_PUBLIC_JWK] = OWN_JWK;
+    expect(await isOwnDpopProof(proofWith({ typ: 'dpop+jwt', alg: 'ES256', jwk: { ...OWN_JWK, x: 'other-x' } }))).toBe(
+      false,
+    );
+  });
+
+  test('false when typ is not dpop+jwt even if the jwk matches', async () => {
+    FAKE_STORE[STORE_KEY_PUBLIC_JWK] = OWN_JWK;
+    expect(await isOwnDpopProof(proofWith({ typ: 'JWT', alg: 'ES256', jwk: OWN_JWK }))).toBe(false);
+  });
+
+  test('false when no key is stored', async () => {
+    expect(await isOwnDpopProof(proofWith({ typ: 'dpop+jwt', alg: 'ES256', jwk: OWN_JWK }))).toBe(false);
+  });
+
+  test('false for an undecodable token', async () => {
+    FAKE_STORE[STORE_KEY_PUBLIC_JWK] = OWN_JWK;
+    expect(await isOwnDpopProof('not a jwt at all')).toBe(false);
+    expect(await isOwnDpopProof('')).toBe(false);
+  });
+
+  // End-to-end against real WebCrypto: createJwt() generates + stores a keypair
+  // and embeds its public jwk in the proof header, so its own proof is recognised.
+  test('recognises a proof actually minted by createJwt', async () => {
+    const jwt = await createJwt();
+    expect(jwt).toBeTruthy();
+    expect(await isOwnDpopProof(jwt!)).toBe(true);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,7 +2980,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -2988,7 +2988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -2996,8 +2996,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/evm@workspace:packages/@magic-ext/evm"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3005,8 +3005,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3014,8 +3014,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3023,7 +3023,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/hedera@workspace:packages/@magic-ext/hedera"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   peerDependencies:
     "@hashgraph/sdk": ^2.31.0
   languageName: unknown
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -3043,7 +3043,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/passkey@workspace:packages/@magic-ext/passkey"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -3051,8 +3051,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^34.9.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/react-native-bare": ^34.9.2
+    "@magic-sdk/types": ^27.10.1
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
     react-native-inappbrowser-reborn: ^3.7.0
@@ -3066,8 +3066,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^34.9.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/react-native-expo": ^34.9.2
+    "@magic-sdk/types": ^27.10.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -3083,7 +3083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/siwe@workspace:packages/@magic-ext/siwe"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@signinwithethereum/siwe": ^4.1.0
     ethers: ^6.0.0
   peerDependencies:
@@ -3095,8 +3095,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/smart-account@workspace:packages/@magic-ext/smart-account"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3104,7 +3104,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3115,8 +3115,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/wallet-kit@workspace:packages/@magic-ext/wallet-kit"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@magiclabs/ui-components": ^2.3.0
     "@reown/appkit": ^1.8.0
     "@reown/appkit-adapter-wagmi": ^1.8.0
@@ -3150,16 +3150,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^33.10.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^33.10.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/types": ^27.10.1
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
     tslib: ^2.3.1
@@ -3168,13 +3168,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^34.9.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^34.9.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@magiclabs/react-native-device-crypto": ^0.1.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/netinfo": ">11.0.0"
@@ -3209,13 +3209,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^34.9.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^34.9.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/assets-registry": ^0.78.2
@@ -3249,7 +3249,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^27.10.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^27.10.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -17791,8 +17791,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Problem

The auth service (toaster) rejects DPoP proofs whose `iat` is older than 180 seconds with zero leeway (`DPoPClaims.DPOP_PROOF_MAX_AGE`), returning 401 `DPOP_VALIDATION_ERROR` / "Invalid DPoP proof." Confirmed in production (Datadog + repro on lab.reown.com during the Aug 2026 WalletConnect investigation): a user who loads a dapp page and sits on it for more than ~3 minutes before clicking "log in" fails their first login attempt; a retry after re-initialization succeeds.

`ViewController.getJWT()` returned the persisted `'jwt'` storage entry verbatim for as long as it existed, minting a new proof only when the entry was absent. A proof minted once was therefore replayed on every subsequent request via `createMagicRequest`, and any consumer of the injectable `'jwt'` entry (introduced in 154d8eaf) was guaranteed stale proofs after 3 minutes.

## Fix

- `getJWT()` now decodes the cached proof's `iat` and re-mints via `createJwt()` when it is older than `DPOP_PROOF_STALE_AFTER_SECONDS` (120s — safely inside the server's 180s limit, leaving margin for request latency and modest clock skew).
- **The keypair is unchanged.** `createJwt()` reuses the persisted keypair (`STORE_KEY_PUBLIC_JWK` / `STORE_KEY_PRIVATE_KEY`) and only generates one if none exists. Device trust (`device_profiler` → `lookup_by_jwk_thumbprint`) and DPoP-bound refresh tokens (`cnf.jkt`) are keyed on the JWK thumbprint, so regenerating the keypair would break device verification and session refresh — only `iat`/`jti` are fresh.
- Tokens whose claims cannot be decoded are passed through untouched, preserving the indexedDB `'jwt'` injection escape hatch for tokens this SDK did not mint (e.g. natively minted proofs injected by mobile webview bundles — re-minting those with the web keypair would also swap thumbprints).
- If re-minting fails (WebCrypto unavailable), the stale token is still sent as a last resort — same failure mode as before this change, never worse.

## Tests

- `web-crypto.spec.ts`: unit tests for `isDpopProofStale` — fresh/stale/boundary `iat`, missing and non-numeric `iat`, undecodable tokens, and that a freshly minted `createJwt()` proof is not stale.
- `post.spec.ts`: fresh cached jwt is reused without minting; stale cached jwt triggers re-mint and the new proof is sent; stale jwt is sent as fallback when minting returns `undefined`. The pre-existing test asserting an (undecodable) injected jwt passes through verbatim still passes by design.

✅ Ran locally (Node 26 / yarn 3.6.0): the `provider` suite passes — 48 tests across `web-crypto.spec.ts`, `post.spec.ts` and the untouched view-controller specs. CI is green (Build, Tests, Canary, linter+audit, gitleaks).

Note: this branch also carries a one-commit `yarn.lock` sync (`chore: sync yarn.lock...`). The `Bump independent versions [skip ci]` automation on master bumped provider/types/react-native package versions without regenerating the lockfile, so every open PR was failing CI on `YN0028: The lockfile would have been modified... explicitly forbidden`. The regen diff is limited to those four workspace version refs. The durable fix is for the bump automation to run a non-immutable install and commit the lockfile.

## Related

Same investigation as magiclabs/embedded-wallet#549 (logout refresh-token fix). Companion PR magiclabs/embedded-wallet#554 fixes the relayer-side staleness path (pending-queue requests reusing the proof of an earlier message) and documents why the relayer must not re-mint stale SDK proofs with the iframe keypair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/bitcoin@29.1.3-canary.1111.31717158054.0
  npm install @magic-ext/cosmos@28.9.3-canary.1111.31717158054.0
  npm install @magic-ext/evm@1.8.3-canary.1111.31717158054.0
  npm install @magic-ext/farcaster@5.9.3-canary.1111.31717158054.0
  npm install @magic-ext/gdkms@16.9.3-canary.1111.31717158054.0
  npm install @magic-ext/hedera@2.8.3-canary.1111.31717158054.0
  npm install @magic-ext/oauth2@15.11.3-canary.1111.31717158054.0
  npm install @magic-ext/passkey@1.4.3-canary.1111.31717158054.0
  npm install @magic-ext/react-native-bare-oauth@30.10.3-canary.1111.31717158054.0
  npm install @magic-ext/react-native-expo-oauth@30.10.3-canary.1111.31717158054.0
  npm install @magic-ext/siwe@3.9.3-canary.1111.31717158054.0
  npm install @magic-ext/smart-account@1.4.3-canary.1111.31717158054.0
  npm install @magic-ext/solana@30.9.3-canary.1111.31717158054.0
  npm install @magic-ext/wallet-kit@0.14.3-canary.1111.31717158054.0
  npm install @magic-ext/webauthn@27.9.3-canary.1111.31717158054.0
  npm install @magic-sdk/provider@33.10.3-canary.1111.31717158054.0
  npm install @magic-sdk/react-native-bare@34.9.3-canary.1111.31717158054.0
  npm install @magic-sdk/react-native-expo@34.9.3-canary.1111.31717158054.0
  npm install magic-sdk@33.10.3-canary.1111.31717158054.0
  # or 
  yarn add @magic-ext/bitcoin@29.1.3-canary.1111.31717158054.0
  yarn add @magic-ext/cosmos@28.9.3-canary.1111.31717158054.0
  yarn add @magic-ext/evm@1.8.3-canary.1111.31717158054.0
  yarn add @magic-ext/farcaster@5.9.3-canary.1111.31717158054.0
  yarn add @magic-ext/gdkms@16.9.3-canary.1111.31717158054.0
  yarn add @magic-ext/hedera@2.8.3-canary.1111.31717158054.0
  yarn add @magic-ext/oauth2@15.11.3-canary.1111.31717158054.0
  yarn add @magic-ext/passkey@1.4.3-canary.1111.31717158054.0
  yarn add @magic-ext/react-native-bare-oauth@30.10.3-canary.1111.31717158054.0
  yarn add @magic-ext/react-native-expo-oauth@30.10.3-canary.1111.31717158054.0
  yarn add @magic-ext/siwe@3.9.3-canary.1111.31717158054.0
  yarn add @magic-ext/smart-account@1.4.3-canary.1111.31717158054.0
  yarn add @magic-ext/solana@30.9.3-canary.1111.31717158054.0
  yarn add @magic-ext/wallet-kit@0.14.3-canary.1111.31717158054.0
  yarn add @magic-ext/webauthn@27.9.3-canary.1111.31717158054.0
  yarn add @magic-sdk/provider@33.10.3-canary.1111.31717158054.0
  yarn add @magic-sdk/react-native-bare@34.9.3-canary.1111.31717158054.0
  yarn add @magic-sdk/react-native-expo@34.9.3-canary.1111.31717158054.0
  yarn add magic-sdk@33.10.3-canary.1111.31717158054.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
