### PR TITLE
chore: sync yarn.lock with bumped workspace versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,7 +2980,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -2988,7 +2988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -2996,8 +2996,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/evm@workspace:packages/@magic-ext/evm"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3005,8 +3005,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3014,8 +3014,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3023,7 +3023,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/hedera@workspace:packages/@magic-ext/hedera"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   peerDependencies:
     "@hashgraph/sdk": ^2.31.0
   languageName: unknown
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -3043,7 +3043,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/passkey@workspace:packages/@magic-ext/passkey"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
@@ -3051,8 +3051,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^34.9.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/react-native-bare": ^34.9.2
+    "@magic-sdk/types": ^27.10.1
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
     react-native-inappbrowser-reborn: ^3.7.0
@@ -3066,8 +3066,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^34.9.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/react-native-expo": ^34.9.2
+    "@magic-sdk/types": ^27.10.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -3083,7 +3083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/siwe@workspace:packages/@magic-ext/siwe"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@signinwithethereum/siwe": ^4.1.0
     ethers: ^6.0.0
   peerDependencies:
@@ -3095,8 +3095,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/smart-account@workspace:packages/@magic-ext/smart-account"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
   languageName: unknown
   linkType: soft
 
@@ -3104,7 +3104,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3115,8 +3115,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/wallet-kit@workspace:packages/@magic-ext/wallet-kit"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@magiclabs/ui-components": ^2.3.0
     "@reown/appkit": ^1.8.0
     "@reown/appkit-adapter-wagmi": ^1.8.0
@@ -3150,16 +3150,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
+    "@magic-sdk/provider": ^33.10.2
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^33.10.1, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^33.10.2, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/types": ^27.10.1
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
     tslib: ^2.3.1
@@ -3168,13 +3168,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^34.9.1, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^34.9.2, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@magiclabs/react-native-device-crypto": ^0.1.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/netinfo": ">11.0.0"
@@ -3209,13 +3209,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^34.9.1, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^34.9.2, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/assets-registry": ^0.78.2
@@ -3249,7 +3249,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^27.10.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^27.10.1, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -17791,8 +17791,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
-    "@magic-sdk/provider": ^33.10.1
-    "@magic-sdk/types": ^27.10.0
+    "@magic-sdk/provider": ^33.10.2
+    "@magic-sdk/types": ^27.10.1
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## What

Regenerates `yarn.lock` so its workspace version references match the `package.json` versions currently on `master`.

## Why

The `Bump independent versions [skip ci]` release commit bumped several workspace packages in their `package.json` files:

- `@magic-sdk/provider` `33.10.1` → `33.10.2`
- `@magic-sdk/types` `27.10.0` → `27.10.1`
- `@magic-sdk/react-native-bare` `34.9.1` → `34.9.2`
- `@magic-sdk/react-native-expo` `34.9.1` → `34.9.2`

…but did **not** regenerate `yarn.lock`. Because those bump commits carry `[skip ci]`, `master` never ran the immutable install and never caught the mismatch. As a result **every open PR fails CI at the install step**:

```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

This has nothing to do with any individual PR's changes — it's a repo-wide breakage from the stale lockfile on `master`.

## The change

Ran `yarn install` and committed the result. The diff is limited to those four workspace version references (33 insertions / 33 deletions) — no dependency additions, removals, or resolution changes.

## Follow-up (not in this PR)

The durable fix is upstream: the version-bump automation should run a non-immutable `yarn install` and commit the regenerated `yarn.lock` in the same `[skip ci]` bump, so this drift can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
