### PR TITLE
add invalid recaptcha error code

### DIFF
--- a/packages/@magic-sdk/types/src/core/exception-types.ts
+++ b/packages/@magic-sdk/types/src/core/exception-types.ts
@@ -43,6 +43,7 @@ export enum RPCErrorCode {
   DpopInvalidated = -10019,
   MaxAttemptsReached = -10031,
   UserRequiredMfa = -10033,
+  InvalidRecaptcha = -10034,
 }
 
 export type ErrorCode = SDKErrorCode | RPCErrorCode;


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/bitcoin@29.2.0-canary.1124.32876468895.0
  npm install @magic-ext/cosmos@28.10.0-canary.1124.32876468895.0
  npm install @magic-ext/evm@1.9.0-canary.1124.32876468895.0
  npm install @magic-ext/farcaster@5.10.0-canary.1124.32876468895.0
  npm install @magic-ext/gdkms@16.10.0-canary.1124.32876468895.0
  npm install @magic-ext/hedera@2.9.0-canary.1124.32876468895.0
  npm install @magic-ext/oauth2@15.12.0-canary.1124.32876468895.0
  npm install @magic-ext/passkey@1.5.0-canary.1124.32876468895.0
  npm install @magic-ext/react-native-bare-oauth@30.11.0-canary.1124.32876468895.0
  npm install @magic-ext/react-native-expo-oauth@30.11.0-canary.1124.32876468895.0
  npm install @magic-ext/siwe@3.10.0-canary.1124.32876468895.0
  npm install @magic-ext/smart-account@1.5.0-canary.1124.32876468895.0
  npm install @magic-ext/solana@30.10.0-canary.1124.32876468895.0
  npm install @magic-ext/wallet-kit@0.15.0-canary.1124.32876468895.0
  npm install @magic-ext/webauthn@27.10.0-canary.1124.32876468895.0
  npm install @magic-sdk/provider@33.11.0-canary.1124.32876468895.0
  npm install @magic-sdk/react-native-bare@34.10.0-canary.1124.32876468895.0
  npm install @magic-sdk/react-native-expo@34.10.0-canary.1124.32876468895.0
  npm install @magic-sdk/types@27.11.0-canary.1124.32876468895.0
  npm install magic-sdk@33.11.0-canary.1124.32876468895.0
  # or 
  yarn add @magic-ext/bitcoin@29.2.0-canary.1124.32876468895.0
  yarn add @magic-ext/cosmos@28.10.0-canary.1124.32876468895.0
  yarn add @magic-ext/evm@1.9.0-canary.1124.32876468895.0
  yarn add @magic-ext/farcaster@5.10.0-canary.1124.32876468895.0
  yarn add @magic-ext/gdkms@16.10.0-canary.1124.32876468895.0
  yarn add @magic-ext/hedera@2.9.0-canary.1124.32876468895.0
  yarn add @magic-ext/oauth2@15.12.0-canary.1124.32876468895.0
  yarn add @magic-ext/passkey@1.5.0-canary.1124.32876468895.0
  yarn add @magic-ext/react-native-bare-oauth@30.11.0-canary.1124.32876468895.0
  yarn add @magic-ext/react-native-expo-oauth@30.11.0-canary.1124.32876468895.0
  yarn add @magic-ext/siwe@3.10.0-canary.1124.32876468895.0
  yarn add @magic-ext/smart-account@1.5.0-canary.1124.32876468895.0
  yarn add @magic-ext/solana@30.10.0-canary.1124.32876468895.0
  yarn add @magic-ext/wallet-kit@0.15.0-canary.1124.32876468895.0
  yarn add @magic-ext/webauthn@27.10.0-canary.1124.32876468895.0
  yarn add @magic-sdk/provider@33.11.0-canary.1124.32876468895.0
  yarn add @magic-sdk/react-native-bare@34.10.0-canary.1124.32876468895.0
  yarn add @magic-sdk/react-native-expo@34.10.0-canary.1124.32876468895.0
  yarn add @magic-sdk/types@27.11.0-canary.1124.32876468895.0
  yarn add magic-sdk@33.11.0-canary.1124.32876468895.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
