### PR TITLE
test(react-native): correct initialization test names

### DIFF
--- a/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/init.spec.ts
+++ b/packages/@magic-sdk/react-native-bare/test/spec/react-native-webview-controller/init.spec.ts
@@ -5,17 +5,17 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test("Intializes 'webView' with null", () => {
+test("Initializes 'webView' with null", () => {
   const overlay = createReactNativeWebViewController();
   expect(overlay.webView).toEqual(null);
 });
 
-test("Intializes 'container' with null", () => {
+test("Initializes 'container' with null", () => {
   const overlay = createReactNativeWebViewController();
   expect(overlay.container).toEqual(null);
 });
 
-test("Intializes 'styles' with the result of React Native's StyleSheet.create", () => {
+test("Initializes 'styles' with the result of React Native's StyleSheet.create", () => {
   const stylesheetCreateStub = reactNativeStyleSheetStub();
 
   createReactNativeWebViewController();

--- a/packages/@magic-sdk/react-native-expo/test/spec/react-native-webview-controller/init.spec.ts
+++ b/packages/@magic-sdk/react-native-expo/test/spec/react-native-webview-controller/init.spec.ts
@@ -5,17 +5,17 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test("Intializes 'webView' with null", () => {
+test("Initializes 'webView' with null", () => {
   const overlay = createReactNativeWebViewController();
   expect(overlay.webView).toEqual(null);
 });
 
-test("Intializes 'container' with null", () => {
+test("Initializes 'container' with null", () => {
   const overlay = createReactNativeWebViewController();
   expect(overlay.container).toEqual(null);
 });
 
-test("Intializes 'styles' with the result of React Native's StyleSheet.create", () => {
+test("Initializes 'styles' with the result of React Native's StyleSheet.create", () => {
   const stylesheetCreateStub = reactNativeStyleSheetStub();
 
   createReactNativeWebViewController();


### PR DESCRIPTION
### 📦 Pull Request

Correct the `Initializes` test descriptions in the bare and Expo React Native WebView controller suites. No assertions or implementation behavior change.


### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

Install dependencies from the repository root and run the two targeted Jest files.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 

- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️
