### PR TITLE
adds recaptcha unavailable error code

### DIFF
--- a/packages/@magic-sdk/types/src/core/exception-types.ts
+++ b/packages/@magic-sdk/types/src/core/exception-types.ts
@@ -45,6 +45,7 @@ export enum RPCErrorCode {
   UserRequiredMfa = -10033,
   InvalidRecaptcha = -10034,
   LoginThrottled = -10035,
+  RecaptchaUnavailable = -10036,
 }
 
 export type ErrorCode = SDKErrorCode | RPCErrorCode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,7 +2980,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/bitcoin@workspace:packages/@magic-ext/bitcoin"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
   languageName: unknown
   linkType: soft
 
@@ -2988,7 +2988,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/cosmos@workspace:packages/@magic-ext/cosmos"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
   languageName: unknown
   linkType: soft
 
@@ -2996,8 +2996,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/evm@workspace:packages/@magic-ext/evm"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
   languageName: unknown
   linkType: soft
 
@@ -3005,8 +3005,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/farcaster@workspace:packages/@magic-ext/farcaster"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
   languageName: unknown
   linkType: soft
 
@@ -3014,8 +3014,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/gdkms@workspace:packages/@magic-ext/gdkms"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
   languageName: unknown
   linkType: soft
 
@@ -3023,7 +3023,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/hedera@workspace:packages/@magic-ext/hedera"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
   peerDependencies:
     "@hashgraph/sdk": ^2.31.0
   languageName: unknown
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/oauth2@workspace:packages/@magic-ext/oauth2"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
   languageName: unknown
@@ -3043,7 +3043,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/passkey@workspace:packages/@magic-ext/passkey"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
   languageName: unknown
   linkType: soft
 
@@ -3051,8 +3051,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-bare-oauth@workspace:packages/@magic-ext/react-native-bare-oauth"
   dependencies:
-    "@magic-sdk/react-native-bare": ^34.10.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/react-native-bare": ^34.11.0
+    "@magic-sdk/types": ^27.12.0
     "@types/crypto-js": 4.2.0
     crypto-js: ^4.2.0
     react-native-inappbrowser-reborn: ^3.7.0
@@ -3066,8 +3066,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/react-native-expo-oauth@workspace:packages/@magic-ext/react-native-expo-oauth"
   dependencies:
-    "@magic-sdk/react-native-expo": ^34.10.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/react-native-expo": ^34.11.0
+    "@magic-sdk/types": ^27.12.0
     "@react-native-async-storage/async-storage": ^2.1.2
     "@types/crypto-js": ~4.2.0
     crypto-js: ^4.2.0
@@ -3083,7 +3083,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/siwe@workspace:packages/@magic-ext/siwe"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
     "@signinwithethereum/siwe": ^4.1.0
     ethers: ^6.0.0
   peerDependencies:
@@ -3095,8 +3095,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/smart-account@workspace:packages/@magic-ext/smart-account"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
   languageName: unknown
   linkType: soft
 
@@ -3104,7 +3104,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/solana@workspace:packages/@magic-ext/solana"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
     "@solana/web3.js": ^1.87.2
   peerDependencies:
     "@solana/web3.js": ^1.87.2
@@ -3115,8 +3115,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/wallet-kit@workspace:packages/@magic-ext/wallet-kit"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
     "@magiclabs/ui-components": ^2.3.0
     "@reown/appkit": ^1.8.0
     "@reown/appkit-adapter-wagmi": ^1.8.0
@@ -3150,16 +3150,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@magic-ext/webauthn@workspace:packages/@magic-ext/webauthn"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
+    "@magic-sdk/provider": ^33.12.0
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/provider@^33.11.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
+"@magic-sdk/provider@^33.12.0, @magic-sdk/provider@workspace:packages/@magic-sdk/provider":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/provider@workspace:packages/@magic-sdk/provider"
   dependencies:
     "@babel/plugin-transform-modules-commonjs": ^7.9.6
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/types": ^27.12.0
     eventemitter3: ^4.0.4
     localforage: ^1.7.4
     tslib: ^2.3.1
@@ -3168,13 +3168,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-bare@^34.10.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
+"@magic-sdk/react-native-bare@^34.11.0, @magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-bare@workspace:packages/@magic-sdk/react-native-bare"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
     "@magiclabs/react-native-device-crypto": ^0.1.1
     "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/netinfo": ">11.0.0"
@@ -3209,13 +3209,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/react-native-expo@^34.10.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
+"@magic-sdk/react-native-expo@^34.11.0, @magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/react-native-expo@workspace:packages/@magic-sdk/react-native-expo"
   dependencies:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
     "@react-native-async-storage/async-storage": ^1.15.5
     "@react-native-community/netinfo": ">11.0.0"
     "@react-native/assets-registry": ^0.78.2
@@ -3249,7 +3249,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@magic-sdk/types@^27.11.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
+"@magic-sdk/types@^27.12.0, @magic-sdk/types@workspace:packages/@magic-sdk/types":
   version: 0.0.0-use.local
   resolution: "@magic-sdk/types@workspace:packages/@magic-sdk/types"
   languageName: unknown
@@ -17814,8 +17814,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "magic-sdk@workspace:packages/magic-sdk"
   dependencies:
-    "@magic-sdk/provider": ^33.11.0
-    "@magic-sdk/types": ^27.11.0
+    "@magic-sdk/provider": ^33.12.0
+    "@magic-sdk/types": ^27.12.0
     localforage: ^1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label! 
Please 🚨 **ONLY ADD ONE** 🚨 of the following labels, failing to do so may lead to adverse versioning of your changes when published:
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.

### Special Note
Please avoid adding any of the `Priority` labels as they conflict with the labels above ☝️

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @magic-ext/bitcoin@29.4.0-canary.1127.33539959419.0
  npm install @magic-ext/cosmos@28.12.0-canary.1127.33539959419.0
  npm install @magic-ext/evm@1.11.0-canary.1127.33539959419.0
  npm install @magic-ext/farcaster@5.12.0-canary.1127.33539959419.0
  npm install @magic-ext/gdkms@16.12.0-canary.1127.33539959419.0
  npm install @magic-ext/hedera@2.11.0-canary.1127.33539959419.0
  npm install @magic-ext/oauth2@15.14.0-canary.1127.33539959419.0
  npm install @magic-ext/passkey@1.7.0-canary.1127.33539959419.0
  npm install @magic-ext/react-native-bare-oauth@30.13.0-canary.1127.33539959419.0
  npm install @magic-ext/react-native-expo-oauth@30.13.0-canary.1127.33539959419.0
  npm install @magic-ext/siwe@3.12.0-canary.1127.33539959419.0
  npm install @magic-ext/smart-account@1.7.0-canary.1127.33539959419.0
  npm install @magic-ext/solana@30.12.0-canary.1127.33539959419.0
  npm install @magic-ext/wallet-kit@0.17.0-canary.1127.33539959419.0
  npm install @magic-ext/webauthn@27.12.0-canary.1127.33539959419.0
  npm install @magic-sdk/provider@33.13.0-canary.1127.33539959419.0
  npm install @magic-sdk/react-native-bare@34.12.0-canary.1127.33539959419.0
  npm install @magic-sdk/react-native-expo@34.12.0-canary.1127.33539959419.0
  npm install @magic-sdk/types@27.13.0-canary.1127.33539959419.0
  npm install magic-sdk@33.13.0-canary.1127.33539959419.0
  # or 
  yarn add @magic-ext/bitcoin@29.4.0-canary.1127.33539959419.0
  yarn add @magic-ext/cosmos@28.12.0-canary.1127.33539959419.0
  yarn add @magic-ext/evm@1.11.0-canary.1127.33539959419.0
  yarn add @magic-ext/farcaster@5.12.0-canary.1127.33539959419.0
  yarn add @magic-ext/gdkms@16.12.0-canary.1127.33539959419.0
  yarn add @magic-ext/hedera@2.11.0-canary.1127.33539959419.0
  yarn add @magic-ext/oauth2@15.14.0-canary.1127.33539959419.0
  yarn add @magic-ext/passkey@1.7.0-canary.1127.33539959419.0
  yarn add @magic-ext/react-native-bare-oauth@30.13.0-canary.1127.33539959419.0
  yarn add @magic-ext/react-native-expo-oauth@30.13.0-canary.1127.33539959419.0
  yarn add @magic-ext/siwe@3.12.0-canary.1127.33539959419.0
  yarn add @magic-ext/smart-account@1.7.0-canary.1127.33539959419.0
  yarn add @magic-ext/solana@30.12.0-canary.1127.33539959419.0
  yarn add @magic-ext/wallet-kit@0.17.0-canary.1127.33539959419.0
  yarn add @magic-ext/webauthn@27.12.0-canary.1127.33539959419.0
  yarn add @magic-sdk/provider@33.13.0-canary.1127.33539959419.0
  yarn add @magic-sdk/react-native-bare@34.12.0-canary.1127.33539959419.0
  yarn add @magic-sdk/react-native-expo@34.12.0-canary.1127.33539959419.0
  yarn add @magic-sdk/types@27.13.0-canary.1127.33539959419.0
  yarn add magic-sdk@33.13.0-canary.1127.33539959419.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
